### PR TITLE
clean up h5p download

### DIFF
--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Interfaces/H5PDownloadInterface.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Interfaces/H5PDownloadInterface.php
@@ -1,10 +1,13 @@
 <?php
 
+declare(strict_types=1);
 
 namespace App\Libraries\H5P\Interfaces;
 
-
 interface H5PDownloadInterface
 {
-    public function downloadContent($filename, $title);
+    /**
+     * @return resource
+     */
+    public function downloadContent(string $filename);
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Storage/H5PCerpusStorage.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Storage/H5PCerpusStorage.php
@@ -23,6 +23,7 @@ use Illuminate\Support\Facades\Log;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\StorageAttributes;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
 class H5PCerpusStorage implements H5PFileStorage, H5PDownloadInterface, CerpusStorageInterface
 {
@@ -540,18 +541,16 @@ class H5PCerpusStorage implements H5PFileStorage, H5PDownloadInterface, CerpusSt
         return $upload;
     }
 
-    /**
-     * @param $filename
-     * @param $title
-     * @return \Symfony\Component\HttpFoundation\StreamedResponse
-     * @throws Exception
-     */
-    public function downloadContent($filename, $title)
+    public function downloadContent(string $filename)
     {
-        return response()->streamDownload(function () use ($filename) {
-            $path = sprintf(ContentStorageSettings::EXPORT_PATH, $filename);
-            echo $this->filesystem->response($path)->sendContent();
-        }, $filename);
+        $path = sprintf(ContentStorageSettings::EXPORT_PATH, $filename);
+        $stream = $this->filesystem->readStream($path);
+
+        if ($stream === null) {
+            throw new RuntimeException('Could not stream '.$filename);
+        }
+
+        return $stream;
     }
 
     public function getDisplayPath(bool $fullUrl = true)


### PR DESCRIPTION
1. Uses `H5PDownloadInterface` to its advantage, instead of relying on the implementation of `H5PFileStorage` having `downloadContent()` (which is not part of that interface).

2. Moves the HTTP-related bit of `downloadContent` to the controller.

3. Cleans up resolution of dependencies in the controller.

In the future, we may want this method to actually do the exporting of H5Ps being downloaded. Currently this is required to be done before calling `downloadContent`, a prerequisite that isn't obvious.