### PR TITLE
resolve upstream DNS dynamically

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[localSetup/projects/nginx/**.conf]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,11 +103,6 @@ services:
     ports:
       - "80:80"
       - "443:443"
-    depends_on:
-      - licenseapi
-      - contentauthor
-      - metadataservice
-      - versioningapi
     networks:
       default:
         aliases:

--- a/localSetup/projects/nginx/nginx-conf.d/contentauthor.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/contentauthor.conf
@@ -21,10 +21,10 @@ server {
 	server_name contentauthor.local;
 
 	location / {
-		proxy_pass http://contentauthor:8081;
+		set $upstream http://contentauthor:8081;
+		proxy_pass $upstream;
 		proxy_set_header X-Forwarded-For  $remote_addr;
 		proxy_set_header Host $host;
-		proxy_redirect default;
 	}
 
 	location ~ /\.ht {

--- a/localSetup/projects/nginx/nginx-conf.d/contentauthor.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/contentauthor.conf
@@ -1,34 +1,33 @@
 server {
-    listen 80;
+  listen 80;
 
-	server_name contentauthor.local;
+  server_name contentauthor.local;
 
-    return 301 https://$host$request_uri;
+  return 301 https://$host$request_uri;
 }
 
 server {
-	listen 443 ssl;
-	ssl_certificate  /etc/ssl/private/cerpus.crt;
-	ssl_certificate_key  /etc/ssl/private/cerpus.key;
+  listen 443 ssl;
+  ssl_certificate  /etc/ssl/private/cerpus.crt;
+  ssl_certificate_key  /etc/ssl/private/cerpus.key;
 
-	root /var/www/proxy-default;
-	index index.html index.htm;
-    client_max_body_size 2G;
-    proxy_read_timeout 5;
-    proxy_connect_timeout 5;
-    proxy_send_timeout 5;
+  root /var/www/proxy-default;
+  index index.html index.htm;
+  client_max_body_size 2G;
+  proxy_read_timeout 5;
+  proxy_connect_timeout 5;
+  proxy_send_timeout 5;
 
-	server_name contentauthor.local;
+  server_name contentauthor.local;
 
-	location / {
-		set $upstream http://contentauthor:8081;
-		proxy_pass $upstream;
-		proxy_set_header X-Forwarded-For  $remote_addr;
-		proxy_set_header Host $host;
-	}
+  location / {
+    set $upstream http://contentauthor:8081;
+    proxy_pass $upstream;
+    proxy_set_header X-Forwarded-For  $remote_addr;
+    proxy_set_header Host $host;
+  }
 
-	location ~ /\.ht {
-		deny all;
-	}
+  location ~ /\.ht {
+    deny all;
+  }
 }
-

--- a/localSetup/projects/nginx/nginx-conf.d/doku.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/doku.conf
@@ -1,13 +1,13 @@
 server {
-    listen       80;
-    server_name  doku-api.local;
-    access_log   off;
+  listen       80;
+  server_name  doku-api.local;
+  access_log   off;
 
-    location / {
-     set $upstream http://dokuapi;
-     proxy_pass              $upstream;
-     proxy_set_header        Host            $host;
-     proxy_set_header        X-Real-IP       $remote_addr;
-     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-   }
+  location / {
+    set $upstream http://dokuapi;
+    proxy_pass              $upstream;
+    proxy_set_header        Host            $host;
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
 }

--- a/localSetup/projects/nginx/nginx-conf.d/doku.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/doku.conf
@@ -4,7 +4,8 @@ server {
     access_log   off;
 
     location / {
-     proxy_pass  http://dokuapi;
+     set $upstream http://dokuapi;
+     proxy_pass              $upstream;
      proxy_set_header        Host            $host;
      proxy_set_header        X-Real-IP       $remote_addr;
      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/localSetup/projects/nginx/nginx-conf.d/edlib-api.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/edlib-api.conf
@@ -1,106 +1,106 @@
 server {
-    listen 80;
+  listen 80;
 
-	server_name api.edlib.local;
+  server_name api.edlib.local;
 
-    return 301 https://$host$request_uri;
+  return 301 https://$host$request_uri;
 }
 
 server {
-	listen 443 ssl;
-	ssl_certificate  /etc/ssl/private/cerpus.crt;
-	ssl_certificate_key  /etc/ssl/private/cerpus.key;
+  listen 443 ssl;
+  ssl_certificate  /etc/ssl/private/cerpus.crt;
+  ssl_certificate_key  /etc/ssl/private/cerpus.key;
 
-    server_name  api.edlib.local;
-    access_log   off;
+  server_name  api.edlib.local;
+  access_log   off;
 
-    location /recommendations {
-     set $upstream  http://proxy-recommendation;
-     proxy_pass              $upstream;
-     proxy_set_header        Host            $host;
-     proxy_set_header        X-Real-IP       $remote_addr;
-     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-   }
+  location /recommendations {
+    set $upstream  http://proxy-recommendation;
+    proxy_pass              $upstream;
+    proxy_set_header        Host            $host;
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
 
-    location /resources {
-     set $upstream  http://proxy-resource;
-     proxy_pass              $upstream;
-     proxy_set_header        Host            $host;
-     proxy_set_header        X-Real-IP       $remote_addr;
-     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-   }
+  location /resources {
+    set $upstream  http://proxy-resource;
+    proxy_pass              $upstream;
+    proxy_set_header        Host            $host;
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
 
-    location /dokus {
-     set $upstream  http://proxy-doku;
-     proxy_pass              $upstream;
-     proxy_set_header        Host            $host;
-     proxy_set_header        X-Real-IP       $remote_addr;
-     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-   }
+  location /dokus {
+    set $upstream  http://proxy-doku;
+    proxy_pass              $upstream;
+    proxy_set_header        Host            $host;
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
 
-    location /auth {
-     set $upstream  http://proxy-auth;
-     proxy_pass              $upstream;
-     proxy_set_header        Host            $host;
-     proxy_set_header        X-Real-IP       $remote_addr;
-     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-   }
+  location /auth {
+    set $upstream  http://proxy-auth;
+    proxy_pass              $upstream;
+    proxy_set_header        Host            $host;
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
 
-    location /lti {
-     set $upstream  http://proxy-lti;
-     proxy_pass              $upstream;
-     proxy_set_header        Host            $host;
-     proxy_set_header        X-Real-IP       $remote_addr;
-     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-     proxy_set_header        X-Forwarded-Proto $scheme;
-   }
+  location /lti {
+    set $upstream  http://proxy-lti;
+    proxy_pass              $upstream;
+    proxy_set_header        Host            $host;
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header        X-Forwarded-Proto $scheme;
+  }
 
-    location /url {
-     set $upstream  http://edlibapi-url;
-     proxy_pass              $upstream;
-     proxy_set_header        Host            $host;
-     proxy_set_header        X-Real-IP       $remote_addr;
-     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-     proxy_set_header        X-Forwarded-Proto $scheme;
-   }
+  location /url {
+    set $upstream  http://edlibapi-url;
+    proxy_pass              $upstream;
+    proxy_set_header        Host            $host;
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header        X-Forwarded-Proto $scheme;
+  }
 
-    location /doku-lti-viewer {
-     set $upstream  http://doku-lti-viewer:3000;
-     proxy_pass              $upstream;
-     proxy_set_header        Host            $host;
-     proxy_set_header        X-Real-IP       $remote_addr;
-     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-   }
+  location /doku-lti-viewer {
+    set $upstream  http://doku-lti-viewer:3000;
+    proxy_pass              $upstream;
+    proxy_set_header        Host            $host;
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
 
-    location /iframe/sockjs-node {
-       set $upstream  http://proxy-iframe:3000;
-       proxy_pass $upstream;
-        proxy_http_version 1.1;
-	    proxy_set_header Upgrade $http_upgrade;
-	    proxy_set_header Connection "upgrade";
-	}
+  location /iframe/sockjs-node {
+    set $upstream  http://proxy-iframe:3000;
+    proxy_pass $upstream;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
 
-    location /iframe {
-     set $upstream  http://proxy-iframe:3000;
-     proxy_pass $upstream;
-     proxy_set_header        Host            $host;
-     proxy_set_header        X-Real-IP       $remote_addr;
-     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-   }
+  location /iframe {
+    set $upstream  http://proxy-iframe:3000;
+    proxy_pass $upstream;
+    proxy_set_header        Host            $host;
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
 
-    location /admin/sockjs-node {
-	    set $upstream  http://proxy-admin:3000;
-      proxy_pass $upstream;
-        proxy_http_version 1.1;
-	    proxy_set_header Upgrade $http_upgrade;
-	    proxy_set_header Connection "upgrade";
-	}
+  location /admin/sockjs-node {
+    set $upstream  http://proxy-admin:3000;
+    proxy_pass $upstream;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
 
-    location /admin {
-      set $upstream  http://proxy-admin:3000;
-      proxy_pass $upstream;
-     proxy_set_header        Host            $host;
-     proxy_set_header        X-Real-IP       $remote_addr;
-     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-   }
+  location /admin {
+    set $upstream  http://proxy-admin:3000;
+    proxy_pass $upstream;
+    proxy_set_header        Host            $host;
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
 }

--- a/localSetup/projects/nginx/nginx-conf.d/edlib-api.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/edlib-api.conf
@@ -15,35 +15,40 @@ server {
     access_log   off;
 
     location /recommendations {
-     proxy_pass  http://proxy-recommendation;
+     set $upstream  http://proxy-recommendation;
+     proxy_pass              $upstream;
      proxy_set_header        Host            $host;
      proxy_set_header        X-Real-IP       $remote_addr;
      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
    }
 
     location /resources {
-     proxy_pass  http://proxy-resource;
+     set $upstream  http://proxy-resource;
+     proxy_pass              $upstream;
      proxy_set_header        Host            $host;
      proxy_set_header        X-Real-IP       $remote_addr;
      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
    }
 
     location /dokus {
-     proxy_pass  http://proxy-doku;
+     set $upstream  http://proxy-doku;
+     proxy_pass              $upstream;
      proxy_set_header        Host            $host;
      proxy_set_header        X-Real-IP       $remote_addr;
      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
    }
 
     location /auth {
-     proxy_pass  http://proxy-auth;
+     set $upstream  http://proxy-auth;
+     proxy_pass              $upstream;
      proxy_set_header        Host            $host;
      proxy_set_header        X-Real-IP       $remote_addr;
      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
    }
 
     location /lti {
-     proxy_pass              http://proxy-lti;
+     set $upstream  http://proxy-lti;
+     proxy_pass              $upstream;
      proxy_set_header        Host            $host;
      proxy_set_header        X-Real-IP       $remote_addr;
      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -51,7 +56,8 @@ server {
    }
 
     location /url {
-     proxy_pass              http://edlibapi-url;
+     set $upstream  http://edlibapi-url;
+     proxy_pass              $upstream;
      proxy_set_header        Host            $host;
      proxy_set_header        X-Real-IP       $remote_addr;
      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -59,35 +65,40 @@ server {
    }
 
     location /doku-lti-viewer {
-     proxy_pass  http://doku-lti-viewer:3000;
+     set $upstream  http://doku-lti-viewer:3000;
+     proxy_pass              $upstream;
      proxy_set_header        Host            $host;
      proxy_set_header        X-Real-IP       $remote_addr;
      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
    }
 
     location /iframe/sockjs-node {
-	    proxy_pass http://proxy-iframe:3000;
+       set $upstream  http://proxy-iframe:3000;
+       proxy_pass $upstream;
         proxy_http_version 1.1;
 	    proxy_set_header Upgrade $http_upgrade;
 	    proxy_set_header Connection "upgrade";
 	}
 
     location /iframe {
-     proxy_pass  http://proxy-iframe:3000;
+     set $upstream  http://proxy-iframe:3000;
+     proxy_pass $upstream;
      proxy_set_header        Host            $host;
      proxy_set_header        X-Real-IP       $remote_addr;
      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
    }
 
     location /admin/sockjs-node {
-	    proxy_pass http://proxy-admin:3000;
+	    set $upstream  http://proxy-admin:3000;
+      proxy_pass $upstream;
         proxy_http_version 1.1;
 	    proxy_set_header Upgrade $http_upgrade;
 	    proxy_set_header Connection "upgrade";
 	}
 
     location /admin {
-     proxy_pass  http://proxy-admin:3000;
+      set $upstream  http://proxy-admin:3000;
+      proxy_pass $upstream;
      proxy_set_header        Host            $host;
      proxy_set_header        X-Real-IP       $remote_addr;
      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/localSetup/projects/nginx/nginx-conf.d/edlib-internal-apis.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/edlib-internal-apis.conf
@@ -18,7 +18,8 @@ server {
     access_log   off;
 
     location / {
-     proxy_pass  http://authapi;
+     set $upstream  http://authapi;
+     proxy_pass              $upstream;
      proxy_set_header        Host            $host;
      proxy_set_header        X-Real-IP       $remote_addr;
      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -34,7 +35,8 @@ server {
     access_log   off;
 
     location / {
-     proxy_pass  http://resourceapi;
+     set $upstream  http://resourceapi;
+     proxy_pass              $upstream;
      proxy_set_header        Host            $host;
      proxy_set_header        X-Real-IP       $remote_addr;
      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -50,7 +52,8 @@ server {
     access_log   off;
 
     location / {
-     proxy_pass  http://dokuapi;
+     set $upstream  http://dokuapi;
+     proxy_pass              $upstream;
      proxy_set_header        Host            $host;
      proxy_set_header        X-Real-IP       $remote_addr;
      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -66,7 +69,8 @@ server {
     access_log   off;
 
     location / {
-     proxy_pass  http://ltiapi;
+     set $upstream  http://ltiapi;
+     proxy_pass              $upstream;
      proxy_set_header        Host            $host;
      proxy_set_header        X-Real-IP       $remote_addr;
      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -83,7 +87,8 @@ server {
     access_log   off;
 
     location / {
-     proxy_pass  http://urlapi;
+     set $upstream  http://urlapi;
+     proxy_pass              $upstream;
      proxy_set_header        Host            $host;
      proxy_set_header        X-Real-IP       $remote_addr;
      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/localSetup/projects/nginx/nginx-conf.d/edlib-internal-apis.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/edlib-internal-apis.conf
@@ -1,96 +1,96 @@
 server {
-    listen 80;
+  listen 80;
 
-	server_name edlib.internal.auth.local
-	            edlib.internal.resource.local
-	            edlib.internal.doku.local
-	            edlib.internal.lti.local;
+  server_name edlib.internal.auth.local
+    edlib.internal.resource.local
+    edlib.internal.doku.local
+    edlib.internal.lti.local;
 
-    return 301 https://$host$request_uri;
+  return 301 https://$host$request_uri;
 }
 
 server {
-	listen 443 ssl;
-	ssl_certificate  /etc/ssl/private/cerpus.crt;
-	ssl_certificate_key  /etc/ssl/private/cerpus.key;
+  listen 443 ssl;
+  ssl_certificate  /etc/ssl/private/cerpus.crt;
+  ssl_certificate_key  /etc/ssl/private/cerpus.key;
 
-    server_name  edlib.internal.auth.local;
-    access_log   off;
+  server_name  edlib.internal.auth.local;
+  access_log   off;
 
-    location / {
-     set $upstream  http://authapi;
-     proxy_pass              $upstream;
-     proxy_set_header        Host            $host;
-     proxy_set_header        X-Real-IP       $remote_addr;
-     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-   }
+  location / {
+    set $upstream  http://authapi;
+    proxy_pass              $upstream;
+    proxy_set_header        Host            $host;
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
 }
 
 server {
-	listen 443 ssl;
-	ssl_certificate  /etc/ssl/private/cerpus.crt;
-	ssl_certificate_key  /etc/ssl/private/cerpus.key;
+  listen 443 ssl;
+  ssl_certificate  /etc/ssl/private/cerpus.crt;
+  ssl_certificate_key  /etc/ssl/private/cerpus.key;
 
-    server_name  edlib.internal.resource.local;
-    access_log   off;
+  server_name  edlib.internal.resource.local;
+  access_log   off;
 
-    location / {
-     set $upstream  http://resourceapi;
-     proxy_pass              $upstream;
-     proxy_set_header        Host            $host;
-     proxy_set_header        X-Real-IP       $remote_addr;
-     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-   }
+  location / {
+    set $upstream  http://resourceapi;
+    proxy_pass              $upstream;
+    proxy_set_header        Host            $host;
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
 }
 
 server {
-	listen 443 ssl;
-	ssl_certificate  /etc/ssl/private/cerpus.crt;
-	ssl_certificate_key  /etc/ssl/private/cerpus.key;
+  listen 443 ssl;
+  ssl_certificate  /etc/ssl/private/cerpus.crt;
+  ssl_certificate_key  /etc/ssl/private/cerpus.key;
 
-    server_name  edlib.internal.doku.local;
-    access_log   off;
+  server_name  edlib.internal.doku.local;
+  access_log   off;
 
-    location / {
-     set $upstream  http://dokuapi;
-     proxy_pass              $upstream;
-     proxy_set_header        Host            $host;
-     proxy_set_header        X-Real-IP       $remote_addr;
-     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-   }
+  location / {
+    set $upstream  http://dokuapi;
+    proxy_pass              $upstream;
+    proxy_set_header        Host            $host;
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
 }
 
 server {
-	listen 443 ssl;
-	ssl_certificate  /etc/ssl/private/cerpus.crt;
-	ssl_certificate_key  /etc/ssl/private/cerpus.key;
+  listen 443 ssl;
+  ssl_certificate  /etc/ssl/private/cerpus.crt;
+  ssl_certificate_key  /etc/ssl/private/cerpus.key;
 
-    server_name  edlib.internal.lti.local;
-    access_log   off;
+  server_name  edlib.internal.lti.local;
+  access_log   off;
 
-    location / {
-     set $upstream  http://ltiapi;
-     proxy_pass              $upstream;
-     proxy_set_header        Host            $host;
-     proxy_set_header        X-Real-IP       $remote_addr;
-     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-   }
+  location / {
+    set $upstream  http://ltiapi;
+    proxy_pass              $upstream;
+    proxy_set_header        Host            $host;
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
 }
 
 
 server {
-	listen 443 ssl;
-	ssl_certificate  /etc/ssl/private/cerpus.crt;
-	ssl_certificate_key  /etc/ssl/private/cerpus.key;
+  listen 443 ssl;
+  ssl_certificate  /etc/ssl/private/cerpus.crt;
+  ssl_certificate_key  /etc/ssl/private/cerpus.key;
 
-    server_name  edlib.internal.url.local;
-    access_log   off;
+  server_name  edlib.internal.url.local;
+  access_log   off;
 
-    location / {
-     set $upstream  http://urlapi;
-     proxy_pass              $upstream;
-     proxy_set_header        Host            $host;
-     proxy_set_header        X-Real-IP       $remote_addr;
-     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-   }
+  location / {
+    set $upstream  http://urlapi;
+    proxy_pass              $upstream;
+    proxy_set_header        Host            $host;
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
 }

--- a/localSetup/projects/nginx/nginx-conf.d/edlibfacade.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/edlibfacade.conf
@@ -17,12 +17,12 @@ server {
 	server_name edlibfacade.local;
 
 	location / {
-		proxy_pass http://edlibfacade:8080;
+		set $upstream  http://edlibfacade:8080;
 
+    proxy_pass $upstream;
 		proxy_set_header X-Forwarded-For  $remote_addr;
 		proxy_set_header Host $host;
 		proxy_set_header X-Forwarded-Proto https;
-		proxy_redirect default;
 	}
 
 	location ~ /\.ht {
@@ -39,14 +39,16 @@ server {
     access_log   on;
 
     location /sockjs-node {
-	    proxy_pass http://edlibfacade-test:3000;
+	    set $upstream http://edlibfacade-test:3000;
+			proxy_pass $upstream;
         proxy_http_version 1.1;
 	    proxy_set_header Upgrade $http_upgrade;
 	    proxy_set_header Connection "upgrade";
 	}
 
     location / {
-     proxy_pass  http://edlibfacade-test:3000;
+     set $upstream  http://edlibfacade-test:3000;
+		 proxy_pass $upstream;
      proxy_set_header        Host            $host;
      proxy_set_header        X-Real-IP       $remote_addr;
      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/localSetup/projects/nginx/nginx-conf.d/edlibfacade.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/edlibfacade.conf
@@ -1,57 +1,57 @@
 server {
-    listen 80;
+  listen 80;
 
-	server_name edlibfacade.local test.edlibfacade.local;
+  server_name edlibfacade.local test.edlibfacade.local;
 
-    return 301 https://$host$request_uri;
+  return 301 https://$host$request_uri;
 }
 
 server {
-	listen 443 ssl;
-	ssl_certificate  /etc/ssl/private/cerpus.crt;
-	ssl_certificate_key  /etc/ssl/private/cerpus.key;
+  listen 443 ssl;
+  ssl_certificate  /etc/ssl/private/cerpus.crt;
+  ssl_certificate_key  /etc/ssl/private/cerpus.key;
 
-	root /var/www/proxy-default;
-	index index.html index.htm;
+  root /var/www/proxy-default;
+  index index.html index.htm;
 
-	server_name edlibfacade.local;
+  server_name edlibfacade.local;
 
-	location / {
-		set $upstream  http://edlibfacade:8080;
+  location / {
+    set $upstream  http://edlibfacade:8080;
 
     proxy_pass $upstream;
-		proxy_set_header X-Forwarded-For  $remote_addr;
-		proxy_set_header Host $host;
-		proxy_set_header X-Forwarded-Proto https;
-	}
+    proxy_set_header X-Forwarded-For  $remote_addr;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto https;
+  }
 
-	location ~ /\.ht {
-		deny all;
-	}
+  location ~ /\.ht {
+    deny all;
+  }
 }
 
 server {
-	listen 443 ssl;
-	ssl_certificate  /etc/ssl/private/cerpus.crt;
-	ssl_certificate_key  /etc/ssl/private/cerpus.key;
+  listen 443 ssl;
+  ssl_certificate  /etc/ssl/private/cerpus.crt;
+  ssl_certificate_key  /etc/ssl/private/cerpus.key;
 
-    server_name  test.edlibfacade.local;
-    access_log   on;
+  server_name  test.edlibfacade.local;
+  access_log   on;
 
-    location /sockjs-node {
-	    set $upstream http://edlibfacade-test:3000;
-			proxy_pass $upstream;
-        proxy_http_version 1.1;
-	    proxy_set_header Upgrade $http_upgrade;
-	    proxy_set_header Connection "upgrade";
-	}
+  location /sockjs-node {
+    set $upstream http://edlibfacade-test:3000;
+    proxy_pass $upstream;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
 
-    location / {
-     set $upstream  http://edlibfacade-test:3000;
-		 proxy_pass $upstream;
-     proxy_set_header        Host            $host;
-     proxy_set_header        X-Real-IP       $remote_addr;
-     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-   }
+  location / {
+    set $upstream  http://edlibfacade-test:3000;
+    proxy_pass $upstream;
+    proxy_set_header        Host            $host;
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
 }
 

--- a/localSetup/projects/nginx/nginx-conf.d/kibana.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/kibana.conf
@@ -1,25 +1,25 @@
 server {
-    listen 80;
-	server_name kibana.edlib.local;
-    return 301 https://$host$request_uri;
+  listen 80;
+  server_name kibana.edlib.local;
+  return 301 https://$host$request_uri;
 }
 
 server {
-    listen       443;
-    server_name  kibana.edlib.local;
+  listen       443;
+  server_name  kibana.edlib.local;
 
-    location / {
-        # kibana sever
-        set $upstream http://kibana:5601/;
-        proxy_pass $upstream;
-        proxy_set_header Authorization "Basic **";
-        proxy_set_header X-Forwarded-User $http_x_forwarded_user;
-        # enable real-time interactions
-        proxy_buffering off;
-        rewrite /login http://localhost:4180/oauth2/sign_in redirect;
-    }
-    # if the user is not "admin", then do a redirect when the user tries to access "dev tools"
-    if ($http_x_forwarded_user != admin) {
-        rewrite ^/api/console.*$ http://kibana:5601/ redirect;
-    }
+  location / {
+    # kibana sever
+    set $upstream http://kibana:5601/;
+    proxy_pass $upstream;
+    proxy_set_header Authorization "Basic **";
+    proxy_set_header X-Forwarded-User $http_x_forwarded_user;
+    # enable real-time interactions
+    proxy_buffering off;
+    rewrite /login http://localhost:4180/oauth2/sign_in redirect;
+  }
+  # if the user is not "admin", then do a redirect when the user tries to access "dev tools"
+  if ($http_x_forwarded_user != admin) {
+    rewrite ^/api/console.*$ http://kibana:5601/ redirect;
+  }
 }

--- a/localSetup/projects/nginx/nginx-conf.d/kibana.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/kibana.conf
@@ -10,7 +10,8 @@ server {
 
     location / {
         # kibana sever
-        proxy_pass http://kibana:5601/;
+        set $upstream http://kibana:5601/;
+        proxy_pass $upstream;
         proxy_set_header Authorization "Basic **";
         proxy_set_header X-Forwarded-User $http_x_forwarded_user;
         # enable real-time interactions

--- a/localSetup/projects/nginx/nginx-conf.d/licenseapi.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/licenseapi.conf
@@ -7,11 +7,11 @@ server {
 	server_name licenseapi licenseapi.local;
 
 	location / {
-		proxy_pass http://licenseapi:80;
+		set $upstream http://licenseapi:80;
+		proxy_pass $upstream;
 
 		proxy_set_header X-Forwarded-For  $remote_addr;
 		proxy_set_header Host $host;
-		proxy_redirect default;
 	}
 
 	location ~ /\.ht {

--- a/localSetup/projects/nginx/nginx-conf.d/licenseapi.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/licenseapi.conf
@@ -1,21 +1,21 @@
 server {
-	listen 80;
+  listen 80;
 
-	root /var/www/proxy-default;
-	index index.html index.htm;
+  root /var/www/proxy-default;
+  index index.html index.htm;
 
-	server_name licenseapi licenseapi.local;
+  server_name licenseapi licenseapi.local;
 
-	location / {
-		set $upstream http://licenseapi:80;
-		proxy_pass $upstream;
+  location / {
+    set $upstream http://licenseapi:80;
+    proxy_pass $upstream;
 
-		proxy_set_header X-Forwarded-For  $remote_addr;
-		proxy_set_header Host $host;
-	}
+    proxy_set_header X-Forwarded-For  $remote_addr;
+    proxy_set_header Host $host;
+  }
 
-	location ~ /\.ht {
-		deny all;
-	}
+  location ~ /\.ht {
+    deny all;
+  }
 }
 

--- a/localSetup/projects/nginx/nginx-conf.d/metadataservice.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/metadataservice.conf
@@ -7,11 +7,11 @@ server {
 	server_name metadataservice metadataservice.local;
 
 	location / {
-		proxy_pass http://metadataservice:8091;
+		set $upstream http://metadataservice:8091;
+		proxy_pass $upstream;
 
 		proxy_set_header X-Forwarded-For  $remote_addr;
 		proxy_set_header Host $host;
-		proxy_redirect default;
 	}
 
 	location ~ /\.ht {

--- a/localSetup/projects/nginx/nginx-conf.d/metadataservice.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/metadataservice.conf
@@ -1,21 +1,21 @@
 server {
-	listen 80;
+  listen 80;
 
-	root /var/www/proxy-default;
-	index index.html index.htm;
+  root /var/www/proxy-default;
+  index index.html index.htm;
 
-	server_name metadataservice metadataservice.local;
+  server_name metadataservice metadataservice.local;
 
-	location / {
-		set $upstream http://metadataservice:8091;
-		proxy_pass $upstream;
+  location / {
+    set $upstream http://metadataservice:8091;
+    proxy_pass $upstream;
 
-		proxy_set_header X-Forwarded-For  $remote_addr;
-		proxy_set_header Host $host;
-	}
+    proxy_set_header X-Forwarded-For  $remote_addr;
+    proxy_set_header Host $host;
+  }
 
-	location ~ /\.ht {
-		deny all;
-	}
+  location ~ /\.ht {
+    deny all;
+  }
 }
 

--- a/localSetup/projects/nginx/nginx-conf.d/nginxconfig.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/nginxconfig.conf
@@ -1,6 +1,4 @@
-
+resolver 127.0.0.11 valid=30s;
 client_max_body_size 256M;
 proxy_send_timeout 7200;
 proxy_read_timeout 7200;
-
-

--- a/localSetup/projects/nginx/nginx-conf.d/npm-components-storybook.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/npm-components-storybook.conf
@@ -15,14 +15,16 @@ server {
     access_log   on;
 
     location /sockjs-node {
-	    proxy_pass http://npm-components-storybook:9009;
+	    set $upstream http://npm-components-storybook:9009;
+      proxy_pass $upstream;
         proxy_http_version 1.1;
 	    proxy_set_header Upgrade $http_upgrade;
 	    proxy_set_header Connection "upgrade";
 	}
 
     location / {
-     proxy_pass  http://npm-components-storybook:9009;
+     set $upstream  http://npm-components-storybook:9009;
+      proxy_pass $upstream;
      proxy_set_header        Host            $host;
      proxy_set_header        X-Real-IP       $remote_addr;
      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/localSetup/projects/nginx/nginx-conf.d/npm-components-storybook.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/npm-components-storybook.conf
@@ -1,32 +1,32 @@
 server {
-    listen 80;
+  listen 80;
 
-	server_name npm.components.edlib.local;
+  server_name npm.components.edlib.local;
 
-    return 301 https://$host$request_uri;
+  return 301 https://$host$request_uri;
 }
 
 server {
-	listen 443 ssl;
-	ssl_certificate  /etc/ssl/private/cerpus.crt;
-	ssl_certificate_key  /etc/ssl/private/cerpus.key;
+  listen 443 ssl;
+  ssl_certificate  /etc/ssl/private/cerpus.crt;
+  ssl_certificate_key  /etc/ssl/private/cerpus.key;
 
-    server_name  npm.components.edlib.local;
-    access_log   on;
+  server_name  npm.components.edlib.local;
+  access_log   on;
 
-    location /sockjs-node {
-	    set $upstream http://npm-components-storybook:9009;
-      proxy_pass $upstream;
-        proxy_http_version 1.1;
-	    proxy_set_header Upgrade $http_upgrade;
-	    proxy_set_header Connection "upgrade";
-	}
+  location /sockjs-node {
+    set $upstream http://npm-components-storybook:9009;
+    proxy_pass $upstream;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
 
-    location / {
-     set $upstream  http://npm-components-storybook:9009;
-      proxy_pass $upstream;
-     proxy_set_header        Host            $host;
-     proxy_set_header        X-Real-IP       $remote_addr;
-     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-   }
+  location / {
+    set $upstream  http://npm-components-storybook:9009;
+    proxy_pass              $upstream;
+    proxy_set_header        Host            $host;
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
 }

--- a/localSetup/projects/nginx/nginx-conf.d/re-recommender.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/re-recommender.conf
@@ -4,7 +4,8 @@ server {
     access_log   off;
 
     location / {
-     proxy_pass  http://re-recommender;
+     set $upstream  http://re-recommender;
+     proxy_pass              $upstream;
      proxy_set_header        Host            $host;
      proxy_set_header        X-Real-IP       $remote_addr;
      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -17,7 +18,8 @@ server {
     access_log   off;
 
     location / {
-     proxy_pass  http://re-content-index;
+     set $upstream  http://re-content-index;
+     proxy_pass              $upstream;
      proxy_set_header        Host            $host;
      proxy_set_header        X-Real-IP       $remote_addr;
      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/localSetup/projects/nginx/nginx-conf.d/re-recommender.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/re-recommender.conf
@@ -1,27 +1,27 @@
 server {
-    listen       80;
-    server_name  re-recommender;
-    access_log   off;
+  listen       80;
+  server_name  re-recommender;
+  access_log   off;
 
-    location / {
-     set $upstream  http://re-recommender;
-     proxy_pass              $upstream;
-     proxy_set_header        Host            $host;
-     proxy_set_header        X-Real-IP       $remote_addr;
-     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-   }
+  location / {
+    set $upstream  http://re-recommender;
+    proxy_pass              $upstream;
+    proxy_set_header        Host            $host;
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
 }
 
 server {
-    listen       80;
-    server_name  re-content-index;
-    access_log   off;
+  listen       80;
+  server_name  re-content-index;
+  access_log   off;
 
-    location / {
-     set $upstream  http://re-content-index;
-     proxy_pass              $upstream;
-     proxy_set_header        Host            $host;
-     proxy_set_header        X-Real-IP       $remote_addr;
-     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-   }
+  location / {
+    set $upstream  http://re-content-index;
+    proxy_pass              $upstream;
+    proxy_set_header        Host            $host;
+    proxy_set_header        X-Real-IP       $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
 }

--- a/localSetup/projects/nginx/nginx-conf.d/versionapi.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/versionapi.conf
@@ -1,21 +1,21 @@
 server {
-	listen 80;
+  listen 80;
 
-	root /var/www/proxy-default;
-	index index.html index.htm;
+  root /var/www/proxy-default;
+  index index.html index.htm;
 
-	server_name versioningapi versioningapi.local;
+  server_name versioningapi versioningapi.local;
 
-	location / {
-		set $upstream http://versioningapi:8080;
-		proxy_pass $upstream;
+  location / {
+    set $upstream http://versioningapi:8080;
+    proxy_pass $upstream;
 
-		proxy_set_header X-Forwarded-For  $remote_addr;
-		proxy_set_header Host $host;
-	}
+    proxy_set_header X-Forwarded-For  $remote_addr;
+    proxy_set_header Host $host;
+  }
 
-	location ~ /\.ht {
-		deny all;
-	}
+  location ~ /\.ht {
+    deny all;
+  }
 }
 

--- a/localSetup/projects/nginx/nginx-conf.d/versionapi.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/versionapi.conf
@@ -7,11 +7,11 @@ server {
 	server_name versioningapi versioningapi.local;
 
 	location / {
-		proxy_pass http://versioningapi:8080;
+		set $upstream http://versioningapi:8080;
+		proxy_pass $upstream;
 
 		proxy_set_header X-Forwarded-For  $remote_addr;
 		proxy_set_header Host $host;
-		proxy_redirect default;
 	}
 
 	location ~ /\.ht {


### PR DESCRIPTION
This change allows nginx to resolve hostnames at runtime instead of relying on each service to be ready at startup.