### PR TITLE
Deobscurify and test ext_question_set middleware

### DIFF
--- a/sourcecode/apis/contentauthor/app/Http/Controllers/QuestionSetController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/QuestionSetController.php
@@ -51,11 +51,7 @@ class QuestionSetController extends Controller
         $this->middleware('lti.question-set')->only(['ltiCreate']);
         $this->middleware('questionset-access', ['only' => ['ltiEdit']]);
         $this->middleware('draftaction', ['only' => ['edit', 'update', 'store', 'create']]);
-
-        // This middleware is used to test the pre filling of the question set with values from the LTI request. Uncomment if you need to test.
-        // Will only work when APP_ENV=local
-        // Enable in .env "FEATURE_EXT_QUESTION_SET_TO_REQUEST=true"
-        //$this->middleware('lti.qs-to-request')->only(['create']);
+        $this->middleware('lti.qs-to-request')->only(['create']);
     }
 
     private function getQuestionsetContentTypes()

--- a/sourcecode/apis/contentauthor/app/Providers/AppServiceProvider.php
+++ b/sourcecode/apis/contentauthor/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use App\Apis\AuthApiService;
 use App\Apis\ResourceApiService;
 use App\H5POption;
+use App\Http\Middleware\AddExtQuestionSetToRequestMiddleware;
 use App\Http\Middleware\SignedOauth10Request;
 use App\Http\Requests\LTIRequest;
 use App\Libraries\ContentAuthorStorage;
@@ -63,6 +64,16 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton(ContentAuthorStorage::class, function () {
             return new ContentAuthorStorage(config('app.cdnPrefix'));
         });
+
+        $this->app
+            ->when(AddExtQuestionSetToRequestMiddleware::class)
+            ->needs('$environment')
+            ->giveConfig('app.env');
+
+        $this->app
+            ->when(AddExtQuestionSetToRequestMiddleware::class)
+            ->needs('$enabled')
+            ->giveConfig('feature.add-ext-question-set-to-request');
 
         $this->app->bind(
             ResourceApiService::class,

--- a/sourcecode/apis/contentauthor/tests/Http/Middleware/AddExtQuestionSetToRequestMiddlewareTest.php
+++ b/sourcecode/apis/contentauthor/tests/Http/Middleware/AddExtQuestionSetToRequestMiddlewareTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Http\Middleware;
+
+use App\Http\Middleware\AddExtQuestionSetToRequestMiddleware;
+use App\SessionKeys;
+use Illuminate\Http\Request;
+use Illuminate\Session\ArraySessionHandler;
+use Illuminate\Session\Store;
+use PHPUnit\Framework\TestCase;
+
+final class AddExtQuestionSetToRequestMiddlewareTest extends TestCase
+{
+    private Request $request;
+
+    protected function setUp(): void
+    {
+        $this->request = new Request();
+        $this->request->setLaravelSession(
+            new Store('test', new ArraySessionHandler(123)),
+        );
+    }
+
+    public function testAddsData(): void
+    {
+        $middleware = new AddExtQuestionSetToRequestMiddleware('local', true);
+        $middleware->handle($this->request, fn() => null);
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode(AddExtQuestionSetToRequestMiddleware::QUESTION_SET_DATA),
+            $this->request->getSession()->get(SessionKeys::EXT_QUESTION_SET),
+        );
+    }
+
+    public function testCanBeDisabled(): void
+    {
+        $middleware = new AddExtQuestionSetToRequestMiddleware('local', false);
+        $middleware->handle($this->request, fn() => null);
+
+        $this->assertFalse(
+            $this->request->getSession()->has(SessionKeys::EXT_QUESTION_SET),
+        );
+    }
+
+    public function testNeverEnabledInProduction(): void
+    {
+        $middleware = new AddExtQuestionSetToRequestMiddleware('production', true);
+        $middleware->handle($this->request, fn() => null);
+
+        $this->assertFalse(
+            $this->request->getSession()->has(SessionKeys::EXT_QUESTION_SET),
+        );
+    }
+}


### PR DESCRIPTION
Makes it possible to actually see what `AddExtQuestionSetToRequestMiddleware` is doing at a first glance.