### PR TITLE
Issue #621: Remove shared resource edit capability if not allowed by license 

### DIFF
--- a/sourcecode/apis/resources/src/constants/licenses.js
+++ b/sourcecode/apis/resources/src/constants/licenses.js
@@ -1,0 +1,4 @@
+export default {
+    EDLIB: 'edll',
+    CC_ELEMENT_ND: '-nd',
+};


### PR DESCRIPTION
Shared resources can not be edited if license is EDLL or CC with ND element