### PR TITLE
Fix broken common API build

### DIFF
--- a/sourcecode/apis/common/Dockerfile
+++ b/sourcecode/apis/common/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-fpm-alpine AS base
+FROM php:8.0.14-fpm-alpine AS base
 
 WORKDIR /var/www/edlibcommon
 


### PR DESCRIPTION
Lock to PHP 8.0.14 to avoid a build failure with ext-sockets.