### PR TITLE
Generate certificates inside nginx container

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -23,3 +23,4 @@ All commands bellow must be run from the base directory of edlib.
 4. run (HOST)`./update-host-file.sh <VM-IP>` to create host file entries for edlib on your host
 5. After the script on step 1 is done, log out and in so that all changes take effect
 6. Run (VM)`dcu` to start docker-compose. `dcu` is an alias for `docker-compose up -d`
+7. Run (VM)`./update-certs.sh` to install the newly generated certificates inside the VM.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,7 +185,7 @@ services:
       target: phpfpm
     env_file:
       - ./localSetup/projects/content-author/.env
-    command: /bin/bash -c "set -eux;update-ca-certificates;chown -R www-data:www-data /app/storage /app/public;/start-scripts/wait-for-multiple.sh mysql:3306;php /app/artisan migrate --force;php-fpm -R -F -O"
+    command: /bin/bash -c "set -eux;/start-scripts/wait-for-multiple.sh mysql:3306 nginx:80;update-ca-certificates;chown -R www-data:www-data /app/storage /app/public;php /app/artisan migrate --force;php-fpm -R -F -O"
     volumes:
       - ./localSetup/projects/content-author/startup.sh:/startup.sh
       - ./sourcecode/not_migrated/h5pviewer:/app
@@ -197,6 +197,7 @@ services:
     depends_on:
       - mysql
       - memcached
+      - nginx
 
   contentauthor-cron:
     build:
@@ -569,7 +570,9 @@ services:
     build:
       context: ./localSetup/projects/edlibfacade
     entrypoint: /before-start.sh
-    command: bash -c "/start-scripts/wait-for-multiple.sh configserver:8888;/start-app.sh"
+    command: bash -c "/start-scripts/wait-for-multiple.sh configserver:8888 nginx:80;/start-app.sh"
+    depends_on:
+      - nginx
     volumes:
       - ./sourcecode/not_migrated/edlibfacade/target/edlibfacade.jar:/app.jar
       - ./data/nginx/ca/cacert.pem:/cacerts.d/dev-cacert.crt:ro

--- a/localSetup/projects/nginx/entrypoint.sh
+++ b/localSetup/projects/nginx/entrypoint.sh
@@ -1,8 +1,79 @@
 #!/bin/sh
+set -e
 
-if [ ! -f '/etc/ssl/private/cerpus.key' ] || [ ! -f '/etc/ssl/private/cerpus.crt' ]; then
-    echo 'certificate not setup. Run "./run.sh update-certs" in docker-compose root to create them'
-    exit 0
+CA_DIR=/etc/ca
+CERTS_DIR=/etc/ssl/private
+
+DOMAINS="\
+DNS:edlib.internal.url.local, \
+DNS:edlib.internal.auth.local, \
+DNS:edlib.internal.resource.local, \
+DNS:edlib.internal.lti.local, \
+DNS:edlib.internal.doku.local, \
+DNS:edlibfacade.local, \
+DNS:test.edlibfacade.local, \
+DNS:localhost, \
+DNS:contentauthor.local, \
+DNS:api.edlib.local, \
+DNS:npm.components.edlib.local, \
+DNS:kibana.edlib.local \
+"
+
+if [ ! -f "$CA_DIR/ca.key" ]; then
+  echo Generating CA key..
+  openssl genrsa -out "$CA_DIR/ca.key" 4096
+
+  echo Generating CA cert..
+  openssl req \
+    -x509 \
+    -new \
+    -nodes \
+    -key "$CA_DIR/ca.key" \
+    -sha256 \
+    -days 3650 \
+    -out "$CA_DIR/cacert.pem" \
+    -subj '/C=NO/ST=Nordland/L=Alsvaag/O=Cerpus AS/OU=local/CN=cerpus.com/emailAddress=local@cerpus.com'
+fi
+
+if [ ! -f "$CERTS_DIR/cerpus.key" ] || [ ! -f "$CERTS_DIR/cerpus.crt" ]; then
+  echo "Generating site certificate..."
+  rm -f "$CERTS_DIR/cerpus.*"
+
+  OPENSSL_CONFIG=$(mktemp)
+  {
+    echo '[dn]'
+    echo 'CN=localhost'
+    echo '[req]'
+    echo 'distinguished_name = dn'
+    echo '[EXT]'
+    echo "subjectAltName = $DOMAINS"
+    echo 'keyUsage=digitalSignature'
+    echo 'extendedKeyUsage=serverAuth'
+  } > "$OPENSSL_CONFIG"
+
+  openssl req \
+    -nodes \
+    -newkey rsa:2048 \
+    -subj '/CN=localhost' \
+    -extensions EXT \
+    -keyout "$CERTS_DIR/cerpus.key" \
+    -out "$CERTS_DIR/cerpus.csr" \
+    -config "$OPENSSL_CONFIG"
+  rm "$OPENSSL_CONFIG"
+
+  EXTFILE=$(mktemp)
+  echo "subjectAltName = $DOMAINS" > "$EXTFILE"
+  openssl x509 \
+    -req \
+    -in "$CERTS_DIR/cerpus.csr" \
+    -CA "$CA_DIR/cacert.pem" \
+    -CAkey "$CA_DIR/ca.key" \
+    -CAcreateserial \
+    -out "$CERTS_DIR/cerpus.crt" \
+    -days 3649 \
+    -sha256 \
+    -extfile "$EXTFILE"
+  rm "$EXTFILE"
 fi
 
 exec "$@"

