### PR TITLE
Remove try-catch in H5PController::store that masks a fatal exception

### DIFF
--- a/sourcecode/apis/contentauthor/app/Exceptions/H5PValidationFailureException.php
+++ b/sourcecode/apis/contentauthor/app/Exceptions/H5PValidationFailureException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use Exception;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+
+class H5PValidationFailureException extends Exception implements HttpExceptionInterface
+{
+    public function getStatusCode()
+    {
+        return Response::HTTP_UNPROCESSABLE_ENTITY;
+    }
+
+    public function getHeaders()
+    {
+        return [];
+    }
+}

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/H5PController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/H5PController.php
@@ -563,11 +563,7 @@ class H5PController extends Controller
 
         event(new ContentCreating($request));
 
-        try {
-            $content = $this->persistContent($request, Session::get('authId'));
-        } catch (Exception $e) {
-            return response($e->getMessage(), Response::HTTP_UNPROCESSABLE_ENTITY);
-        }
+        $content = $this->persistContent($request, Session::get('authId'));
         $scoring = $this->getScoringForContent($content);
 
         Cache::forget($this->viewDataCacheName . $content->id);

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/H5PController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/H5PController.php
@@ -8,6 +8,7 @@ use App\Events\ContentUpdated;
 use App\Events\ContentUpdating;
 use App\Events\H5PWasSaved;
 use App\Events\ResourceSaved;
+use App\Exceptions\H5PValidationFailureException;
 use App\H5PCollaborator;
 use App\H5PContent;
 use App\H5PFile;
@@ -599,7 +600,7 @@ class H5PController extends Controller
         $this->initH5P();
 
         if ($this->h5p->validateStoreInput($request, app(H5PContent::class)) !== true) {
-            throw new Exception($this->h5p->getErrorMessage());
+            throw new H5PValidationFailureException($this->h5p->getErrorMessage());
         }
 
         $this->h5p->setUserId($authId);


### PR DESCRIPTION
`App\Exceptions\H5PValidationFailureException` is created to represent the exception that presumably was meant to be caught here. This will result in the expected 422 status code when it bubbles up.