### PR TITLE
Fix incorrect test

### DIFF
--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PCopyright.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PCopyright.php
@@ -9,6 +9,8 @@ use App\Libraries\H5P\Dataobjects\H5PCopyrightAuthorDataObject;
 use App\Libraries\H5P\Dataobjects\H5PCopyrightDataObject;
 use App\Libraries\H5P\Interfaces\CerpusStorageInterface;
 use Illuminate\Support\Collection;
+use JsonException;
+use const JSON_THROW_ON_ERROR;
 
 class H5PCopyright
 {
@@ -30,7 +32,7 @@ class H5PCopyright
     /**
      * @param H5PContent $content
      * @return array
-     * @throws \Exception
+     * @throws JsonException
      */
     public function getCopyrights(H5PContent $content)
     {
@@ -42,10 +44,7 @@ class H5PCopyright
             $contentCopy['library'] = $content->library->getLibraryH5PFriendly();
             $content->filtered = $this->h5pCore->filterParameters($contentCopy);
         }
-        $filtered = json_decode($content->filtered, true);
-        if( json_last_error() !== JSON_ERROR_NONE) {
-            throw new \Exception(json_last_error_msg());
-        }
+        $filtered = json_decode($content->filtered, true, flags: JSON_THROW_ON_ERROR);
         $this->traverseFiltered(collect($filtered));
 
         return [

--- a/sourcecode/apis/contentauthor/database/factories/H5PContentFactory.php
+++ b/sourcecode/apis/contentauthor/database/factories/H5PContentFactory.php
@@ -9,7 +9,6 @@ class H5PContentFactory extends Factory
     public function definition(): array
     {
         return [
-            'id' => $this->faker->numberBetween(),
             'created_at' => $this->faker->unixTime,
             'updated_at' => $this->faker->unixTime,
             'user_id' => $this->faker->uuid,

--- a/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PCopyrightTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PCopyrightTest.php
@@ -8,34 +8,25 @@ use App\H5PLibrary;
 use App\Libraries\H5P\Dataobjects\H5PCopyrightAuthorDataObject;
 use App\Libraries\H5P\Dataobjects\H5PCopyrightDataObject;
 use App\Libraries\H5P\H5PCopyright;
-use Exception;
 use H5PCore;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Storage;
+use JsonException;
 use Tests\TestCase;
 
 class H5PCopyrightTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected function setUp(): void
+    public function testThrowsJsonExceptionOnInvalidData()
     {
-        parent::setUp();
+        $h5pContent = H5PContent::factory()
+            ->has(H5PLibrary::factory(), 'library')
+            ->create(['filtered' => 'invalid json']);
+        $h5pCopyright = new H5PCopyright(app(H5PCore::class));
 
-        Storage::fake('h5p-uploads');
-    }
+        $this->expectException(JsonException::class);
 
-    /**
-     * @test
-     */
-    public function invalidData()
-    {
-        $this->expectException(Exception::class);
-
-        $h5pContent = H5PContent::factory()->create([
-            'filtered' => null,
-        ]);
-        (new H5PCopyright())->getCopyrights($h5pContent);
+        $h5pCopyright->getCopyrights($h5pContent);
     }
 
     /**


### PR DESCRIPTION
This test was causing an SQL error due to a not-null constraint on the `filtered` column. However, it appeared to succeed due to the expectation matching the base `Exception` class, and `expectException` being called too early in the test.

`H5PCopyright::getCopyrights()` is changed to throw JsonException, and the test is changed to match against it.