--- a/scripts/first-time-setup.sh
+++ b/scripts/first-time-setup.sh
@@ -6,7 +6,6 @@ cd "$(dirname "$0")"
 ./git-clone-ssh.sh
 ./initialize-data-folders.sh
 ./update-all.sh
-./update-certs.sh
 ./create-aliases.sh
 
 pushd ../localSetup

--- a/scripts/update-certs.sh
+++ b/scripts/update-certs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 cd "$(dirname "$0")"
 cd ..
@@ -6,64 +7,10 @@ cd ..
 CA_DIR=data/nginx/ca
 CERTS_DIR=data/nginx/certs
 
-mkdir -p $CA_DIR
-mkdir -p $CERTS_DIR
-
-ls -l $CA_DIR
-
-if [ ! -f $CA_DIR/ca.key ];then
-  echo Generating CA key..
-  openssl genrsa -out $CA_DIR/ca.key 4096
-  echo Generating CA cert..
-  openssl req -x509 -new -nodes -key $CA_DIR/ca.key -sha256 -days 3650 -out $CA_DIR/cacert.pem \
-    -subj "/C=NO/ST=Nordland/L=Alsvaag/O=Cerpus AS/OU=local/CN=cerpus.com/emailAddress=local@cerpus.com"
-  echo CA is complete.
-else
-  echo "Certificate issuer already exists"
+if [ ! -f "$CA_DIR/cacert.pem" ]; then
+  echo "$CA_DIR/cacert.pem does not exist. Did you start the nginx container?"
+  exit 1
 fi
-
-DOMAINS=(
-  "DNS:edlib.internal.url.local"
-  "DNS:edlib.internal.auth.local"
-  "DNS:edlib.internal.resource.local"
-  "DNS:edlib.internal.lti.local"
-  "DNS:edlib.internal.doku.local"
-  "DNS:edlibfacade.local"
-  "DNS:test.edlibfacade.local"
-  "DNS:localhost"
-  "DNS:contentauthor.local"
-  "DNS:api.edlib.local"
-  "DNS:npm.components.edlib.local"
-  "DNS:kibana.edlib.local"
-)
-DNS=$(IFS=, ; echo "${DOMAINS[*]}")
-
-OPENSSL_CONFIG=$(mktemp)
-    {
-        echo '[dn]'
-        echo 'CN=localhost'
-        echo '[req]'
-        echo 'distinguished_name = dn'
-        echo '[EXT]'
-	      echo "subjectAltName = $DNS"
-        echo 'keyUsage=digitalSignature'
-        echo 'extendedKeyUsage=serverAuth'
-    } > "$OPENSSL_CONFIG"
-    openssl req \
-        -nodes \
-        -newkey rsa:2048 \
-        -subj '/CN=localhost' \
-        -extensions EXT \
-        -keyout $CERTS_DIR/cerpus.key \
-        -out $CERTS_DIR/cerpus.csr \
-        -config "$OPENSSL_CONFIG"
-
-    EXTFILE=$(mktemp)
-    echo "subjectAltName = $DNS" > "$EXTFILE"
-
-    openssl x509 -req -in $CERTS_DIR/cerpus.csr -CA $CA_DIR/cacert.pem -CAkey $CA_DIR/ca.key -CAcreateserial \
--out $CERTS_DIR/cerpus.crt -days 3649 -sha256 -extfile "$EXTFILE"
-    rm "$OPENSSL_CONFIG" "$EXTFILE"
 
 echo "Copying $CA_DIR/cacert.pem to /usr/local/share/ca-certificates/cerpus-dev"
 sudo cp $CA_DIR/cacert.pem /usr/local/share/ca-certificates/cerpus.crt


### PR DESCRIPTION
In the interest of creating a pure Docker-based setup, this change moves generation of TLS certificates to the nginx container's entrypoint script.