### PR TITLE
Refactor AjaxRequest

### DIFF
--- a/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/AdminController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/AdminController.php
@@ -93,23 +93,12 @@ class AdminController extends Controller
         return view('admin.maxscore-failed-overview', compact('resources'));
     }
 
-    /**
-     * @param Request $request
-     * @param H5PCore $core
-     * @param H5peditor $editor
-     * @return array|JsonResponse|void
-     * @throws Exception
-     */
-    public function ajaxLoading(Request $request, H5PCore $core, H5peditor $editor, ContentAuthorStorage $contentAuthorStorage)
+    public function ajaxLoading(Request $request, AjaxRequest $ajaxRequest): object|array|string|null
     {
-        $ajaxRequest = new AjaxRequest($core, $editor, $contentAuthorStorage);
         $returnValue = $ajaxRequest->handleAjaxRequest($request);
-        switch ($ajaxRequest->getReturnType()) {
-            case "json":
-                return response()->json($returnValue);
-                break;
-            default:
-                return $returnValue;
-        }
+        return match ($ajaxRequest->getReturnType()) {
+            "json" => response()->json($returnValue),
+            default => $returnValue,
+        };
     }
 }

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/H5PController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/H5PController.php
@@ -705,21 +705,13 @@ class H5PController extends Controller
         //
     }
 
-    /**
-     * @return array|JsonResponse|void
-     * @throws Exception
-     */
-    public function ajaxLoading(Request $request, H5PCore $core, H5peditor $editor, ContentAuthorStorage $contentAuthorStorage)
+    public function ajaxLoading(Request $request, AjaxRequest $ajaxRequest): object|array|string|null
     {
-        $ajaxRequest = new AjaxRequest($core, $editor, $contentAuthorStorage);
         $returnValue = $ajaxRequest->handleAjaxRequest($request);
-        switch ($ajaxRequest->getReturnType()) {
-            case "json":
-                return response()->json($returnValue);
-                break;
-            default:
-                return $returnValue;
-        }
+        return match ($ajaxRequest->getReturnType()) {
+            "json" => response()->json($returnValue),
+            default => $returnValue,
+        };
     }
 
     /**

--- a/sourcecode/apis/contentauthor/routes/web.php
+++ b/sourcecode/apis/contentauthor/routes/web.php
@@ -124,7 +124,7 @@ Route::group(['middleware' => ['core.auth']], function () {
 Route::post('api/progress', 'Progress@storeProgress')->name("setProgress");
 Route::get('api/progress', 'Progress@getProgress')->name("getProgress");
 
-Route::match(['GET', 'POST'], '/ajax', 'H5PController@ajaxLoading')->middleware("adaptermode"); // TODO: Refactor into its own controller
+Route::match(['GET', 'POST'], '/ajax', [H5PController::class, 'ajaxLoading'])->middleware("adaptermode"); // TODO: Refactor into its own controller
 
 Route::post('v1/sessiontest/{id}', 'API\SessionTestController@setValue');
 Route::get('v1/sessiontest/{id}', 'API\SessionTestController@getValue');


### PR DESCRIPTION
1. Removes unused actions
    * `content_upgrade_progress` (broken due to private method missing)
    * `setProgress` (handled by progress controller)
    * `contents_user_data` (handled by progress controller)
2. Split each action into its own method
3. Removes usage of `filter_var(INPUT_GET, ...)` in favour of using Laravel's requests
4. Throws HTTP exception objects
5. General cleanup until PHPStorm showed ✅