### PR TITLE
Cast non-template uses of mix() to string

### DIFF
--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Adapters/NDLAH5PAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Adapters/NDLAH5PAdapter.php
@@ -145,10 +145,10 @@ class NDLAH5PAdapter implements H5PAdapterInterface
      */
     public function getEditorCss(): array
     {
-        $css = [mix('ndlah5p-editor.css')];
+        $css = [(string) mix('ndlah5p-editor.css')];
         $css[] = '/js/cropperjs/cropper.min.css';
         if (config('h5p.include-custom-css') === true) {
-            $css[] = mix('ndlah5p-edit.css');
+            $css[] = (string) mix('ndlah5p-edit.css');
         }
         return $css;
     }
@@ -170,17 +170,17 @@ class NDLAH5PAdapter implements H5PAdapterInterface
     {
         return [
             "/js/h5p/wiris/h5peditor-html-wiris-addon.js",
-            mix("ndla-contentbrowser.js"),
+            (string) mix("ndla-contentbrowser.js"),
             "/js/videos/brightcove.js",
-            mix('h5p/h5peditor-image-popup.js'),
-            mix('h5peditor-custom.js'),
+            (string) mix('h5p/h5peditor-image-popup.js'),
+            (string) mix('h5peditor-custom.js'),
         ];
     }
 
     public function getCustomEditorStyles(): array
     {
         return [
-            mix('react-contentbrowser.css'),
+            (string) mix('react-contentbrowser.css'),
         ];
     }
 
@@ -192,7 +192,7 @@ class NDLAH5PAdapter implements H5PAdapterInterface
         $scripts = [
             '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-AMS-MML_SVG',
             '/js/h5p/wiris/view.js',
-            mix('h5peditor-custom.js'),
+            (string) mix('h5peditor-custom.js'),
         ];
         $libraries = $this->config->h5pCore->loadContentDependencies($this->config->id, "preloaded");
         if ($this->hasVideoLibrary($libraries, 1, 3) === true) {
@@ -212,10 +212,10 @@ class NDLAH5PAdapter implements H5PAdapterInterface
             $customCssBreakpoint = Carbon::parse($ndlaCustomCssOption->option_value);
             $updated = $this->config->content['updated_at'];
             if ($customCssBreakpoint > $updated) {
-                $css[] = mix('ndlah5p-iframe-legacy.css');
+                $css[] = (string) mix('ndlah5p-iframe-legacy.css');
             }
         }
-        $css[] = mix('ndlah5p-iframe.css');
+        $css[] = (string) mix('ndlah5p-iframe.css');
         return $css;
     }
 
@@ -415,7 +415,7 @@ class NDLAH5PAdapter implements H5PAdapterInterface
     public function getConfigJs(): array
     {
         return [
-            mix('react-contentbrowser.js')
+            (string) mix('react-contentbrowser.js')
         ];
     }
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/AdminConfig.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/AdminConfig.php
@@ -65,7 +65,7 @@ class AdminConfig implements ConfigInterface
         $this->addCoreAssets();
         $this->addAsset('scripts', $this->getAssetUrl('editor', 'scripts/h5peditor-editor.js'));
         //$this->addAsset('scripts', $this->getAssetUrl('editor', 'scripts/h5peditor.js'));
-        $this->addAsset('scripts', mix('maxscore.js'));
+        $this->addAsset('scripts', (string) mix('maxscore.js'));
         $this->addAsset('scripts', $this->getAssetUrl('editor', 'scripts/h5peditor-pre-save.js'));
         $h5pLibraryDisk = \Storage::disk('h5p');
         H5PLibrary::get()

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/EditorConfig.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/EditorConfig.php
@@ -119,13 +119,13 @@ class EditorConfig implements ConfigInterface
     private function getEditorStyles()
     {
         $editor = $this->editor;
-        $editorStyles[] = mix('h5p-core.css');
-        $editorStyles[] = mix('h5p-admin.css');
+        $editorStyles[] = (string) mix('h5p-core.css');
+        $editorStyles[] = (string) mix('h5p-admin.css');
         foreach ($editor::$styles as $style) {
             $editorStyles[] = $this->getAssetUrl("editor", $style);
         }
         $editorStyles[] = '//fonts.googleapis.com/css?family=Lato:400,700';
-        $editorStyles[] = mix('react-h5p.css');
+        $editorStyles[] = (string) mix('react-h5p.css');
         return array_merge($editorStyles, $this->adapter->getEditorCss());
     }
 
@@ -158,7 +158,7 @@ class EditorConfig implements ConfigInterface
         }
 
         foreach ([
-                     mix("h5pmetadata.js"),
+                     (string) mix("h5pmetadata.js"),
                      '/js/editor-setup.js',
                  ] as $script) {
             $scriptPath = $this->getAssetUrl(null, $script);


### PR DESCRIPTION
The `mix()` function returns objects, apparently. These are implicitly cast to string when rendered in a template, but in non-template contexts this is not necessarily the case. We fix the issue by casting non-template uses of `mix()` to string.