### PR TITLE
Fail early upon missing config in video adapters

### DIFF
--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Video/NDLAVideoAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Video/NDLAVideoAdapter.php
@@ -9,7 +9,9 @@ use App\Libraries\H5P\Interfaces\H5PExternalProviderInterface;
 use App\Libraries\H5P\Interfaces\H5PVideoInterface;
 use Exception;
 use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use Illuminate\Http\File;
+use InvalidArgumentException;
 
 class NDLAVideoAdapter implements H5PVideoInterface, H5PExternalProviderInterface
 {
@@ -21,12 +23,16 @@ class NDLAVideoAdapter implements H5PVideoInterface, H5PExternalProviderInterfac
 
     const VIDEO_URL = 'https://bc/%s';
 
-    private $client, $accountId;
-    /** @var CerpusStorageInterface */
-    private $storage;
+    private ClientInterface $client;
+    private string $accountId;
+    private CerpusStorageInterface $storage;
 
-    public function __construct(Client $client, $accountId)
+    public function __construct(Client $client, string $accountId)
     {
+        if ($accountId === '') {
+            throw new InvalidArgumentException('$accountId cannot be an empty string');
+        }
+
         $this->client = $client;
         $this->accountId = $accountId;
     }
@@ -119,9 +125,8 @@ class NDLAVideoAdapter implements H5PVideoInterface, H5PExternalProviderInterfac
             ->pluck('src')
             ->first();
 
-        $client = resolve(Client::class);
         $tempFile = tempnam(sys_get_temp_dir(), 'h5p-');
-        $client->get($videoSource, [
+        $this->client->get($videoSource, [
             'sink' => $tempFile
         ]);
 

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Video/NDLAVideoAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Video/NDLAVideoAdapter.php
@@ -125,8 +125,9 @@ class NDLAVideoAdapter implements H5PVideoInterface, H5PExternalProviderInterfac
             ->pluck('src')
             ->first();
 
+        $client = resolve(Client::class);
         $tempFile = tempnam(sys_get_temp_dir(), 'h5p-');
-        $this->client->get($videoSource, [
+        $client->get($videoSource, [
             'sink' => $tempFile
         ]);
 

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Video/StreampsAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Video/StreampsAdapter.php
@@ -4,8 +4,8 @@ namespace App\Libraries\H5P\Video;
 
 
 use App\Libraries\H5P\Interfaces\H5PVideoInterface;
-use GuzzleHttp\Client;
-use Illuminate\Support\Facades\Log;
+use GuzzleHttp\ClientInterface;
+use InvalidArgumentException;
 
 class StreampsAdapter implements H5PVideoInterface
 {
@@ -14,10 +14,21 @@ class StreampsAdapter implements H5PVideoInterface
     const VIDEO_DETAILS = '/video/%s/%s.json';
     const SEE_VIDEO = '/video/%s/%s';
     const MIME_TYPE = 'video/Streamps';
-    private $client, $appId, $appKey;
 
-    public function __construct(Client $client, $appId, $appKey)
+    private ClientInterface $client;
+    private string $appId;
+    private string $appKey;
+
+    public function __construct(ClientInterface $client, string $appId, string $appKey)
     {
+        if ($appId === '') {
+            throw new InvalidArgumentException('$appId cannot be an empty string');
+        }
+
+        if ($appKey === '') {
+            throw new InvalidArgumentException('$appKey cannot be an empty string');
+        }
+
         $this->client = $client;
         $this->appId = $appId;
         $this->appKey = $appKey;

--- a/sourcecode/apis/contentauthor/config/ndla-import.php
+++ b/sourcecode/apis/contentauthor/config/ndla-import.php
@@ -2,8 +2,8 @@
 return [
     'video' => [
         'url' => env("NDLA_H5P_VIDEO_URL", 'https://cms.api.brightcove.com'),
-        'key' => env("NDLA_H5P_VIDEO_ADAPTER_KEY", ''),
-        'secret' => env("NDLA_H5P_VIDEO_ADAPTER_SECRET",''),
+        'key' => env("NDLA_H5P_VIDEO_ADAPTER_KEY"),
+        'secret' => env("NDLA_H5P_VIDEO_ADAPTER_SECRET"),
         'accountId' => env("NDLA_H5P_VIDEO_ACCOUNT_ID",'4806596774001'),
         'authUrl' => env("NDLA_H5P_VIDEO_AUTH_URL", 'https://oauth.brightcove.com/v4/access_token'),
     ],


### PR DESCRIPTION
NDLAVideoAdapter and StreampsAdapter will create malformed URLs if passed null or empty string. This happens if `NDLA_H5P_VIDEO_ADAPTER_KEY` and related env variables are left unconfigured, which causes a cryptic cURL error to be raised.

To make the problem more obvious, the config values are defaulted to null, and the `string` type added to the config parameters in the adapters' constructors. In addition, the strings are checked for emptyness to ensure that a declared env variable left blank cannot result in a malformed URL.