### PR TITLE
Wrong message format in pubsub

### DIFF
--- a/sourcecode/apis/contentauthor/app/Content.php
+++ b/sourcecode/apis/contentauthor/app/Content.php
@@ -451,7 +451,7 @@ abstract class Content extends Model implements RecommendableInterface
                     return $email != "";
                 })
                 ->sort()
-                ->all(),
+                ->values(),
             $this->getAuthorOverwrite()
         );
     }


### PR DESCRIPTION
We are receiving messages in the resourceapi with the wrong data format:
```json
{
	"externalSystemName": "contentAuthor",
	"externalSystemId": "88753afb-ac86-4c11-b843-a1e913f8109d",
	"title": "asdf",
	"ownerId": "1",
	"isListed": false,
	"isPublished": false,
	"language": "eng",
	"contentType": "article",
	"license": "BY",
	"maxScore": 0,
	"createdAt": "2022-02-24T14:10:54.000000Z",
	"updatedAt": "2022-02-24T14:10:54.000000Z",
	"emailCollaborators": {
		"2": "max+2@cerpus.com",
		"1": "max@cerpus.com"
	},
	"collaborators": [],
	"authorOverwrite": null
}
```
`emailCollaborators` should have been an array. This PR fixes the source of this problem