### PR TITLE
Ignore updates to es client

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -36,6 +36,9 @@ updates:
     directory: "/sourcecode/apis/resources"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "@elastic/elasticsearch"
+
   - package-ecosystem: "npm"
     directory: "/sourcecode/apis/url"
     schedule:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -37,7 +37,7 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      - dependency-name: "@elastic/elasticsearch"
+      - dependency-name: "@elastic/elasticsearch" # newer versions of this client doesn't support elasticsearch in AWS
 
   - package-ecosystem: "npm"
     directory: "/sourcecode/apis/url"

--- a/sourcecode/apis/resources/package.json
+++ b/sourcecode/apis/resources/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@babel/preset-env": "^7.16.4",
     "@cerpus/edlib-node-utils": "1.6.0",
-    "@elastic/elasticsearch": "7.15.x",
+    "@elastic/elasticsearch": "7.12.x",
     "amqplib": "^0.8.0",
     "axios-mock-adapter": "^1.20.0",
     "babel-plugin-transform-default-import": "^1.0.0",

--- a/sourcecode/apis/resources/yarn.lock
+++ b/sourcecode/apis/resources/yarn.lock
@@ -973,15 +973,16 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@elastic/elasticsearch@7.15.x":
-  version "7.15.0"
-  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch/-/elasticsearch-7.15.0.tgz#4b009a87e0b11b8cfd2e4f378f0292574bc17300"
-  integrity sha512-FUKvjV2IKtIiWsvBy7D+wLbSEONsmNR15RRN7P/Sb30g4ObZRHH2qGOP5PPnzxdntEkzZ8HzY7nKKXFS+3Du1g==
+"@elastic/elasticsearch@7.12.x":
+  version "7.12.0"
+  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch/-/elasticsearch-7.12.0.tgz#dbb51a2841f644b670a56d8c15899e860928856f"
+  integrity sha512-GquUEytCijFRPEk3DKkkDdyhspB3qbucVQOwih9uNyz3iz804I+nGBUsFo2LwVvLQmQfEM0IY2+yoYfEz5wMug==
   dependencies:
     debug "^4.3.1"
     hpagent "^0.1.1"
     ms "^2.1.3"
-    secure-json-parse "^2.4.0"
+    pump "^3.0.0"
+    secure-json-parse "^2.3.1"
 
 "@hapi/address@^4.0.1":
   version "4.1.0"
@@ -4971,7 +4972,7 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-secure-json-parse@^2.4.0:
+secure-json-parse@^2.3.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.4.0.tgz#5aaeaaef85c7a417f76271a4f5b0cc3315ddca85"
   integrity sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg==


### PR DESCRIPTION
Newer versions of the elasticsearch client doesn't support elasticsearch in AWS