### PR TITLE
Clean up h5p library deletion

### DIFF
--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/AjaxRequest.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/AjaxRequest.php
@@ -7,7 +7,6 @@ use App\Libraries\ContentAuthorStorage;
 use App\Libraries\H5P\Interfaces\H5PImageAdapterInterface;
 use H5PCore;
 use H5peditor;
-use Illuminate\Support\Facades\Storage;
 use App\Exceptions\UnknownH5PPackageException;
 use App\Libraries\H5P\Helper\H5PPackageProvider;
 use App\Libraries\H5P\Interfaces\ContentTypeInterface;
@@ -27,7 +26,6 @@ class AjaxRequest extends \H5PEditorEndpoints
     const H5P_BEHAVIOR_SETTINGS = 'cache/%s.css';
     const H5P_IMAGE_MANIPULATION = 'imageManipulation';
 
-    const LIBRARY_DELETE = 'delete';
     const LIBRARY_REBUILD = 'rebuild';
 
     public function __construct(
@@ -129,16 +127,6 @@ class AjaxRequest extends \H5PEditorEndpoints
                 }
                 $library = $request->input('libraryId');
                 return $this->libraryRebuild(H5PLibrary::findOrFail($library));
-            case self::LIBRARY_DELETE:
-                /** @var \H5PEditorAjaxInterface $editorAjax */
-                $editorAjax = $this->editor->ajaxInterface;
-                $canDelete = $this->core->mayUpdateLibraries();
-                if (!$canDelete || !$editorAjax->validateEditorToken($request->bearerToken())) {
-                    throw new \Exception("Not logged in");
-                }
-                $this->returnType = "json";
-                $library = $request->input('libraryId');
-                return $this->libraryDelete($library);
             case self::H5P_IMAGE_MANIPULATION:
                 $imageId = $request->get('imageId');
 
@@ -293,19 +281,5 @@ class AjaxRequest extends \H5PEditorEndpoints
             }
         }
         return $affectedLibraries;
-    }
-
-    private function libraryDelete($libraryId)
-    {
-        $library = H5PLibrary::findOrFail($libraryId);
-        $this->core->deleteLibrary($library);
-
-        $library->refresh();
-        if ($library->exists) {
-            throw new \Exception("Library not deleted.");
-        }
-        return [
-            'success' => true,
-        ];
     }
 }

--- a/sourcecode/apis/contentauthor/resources/assets/js/admin.js
+++ b/sourcecode/apis/contentauthor/resources/assets/js/admin.js
@@ -1,9 +1,3 @@
-/**
- * First we will load all of this project's JavaScript dependencies which
- * includes Vue and other libraries. It is a great starting point when
- * building robust, powerful web applications using Vue and Laravel.
- */
-
 import './bootstrap';
 import $ from 'jquery';
 
@@ -33,13 +27,23 @@ $('.delete-btn')
         element.on('click', deleteLibrary);
     });
 
-function sendRequest(element, url, params, onDone, fail) {
+function sendRequest(element, optionsOrUrl, params, onDone, fail) {
+    let url, method;
+
+    if (typeof optionsOrUrl === 'string') {
+        url = optionsOrUrl;
+        method = 'POST';
+    } else {
+        url = optionsOrUrl.url;
+        method = optionsOrUrl.method || 'POST';
+    }
+
     const onFail = fail ? fail : function (response) {
         console.log(response.responseText);
         alert(response.responseJSON.message);
     };
     $.ajax(url, {
-        method: "post",
+        method,
         data: params,
         dataType: "json",
     })
@@ -91,16 +95,13 @@ function rebuildLibrary(event) {
 }
 
 function deleteLibrary(event) {
+    event.preventDefault();
+
     const element = $(event.currentTarget);
     const url = element.data('ajax-url')
-    const action = element.data('ajax-action');
-    const libraryId = element.data('libraryid');
 
     element.prop('disabled', true);
-    sendRequest(element, url, {
-        action,
-        libraryId,
-    }, function (response) {
+    sendRequest(element, { method: 'DELETE', url }, null, function () {
         alert('Library deleted');
         window.location.reload();
     });

--- a/sourcecode/apis/contentauthor/resources/views/admin/fragments/library-table.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/fragments/library-table.blade.php
@@ -22,7 +22,7 @@
                                 class="btn btn-info btn-xs"
                                 title="Upgrade"
                         >
-                            <span class="fa fa-refresh" />
+                            <span class="fa fa-refresh"></span>
                         </button>
                     </a>
                 @elseif ($library['hubUpgrade'] !== null)
@@ -34,7 +34,7 @@
                             data-ajax-action="{{H5PEditorEndpoints::LIBRARY_INSTALL}}"
                             title="Install version {{ $library['hubUpgrade'] }}"
                     >
-                        <span class="fa fa-cloud-download" />
+                        <span class="fa fa-cloud-download"></span>
                     </button>
                 @endif
                 @if(!empty($library['libraryId']))
@@ -46,19 +46,17 @@
                             data-ajax-action="{{\App\Libraries\H5P\AjaxRequest::LIBRARY_REBUILD}}"
                             title="Rebuild"
                     >
-                        <span class="fa fa-history" />
+                        <span class="fa fa-history"></span>
                     </button>
                 @endif
                 @if(empty($library['numLibraryDependencies']) && !empty($library['libraryId']))
                     <button
                             type="button"
                             class="btn btn-danger btn-xs delete-btn"
-                            data-libraryId="{{$library['libraryId'] ?? null}}"
-                            data-ajax-url="{{route('admin.ajax')}}"
-                            data-ajax-action="{{\App\Libraries\H5P\AjaxRequest::LIBRARY_DELETE}}"
+                            data-ajax-url="{{ route('admin.delete-library', [$library['libraryId']]) }}"
                             title="Delete"
                     >
-                         <span class="fa fa-trash" />
+                        <span class="fa fa-trash"></span>
                     </button>
                 @endif
             </td>

--- a/sourcecode/apis/contentauthor/routes/admin.php
+++ b/sourcecode/apis/contentauthor/routes/admin.php
@@ -35,6 +35,9 @@ Route::middleware('edlib.auth:superadmin')->namespace('Admin')->prefix('admin')-
             ->name('admin.check-for-updates');
         Route::post('/update-library', [LibraryUpgradeController::class, 'upgradeLibrary'])
             ->name('admin.upgrade-library');
+        Route::delete('libraries/{library}', [LibraryUpgradeController::class, 'deleteLibrary'])
+            ->name('admin.delete-library');
+
         Route::get('libraries/{libraryId}', [ContentUpgradeController::class, 'upgrade'])->name('admin.library');
 
         Route::post('content/upgrade', [AdminController::class, 'contentUpgrade'])->name('admin.content-upgrade');


### PR DESCRIPTION
* Changes `Framework::deleteLibrary` to adhere strictly to the interface specification.

* Moves the `H5PCore::deleteLibrary` call to its own controller, away from the horror show in `App\Libraries\H5P\AjaxRequest`.

* Adds a check preventing the library from being deleted if it has associated resources (may or may not be related to #638)