### PR TITLE
Log stack traces in Content Author

### DIFF
--- a/sourcecode/apis/contentauthor/app/Logging/JsonFormatter.php
+++ b/sourcecode/apis/contentauthor/app/Logging/JsonFormatter.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Logging;
+
+use Monolog\Formatter\JsonFormatter as BaseJsonFormatter;
+
+/**
+ * JSON formatter with stack traces
+ */
+class JsonFormatter extends BaseJsonFormatter
+{
+    public function __construct(
+        int $batchMode = BaseJsonFormatter::BATCH_MODE_JSON,
+        bool $appendNewline = true,
+        bool $ignoreEmptyContextAndExtra = false
+    ) {
+        parent::__construct($batchMode, $appendNewline, $ignoreEmptyContextAndExtra);
+
+        $this->includeStacktraces = true;
+    }
+}

--- a/sourcecode/apis/contentauthor/config/logging.php
+++ b/sourcecode/apis/contentauthor/config/logging.php
@@ -59,7 +59,7 @@ return [
         'stderr' => [
             'driver' => 'monolog',
             'handler' => StreamHandler::class,
-            'formatter' => Monolog\Formatter\JsonFormatter::class,
+            'formatter' => App\Logging\JsonFormatter::class,
             'with' => [
                 'stream' => 'php://stderr',
             ],


### PR DESCRIPTION
Brings back stack traces for JSON logs. Functions/methods and parameters are still missing, but better than nothing.

Before:

~~~json
{
   "channel" : "local",
   "context" : {
      "exception" : {
         "class" : "Exception",
         "code" : 0,
         "file" : "/app/app/Http/Controllers/Admin/AdminController.php:149",
         "message" : "some message"
      },
      "userId" : 2
   },
   "datetime" : "2022-01-14T08:20:08.188890+00:00",
   "extra" : {},
   "level" : 400,
   "level_name" : "ERROR",
   "message" : "some message"
}
~~~

After:

~~~json
{
   "channel" : "local",
   "context" : {
      "exception" : {
         "class" : "Exception",
         "code" : 0,
         "file" : "/app/app/Http/Controllers/Admin/AdminController.php:149",
         "message" : "some message",
         "trace" : [
            "/app/vendor/laravel/framework/src/Illuminate/Routing/Controller.php:54",
            "/app/vendor/laravel/framework/src/Illuminate/Routing/ControllerDispatcher.php:45",
            "/app/vendor/laravel/framework/src/Illuminate/Routing/Route.php:262",
            "/app/vendor/laravel/framework/src/Illuminate/Routing/Route.php:205",
            "/app/vendor/laravel/framework/src/Illuminate/Routing/Router.php:695",
            "/app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:128",
            "/app/vendor/laravel/framework/src/Illuminate/Routing/Middleware/SubstituteBindings.php:50",
            "/app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167",
            "/app/app/Http/Middleware/Authenticate.php:45",
            "/app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167",
            "/app/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php:78",
            "/app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167",
            "/app/vendor/laravel/framework/src/Illuminate/View/Middleware/ShareErrorsFromSession.php:49",
            "/app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167",
            "/app/vendor/laravel/framework/src/Illuminate/Session/Middleware/StartSession.php:121",
            "/app/vendor/laravel/framework/src/Illuminate/Session/Middleware/StartSession.php:64",
            "/app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167",
            "/app/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/AddQueuedCookiesToResponse.php:37",
            "/app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167",
            "/app/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/EncryptCookies.php:67",
            "/app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167",
            "/app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:103",
            "/app/vendor/laravel/framework/src/Illuminate/Routing/Router.php:697",
            "/app/vendor/laravel/framework/src/Illuminate/Routing/Router.php:672",
            "/app/vendor/laravel/framework/src/Illuminate/Routing/Router.php:636",
            "/app/vendor/laravel/framework/src/Illuminate/Routing/Router.php:625",
            "/app/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php:167",
            "/app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:128",
            "/app/app/Http/Middleware/RequestId.php:29",
            "/app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167",
            "/app/vendor/fideloper/proxy/src/TrustProxies.php:57",
            "/app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167",
            "/app/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php:21",
            "/app/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php:31",
            "/app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167",
            "/app/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php:21",
            "/app/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php:40",
            "/app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167",
            "/app/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/ValidatePostSize.php:27",
            "/app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167",
            "/app/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php:86",
            "/app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167",
            "/app/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:103",
            "/app/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php:142",
            "/app/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php:111",
            "/app/public/index.php:54"
         ]
      },
      "userId" : 2
   },
   "datetime" : "2022-01-14T09:05:11.629185+00:00",
   "extra" : {},
   "level" : 400,
   "level_name" : "ERROR",
   "message" : "some message"
}
~~~