### PR TITLE
Improve error handling in HTTP utility

### DIFF
--- a/sourcecode/apis/contentauthor/app/Util.php
+++ b/sourcecode/apis/contentauthor/app/Util.php
@@ -26,6 +26,7 @@ class Util
      * @param callable():ResponseInterface $wrapper
      * @return array|string|float|int|bool|null
      * @throws NotFoundException
+     * @throws \JsonException
      */
     public static function handleEdlibNodeApiRequest(callable $wrapper)
     {

--- a/sourcecode/apis/contentauthor/tests/Unit/UtilTest.php
+++ b/sourcecode/apis/contentauthor/tests/Unit/UtilTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Exceptions\NotFoundException;
+use App\Util;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+
+class UtilTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function testHandleEdlibNodeApiRequest(): void
+    {
+        $jsonData = ['a' => ['b' => 'c']];
+        $response = new Response(200, [], json_encode($jsonData, JSON_THROW_ON_ERROR));
+
+        $this->assertSame($jsonData, Util::handleEdlibNodeApiRequest(fn() => $response));
+    }
+
+    /**
+     * @test
+     */
+    public function testHandleEdlibNodeApiRequest_withBadJson(): void
+    {
+        $response = new Response(200, [], '{"a":');
+
+        $this->expectException(\JsonException::class);
+
+        Util::handleEdlibNodeApiRequest(fn() => $response);
+    }
+
+    /**
+     * @test
+     */
+    public function handleEdlibNodeApiRequest_with404(): void
+    {
+        $errorMessage = 'oops!';
+        $errorJson = ['error' => ['parameter' => $errorMessage]];
+        $request = new Request('GET', '/');
+        $response = new Response(404, [], json_encode($errorJson, JSON_THROW_ON_ERROR));
+
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage($errorMessage);
+
+        Util::handleEdlibNodeApiRequest(function () use ($request, $response) {
+            throw new RequestException('', $request, $response);
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function handleEdlibNodeApiRequest_withOtherErrorCode(): void
+    {
+        $request = new Request('GET', '/');
+        $response = new Response(500, [], '');
+        $exception = new RequestException('Server error', $request, $response);
+
+        $this->expectExceptionObject($exception);
+
+        Util::handleEdlibNodeApiRequest(function () use ($exception) {
+            throw $exception;
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function handleEdlibNodeApiRequest_withNoResponseError(): void
+    {
+        $request = new Request('GET', '/');
+        $exception = new RequestException('Server error', $request);
+
+        $this->expectExceptionObject($exception);
+
+        Util::handleEdlibNodeApiRequest(function () use ($exception) {
+            throw $exception;
+        });
+    }
+}

--- a/sourcecode/apis/contentauthor/tests/Unit/UtilTest.php
+++ b/sourcecode/apis/contentauthor/tests/Unit/UtilTest.php
@@ -40,15 +40,31 @@ class UtilTest extends TestCase
     public function handleEdlibNodeApiRequest_with404(): void
     {
         $errorMessage = 'oops!';
-        $errorJson = ['error' => ['parameter' => $errorMessage]];
+        $errorData = ['error' => ['parameter' => $errorMessage]];
         $request = new Request('GET', '/');
-        $response = new Response(404, [], json_encode($errorJson, JSON_THROW_ON_ERROR));
+        $response = new Response(404, [], json_encode($errorData, JSON_THROW_ON_ERROR));
 
         $this->expectException(NotFoundException::class);
         $this->expectExceptionMessage($errorMessage);
 
         Util::handleEdlibNodeApiRequest(function () use ($request, $response) {
             throw new RequestException('', $request, $response);
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function handleEdlibNodeApiRequest_with404AndBadJson(): void
+    {
+        $request = new Request('GET', '/');
+        $response = new Response(404, [], '{"a":');
+        $exception = new RequestException('', $request, $response);
+
+        $this->expectExceptionObject($exception);
+
+        Util::handleEdlibNodeApiRequest(function () use ($exception) {
+            throw $exception;
         });
     }
 


### PR DESCRIPTION
Assuming this is the cause of #362.

* Annotate App\Util methods properly.

* Handle exception without response, actually throw JsonException upon invalid JSON.

* Test App\Util::handleEdlibNodeApiRequest.