### PR TITLE
Handle directory creation when uploading h5ps

### DIFF
--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Storage/H5PCerpusStorage.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Storage/H5PCerpusStorage.php
@@ -508,12 +508,14 @@ class H5PCerpusStorage implements H5PFileStorage, H5PDownloadInterface, CerpusSt
         return $this->filesystem->exists($path) ? "/$path" : null;
     }
 
-    /**
-     * @inheritDoc
-     */
-    public function saveFileFromZip($path, $file, $stream)
+    public function saveFileFromZip($path, $file, $stream): bool
     {
         $filePath = Str::after($path, $this->uploadDisk->path("")) . "/" . $file;
+
+        if (str_ends_with($filePath, '/')) {
+            return $this->uploadDisk->createDir($filePath);
+        }
+
         $upload = $this->uploadDisk->putStream($filePath, $stream);
 
         if (preg_match('/^content\/(?:images|videos|audios|files)/', $file, $matches)) {


### PR DESCRIPTION
Fixes an issue where uploading certain .h5p files would result in an error such as:

~~~
Impossible to create the root directory "/tmp/h5p/temp/h5p-627103cd869c6/blob-1.0".
~~~

That `saveFileFromZip` is called for directories is probably a bug in the H5P core library.