### PR TITLE
Remove try/catch that silently breaks versioning

### DIFF
--- a/sourcecode/apis/contentauthor/app/Traits/Versionable.php
+++ b/sourcecode/apis/contentauthor/app/Traits/Versionable.php
@@ -5,6 +5,7 @@ namespace App\Traits;
 use Cerpus\VersionClient\VersionClient;
 use Cerpus\VersionClient\VersionData;
 use Illuminate\Support\Facades\Cache;
+use RuntimeException;
 
 trait Versionable
 {
@@ -23,6 +24,11 @@ trait Versionable
                     $versionData = $vc->getVersion($this->version_id);
                     if ($versionData instanceof VersionData) {
                         Cache::put($cacheKey, $versionData, now()->addSeconds($cacheTime));
+                    } else {
+                        throw new RuntimeException(sprintf(
+                            'Versioning failed (%s)',
+                            json_encode($vc->getError()),
+                        ), $vc->getErrorCode());
                     }
                 }
             }

--- a/sourcecode/apis/contentauthor/app/Traits/Versionable.php
+++ b/sourcecode/apis/contentauthor/app/Traits/Versionable.php
@@ -1,13 +1,10 @@
 <?php
 
-
 namespace App\Traits;
-
 
 use Cerpus\VersionClient\VersionClient;
 use Cerpus\VersionClient\VersionData;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Log;
 
 trait Versionable
 {
@@ -22,14 +19,10 @@ trait Versionable
         if (!$this->versionData) {
             if (!$versionData = Cache::get($cacheKey)) {
                 if ($this->version_id) {
-                    try {
-                        $vc = app(VersionClient::class);
-                        $versionData = $vc->getVersion($this->version_id);
-                        if ($versionData instanceof VersionData) {
-                            Cache::put($cacheKey, $versionData, now()->addSeconds($cacheTime));
-                        }
-                    } catch (\Throwable $t) {
-                        Log::error("Unable to fetch version data for id: {$this->id}", $this->toArray());
+                    $vc = app(VersionClient::class);
+                    $versionData = $vc->getVersion($this->version_id);
+                    if ($versionData instanceof VersionData) {
+                        Cache::put($cacheKey, $versionData, now()->addSeconds($cacheTime));
                     }
                 }
             }


### PR DESCRIPTION
Versioning is *required* for publishing to work, but in the event it fails, it would do so silently. This should fix the problem.