### PR TITLE
Clean up H5P integrations with external media services

### DIFF
--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Audio/NDLAAudioBrowser.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Audio/NDLAAudioBrowser.php
@@ -9,24 +9,19 @@ use App\Libraries\H5P\Interfaces\CerpusStorageInterface;
 use App\Libraries\H5P\Interfaces\H5PAudioInterface;
 use App\Libraries\H5P\Interfaces\H5PExternalProviderInterface;
 use Exception;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use Illuminate\Http\File;
 
 class NDLAAudioBrowser implements H5PAudioInterface, H5PExternalProviderInterface
 {
-
-    private $client;
-    /** @var CerpusStorageInterface */
-    private $storage;
-
     const FIND_AUDIOS_URL = '/audio-api/v1/audio';
     const GET_AUDIO_URL = '/audio-api/v1/audio/%s';
 
-    public function __construct(Client $client)
-    {
-        $this->client = $client;
+    public function __construct(
+        private readonly ClientInterface $client,
+        private readonly CerpusStorageInterface $storage
+    ) {
     }
-
 
     public function findAudio($filterParameters)
     {
@@ -114,8 +109,4 @@ class NDLAAudioBrowser implements H5PAudioInterface, H5PExternalProviderInterfac
     {
         return "audio";
     }
-
-    public function setStorage(CerpusStorageInterface $storage)
-    {
-        $this->storage = $storage;
-    }}
+}

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/File/NDLATextTrack.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/File/NDLATextTrack.php
@@ -8,18 +8,14 @@ use App\Libraries\DataObjects\ContentStorageSettings;
 use App\Libraries\H5P\Interfaces\CerpusStorageInterface;
 use App\Libraries\H5P\Interfaces\H5PExternalProviderInterface;
 use Exception;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 
 class NDLATextTrack implements H5PExternalProviderInterface
 {
-
-    private $client;
-    /** @var CerpusStorageInterface */
-    private $storage;
-
-    public function __construct(Client $client)
-    {
-        $this->client = $client;
+    public function __construct(
+        private readonly ClientInterface $client,
+        private readonly CerpusStorageInterface $storage,
+    ) {
     }
 
     public function isTargetType($mimeType, $pathToFile): bool
@@ -63,10 +59,5 @@ class NDLATextTrack implements H5PExternalProviderInterface
     public function getType(): string
     {
         return 'file';
-    }
-
-    public function setStorage(CerpusStorageInterface $storage)
-    {
-        $this->storage = $storage;
     }
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PExport.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PExport.php
@@ -95,7 +95,6 @@ class H5PExport
         });
 
         if( !is_null($externalProvider)){
-            $externalProvider->setStorage($this->export->h5pC->fs);
             $fileDetails = $externalProvider->storeContent($values, $content);
             $values = array_merge($values, $fileDetails);
         }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Image/NDLAContentBrowser.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Image/NDLAContentBrowser.php
@@ -2,22 +2,16 @@
 
 namespace App\Libraries\H5P\Image;
 
-
 use App\Libraries\DataObjects\ContentStorageSettings;
 use App\Libraries\H5P\Interfaces\CerpusStorageInterface;
 use App\Libraries\H5P\Interfaces\H5PExternalProviderInterface;
 use App\Libraries\H5P\Interfaces\H5PImageAdapterInterface;
 use Exception;
-use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
 use Illuminate\Http\File;
 
 class NDLAContentBrowser implements H5PImageAdapterInterface, H5PExternalProviderInterface
 {
-
-    private $client;
-    /** @var CerpusStorageInterface */
-    private $storage;
-
     private $mappings = [
         'startX' => 'cropStartX',
         'startY' => 'cropStartY',
@@ -32,14 +26,10 @@ class NDLAContentBrowser implements H5PImageAdapterInterface, H5PExternalProvide
     const GET_IMAGE_ID = '/image-api/raw/id/%s';
     const GET_IMAGE_NAME = '/image-api/raw/%s';
 
-    public function __construct(Client $client)
-    {
-        $this->client = $client;
-    }
-
-    public function setStorage(CerpusStorageInterface $storage)
-    {
-        $this->storage = $storage;
+    public function __construct(
+        private readonly ClientInterface $client,
+        private readonly CerpusStorageInterface $storage,
+    ) {
     }
 
     public function findImages($filterParameters)

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Interfaces/H5PExternalProviderInterface.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Interfaces/H5PExternalProviderInterface.php
@@ -11,6 +11,4 @@ interface H5PExternalProviderInterface
     public function storeContent($source, $content);
 
     public function getType():string;
-
-    public function setStorage(CerpusStorageInterface $storage);
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Video/NDLAVideoAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Video/NDLAVideoAdapter.php
@@ -24,18 +24,14 @@ class NDLAVideoAdapter implements H5PVideoInterface, H5PExternalProviderInterfac
 
     const VIDEO_URL = 'https://bc/%s';
 
-    private ClientInterface $client;
-    private string $accountId;
-    private CerpusStorageInterface $storage;
-
-    public function __construct(Client $client, string $accountId)
-    {
-        if ($accountId === '') {
+    public function __construct(
+        private readonly ClientInterface $client,
+        private readonly CerpusStorageInterface $storage,
+        private readonly string $accountId,
+    ) {
+        if ($this->accountId === '') {
             throw new InvalidArgumentException('$accountId cannot be an empty string');
         }
-
-        $this->client = $client;
-        $this->accountId = $accountId;
     }
 
     public function upload($file, $fileHash)
@@ -188,10 +184,5 @@ class NDLAVideoAdapter implements H5PVideoInterface, H5PExternalProviderInterfac
     public function getType(): string
     {
         return "video";
-    }
-
-    public function setStorage(CerpusStorageInterface $storage)
-    {
-        $this->storage = $storage;
     }
 }

--- a/sourcecode/apis/contentauthor/tests/Functional/Provider/H5PServiceProviderTest.php
+++ b/sourcecode/apis/contentauthor/tests/Functional/Provider/H5PServiceProviderTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Functional\Provider;
+
+use App\Libraries\H5P\Audio\NDLAAudioBrowser;
+use App\Libraries\H5P\Image\NDLAContentBrowser;
+use App\Libraries\H5P\Interfaces\H5PAdapterInterface;
+use App\Libraries\H5P\Interfaces\H5PAudioInterface;
+use App\Libraries\H5P\Interfaces\H5PImageAdapterInterface;
+use App\Libraries\H5P\Interfaces\H5PVideoInterface;
+use App\Libraries\H5P\Video\NDLAVideoAdapter;
+use App\Libraries\H5P\Video\StreampsAdapter;
+use Generator;
+use RuntimeException;
+use Tests\TestCase;
+
+final class H5PServiceProviderTest extends TestCase
+{
+    /**
+     * @dataProvider ndlaConcreteServiceAndInterfaceProvider
+     */
+    public function testNdlaServices(string $concrete, string $interface): void
+    {
+        $this->app->bind(H5PAdapterInterface::class, function () {
+            $ndlaAdapter = $this->createMock(H5PAdapterInterface::class);
+            $ndlaAdapter->method('getAdapterName')->willReturn('ndla');
+
+            return $ndlaAdapter;
+        });
+
+        $this->assertInstanceOf($concrete, $this->app->make($interface));
+    }
+
+    public function ndlaConcreteServiceAndInterfaceProvider(): Generator
+    {
+        yield [NDLAAudioBrowser::class, H5PAudioInterface::class];
+        yield [NDLAContentBrowser::class, H5PImageAdapterInterface::class];
+        yield [NDLAVideoAdapter::class, H5PVideoInterface::class];
+    }
+
+    /**
+     * @dataProvider cerpusConcreteServiceAndInterfaceProvider
+     */
+    public function testCerpusServices(string $concrete, string $interface): void
+    {
+        $this->app->bind(H5PAdapterInterface::class, function () {
+            $ndlaAdapter = $this->createMock(H5PAdapterInterface::class);
+            $ndlaAdapter->method('getAdapterName')->willReturn('cerpus');
+
+            return $ndlaAdapter;
+        });
+
+        $this->assertInstanceOf($concrete, $this->app->make($interface));
+    }
+
+    public function cerpusConcreteServiceAndInterfaceProvider(): Generator
+    {
+        yield [StreampsAdapter::class, H5PVideoInterface::class];
+    }
+
+    /**
+     * @dataProvider cerpusUnmappedServiceProvider
+     */
+    public function testUnmappedCerpusServices(string $interface): void
+    {
+        $this->app->bind(H5PAdapterInterface::class, function () {
+            $ndlaAdapter = $this->createMock(H5PAdapterInterface::class);
+            $ndlaAdapter->method('getAdapterName')->willReturn('cerpus');
+
+            return $ndlaAdapter;
+        });
+
+        $this->expectException(RuntimeException::class);
+
+        $this->app->make($interface);
+    }
+
+    public function cerpusUnmappedServiceProvider(): Generator
+    {
+        yield [H5PAudioInterface::class];
+        yield [H5PImageAdapterInterface::class];
+    }
+}


### PR DESCRIPTION
Since we're going to document how integration with external image providers in Edlib works (#986), it'd be nice to clean up and test the code related to it.

### To do

* [x] Simplify the service provider
* [x] Remove `H5PExternalProviderInterface::setStorage` that imposed a prerequisite to calling other methods.
* [ ] Document/type related interfaces properly
* [ ] Look into the API responses from the media services, and write proper data classes to represent them
* [ ] Find out if anything is needed on the frontend to provide the integration
* [ ] Fix failing tests