### PR TITLE
Fix access to undefined roles property

### DIFF
--- a/sourcecode/apis/contentauthor/app/Http/Middleware/EdlibParseJwt.php
+++ b/sourcecode/apis/contentauthor/app/Http/Middleware/EdlibParseJwt.php
@@ -50,7 +50,7 @@ class EdlibParseJwt extends AuthJwtParser
                 Session::put('authId', $payload->sub);
                 Session::put('userId', $payload->sub);
                 $user = $payload->payload->user;
-                $roles = $payload->payload->roles;
+                $roles = $payload->payload->roles ?? [];
                 Session::put('name', $this->getBestName($user));
                 Session::put('email', $this->getEmail($user));
                 Session::put('verifiedEmails', $this->getVerifiedEmails($user));


### PR DESCRIPTION
Sometimes, after a session expiry(?), CA will attempt to access an undefined `roles` property in the JWT payload. This change fixes the problem.