### PR TITLE
Implement phpstan

### DIFF
--- a/.github/workflows/api-contentauthor.yaml
+++ b/.github/workflows/api-contentauthor.yaml
@@ -31,7 +31,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        working-directory: ./
         with:
           fetch-depth: 0
 

--- a/.github/workflows/api-contentauthor.yaml
+++ b/.github/workflows/api-contentauthor.yaml
@@ -22,6 +22,35 @@ env:
   shouldPublishImage: ${{ inputs.versionToRelease && '1' || '0' }}
 
 jobs:
+  phpstan:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          coverage: pcov
+
+      - name: Get Composer cache dir
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-${{ hashFiles('**/composer.json') }}
+
+      - name: Install dependencies
+        run: composer install --no-progress --prefer-dist --optimize-autoloader
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse --memory-limit=512M
+
   test_and_release:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/api-contentauthor.yaml
+++ b/.github/workflows/api-contentauthor.yaml
@@ -38,6 +38,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.1
+          extensions: memcached, oauth, sockets, zip
           coverage: pcov
 
       - name: Get Composer cache dir

--- a/.github/workflows/api-contentauthor.yaml
+++ b/.github/workflows/api-contentauthor.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: 8.1
           coverage: pcov
 
       - name: Get Composer cache dir

--- a/.github/workflows/api-contentauthor.yaml
+++ b/.github/workflows/api-contentauthor.yaml
@@ -24,8 +24,14 @@ env:
 jobs:
   phpstan:
     runs-on: ubuntu-20.04
+
+    defaults:
+      run:
+        working-directory: sourcecode/apis/contentauthor
+
     steps:
       - uses: actions/checkout@v3
+        working-directory: ./
         with:
           fetch-depth: 0
 

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/Column.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/Column.php
@@ -5,6 +5,7 @@ namespace App\Libraries\H5P\Packages;
 
 use App\Exceptions\UnknownH5PPackageException;
 use App\Libraries\H5P\Helper\H5PPackageProvider;
+use LogicException;
 
 class Column extends H5PBase
 {
@@ -27,6 +28,7 @@ class Column extends H5PBase
     public function getElements(): array
     {
         // TODO: Implement getElements() method.
+        throw new LogicException('This method is not implemented');
     }
 
     public function getAnswers($index = null)

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/Dialogcards.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/Dialogcards.php
@@ -9,6 +9,8 @@
 namespace App\Libraries\H5P\Packages;
 
 
+use LogicException;
+
 class Dialogcards extends H5PBase
 {
     public static $machineName = "H5P.Dialogcards";
@@ -29,6 +31,7 @@ class Dialogcards extends H5PBase
     public function getElements(): array
     {
         // TODO: Implement getElements() method.
+        throw new LogicException('This method is not implemented');
     }
 
     public function getAnswers($index = null)

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/DragQuestion.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/DragQuestion.php
@@ -3,6 +3,8 @@
 namespace App\Libraries\H5P\Packages;
 
 
+use LogicException;
+
 class DragQuestion extends H5PBase
 {
 
@@ -23,6 +25,7 @@ class DragQuestion extends H5PBase
     public function getElements(): array
     {
         // TODO: Implement getElements() method.
+        throw new LogicException('This method is not implemented');
     }
 
     public function getAnswers($index = null)

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/DragText.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/DragText.php
@@ -3,6 +3,8 @@
 namespace App\Libraries\H5P\Packages;
 
 
+use LogicException;
+
 class DragText extends H5PBase
 {
 
@@ -23,6 +25,7 @@ class DragText extends H5PBase
     public function getElements(): array
     {
         // TODO: Implement getElements() method.
+        throw new LogicException('This method is not implemented');
     }
 
     public function getAnswers($index = null)

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/ImagePair.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/ImagePair.php
@@ -2,6 +2,8 @@
 
 namespace App\Libraries\H5P\Packages;
 
+use LogicException;
+
 class ImagePair extends H5PBase
 {
     public static $machineName = "H5P.ImagePair";
@@ -33,6 +35,7 @@ class ImagePair extends H5PBase
     public function getElements(): array
     {
         // TODO: Implement getElements() method.
+        throw new LogicException('This method is not implemented');
     }
 
     public function getAnswers($index = null)

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/MemoryGame.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/MemoryGame.php
@@ -2,6 +2,8 @@
 
 namespace App\Libraries\H5P\Packages;
 
+use LogicException;
+
 class MemoryGame extends H5PBase
 {
     public static $machineName = "H5P.MemoryGame";
@@ -13,6 +15,7 @@ class MemoryGame extends H5PBase
     public function getElements(): array
     {
         // TODO: Implement getElements() method.
+        throw new LogicException('This method is not implemented');
     }
 
     public function getAnswers($index = null)

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/MultiChoice.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/MultiChoice.php
@@ -5,6 +5,7 @@ namespace App\Libraries\H5P\Packages;
 
 use App\H5PLibrary;
 use App\Libraries\H5P\Helper\H5PPackageProvider;
+use LogicException;
 
 class MultiChoice extends H5PBase
 {
@@ -17,6 +18,7 @@ class MultiChoice extends H5PBase
     public function getElements(): array
     {
         // TODO: Implement getElements() method.
+        throw new LogicException('This method is not implemented');
     }
 
     public function getAnswers($index = null)

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/QuestionSet.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/QuestionSet.php
@@ -2,6 +2,8 @@
 
 namespace App\Libraries\H5P\Packages;
 
+use LogicException;
+
 class QuestionSet extends H5PBase
 {
 
@@ -14,6 +16,7 @@ class QuestionSet extends H5PBase
     public function getElements(): array
     {
         // TODO: Implement getElements() method.
+        throw new LogicException('This method is not implemented');
     }
 
     public function getAnswers($index = null)

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/Video.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/Video.php
@@ -4,6 +4,8 @@
 namespace App\Libraries\H5P\Packages;
 
 
+use LogicException;
+
 class Video extends H5PBase
 {
 
@@ -24,6 +26,7 @@ class Video extends H5PBase
     public function getElements(): array
     {
         // TODO: Implement getElements() method.
+        throw new LogicException('This method is not implemented');
     }
 
     public function getAnswers($index = null)

--- a/sourcecode/apis/contentauthor/app/Traits/ReturnToCore.php
+++ b/sourcecode/apis/contentauthor/app/Traits/ReturnToCore.php
@@ -13,24 +13,7 @@ use Illuminate\Support\Facades\Session;
 
 trait ReturnToCore
 {
-
-    /**
-     * Redirect to core.
-     *
-     * @param  int $id , string $title, string $type, int $score
-     * @return Return
-     */
-    public function redirectToCore($id, $title, $type = '', $score = 0, $redirectToken)
-    {
-        $returnUrl = $this->getRedirectToCoreUrl($id, $title, $type, $score, $redirectToken);
-        if (!is_null($returnUrl)) {
-            header('Location: ' . $returnUrl);
-            die();
-        }
-        return;
-    }
-
-    public function getRedirectToCoreUrl($id, $title, $type = '', $score = 0, $redirectToken)
+    public function getRedirectToCoreUrl($id, $title, $type, $score, $redirectToken)
     {
         $returnUrl = $this->getCoreBaseUrl($redirectToken);
 

--- a/sourcecode/apis/contentauthor/composer.json
+++ b/sourcecode/apis/contentauthor/composer.json
@@ -52,6 +52,8 @@
         "barryvdh/laravel-ide-helper": "^2.10",
         "fakerphp/faker": "^1.16",
         "mockery/mockery": "^1.0",
+        "nunomaduro/larastan": "^2.0",
+        "phpstan/phpstan": "^1.7",
         "phpunit/phpunit": "^9.5",
         "symfony/css-selector": "^4.0"
     },

--- a/sourcecode/apis/contentauthor/composer.lock
+++ b/sourcecode/apis/contentauthor/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "326ff0383e15851863b864f92d09cc77",
+    "content-hash": "127babeca770b2d0c3a24b4eb85e656b",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -8839,6 +8839,104 @@
             "time": "2022-03-03T13:19:32+00:00"
         },
         {
+            "name": "nunomaduro/larastan",
+            "version": "v2.1.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nunomaduro/larastan.git",
+                "reference": "8514c5ec475b440702f08cf804e73cd55a05f622"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nunomaduro/larastan/zipball/8514c5ec475b440702f08cf804e73cd55a05f622",
+                "reference": "8514c5ec475b440702f08cf804e73cd55a05f622",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^3.0",
+                "ext-json": "*",
+                "illuminate/console": "^9",
+                "illuminate/container": "^9",
+                "illuminate/contracts": "^9",
+                "illuminate/database": "^9",
+                "illuminate/http": "^9",
+                "illuminate/pipeline": "^9",
+                "illuminate/support": "^9",
+                "mockery/mockery": "^1.4.4",
+                "php": "^8.0.2",
+                "phpmyadmin/sql-parser": "^5.5",
+                "phpstan/phpstan": "^1.7.12"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^4.13.2",
+                "orchestra/testbench": "^7.0.0",
+                "phpunit/phpunit": "^9.5.11"
+            },
+            "suggest": {
+                "orchestra/testbench": "Using Larastan for analysing a package needs Testbench"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "NunoMaduro\\Larastan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan wrapper for Laravel",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "larastan",
+                "laravel",
+                "package",
+                "php",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/nunomaduro/larastan/issues",
+                "source": "https://github.com/nunomaduro/larastan/tree/v2.1.11"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/canvural",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2022-06-13T21:45:42+00:00"
+        },
+        {
             "name": "phar-io/manifest",
             "version": "2.0.3",
             "source": {
@@ -9110,6 +9208,79 @@
             "time": "2022-03-15T21:29:03+00:00"
         },
         {
+            "name": "phpmyadmin/sql-parser",
+            "version": "5.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpmyadmin/sql-parser.git",
+                "reference": "8ab99cd0007d880f49f5aa1807033dbfa21b1cb5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpmyadmin/sql-parser/zipball/8ab99cd0007d880f49f5aa1807033dbfa21b1cb5",
+                "reference": "8ab99cd0007d880f49f5aa1807033dbfa21b1cb5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.3"
+            },
+            "conflict": {
+                "phpmyadmin/motranslator": "<3.0"
+            },
+            "require-dev": {
+                "phpmyadmin/coding-standard": "^3.0",
+                "phpmyadmin/motranslator": "^4.0 || ^5.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/php-code-coverage": "*",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.11",
+                "zumba/json-serializer": "^3.0"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance",
+                "phpmyadmin/motranslator": "Translate messages to your favorite locale"
+            },
+            "bin": [
+                "bin/highlight-query",
+                "bin/lint-query",
+                "bin/tokenize-query"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpMyAdmin\\SqlParser\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The phpMyAdmin Team",
+                    "email": "developers@phpmyadmin.net",
+                    "homepage": "https://www.phpmyadmin.net/team/"
+                }
+            ],
+            "description": "A validating SQL lexer and parser with a focus on MySQL dialect.",
+            "homepage": "https://github.com/phpmyadmin/sql-parser",
+            "keywords": [
+                "analysis",
+                "lexer",
+                "parser",
+                "sql"
+            ],
+            "support": {
+                "issues": "https://github.com/phpmyadmin/sql-parser/issues",
+                "source": "https://github.com/phpmyadmin/sql-parser"
+            },
+            "time": "2021-12-09T04:31:52+00:00"
+        },
+        {
             "name": "phpspec/prophecy",
             "version": "v1.15.0",
             "source": {
@@ -9175,6 +9346,65 @@
                 "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
             },
             "time": "2021-12-08T12:19:24+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.7.14",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "e6f145f196a59c7ca91ea926c87ef3d936c4305f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e6f145f196a59c7ca91ea926c87ef3d936c4305f",
+                "reference": "e6f145f196a59c7ca91ea926c87ef3d936c4305f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "source": "https://github.com/phpstan/phpstan/tree/1.7.14"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-06-14T13:09:35+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/sourcecode/apis/contentauthor/database/factories/FileFactory.php
+++ b/sourcecode/apis/contentauthor/database/factories/FileFactory.php
@@ -12,7 +12,7 @@ class FileFactory extends Factory
         return [
             'article_id' => $this->faker->uuid,
             'name' => $this->faker->uuid.'.jpg',
-            'original_name' => $this->faker->slug(3).'.'.$this->faker->fileExtension,
+            'original_name' => $this->faker->slug(3).'.'.$this->faker->fileExtension(),
             'remember_token' => Str::random(10),
         ];
     }

--- a/sourcecode/apis/contentauthor/phpstan-baseline.neon
+++ b/sourcecode/apis/contentauthor/phpstan-baseline.neon
@@ -1,0 +1,2792 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Method GuzzleHttp\\\\ClientInterface\\:\\:request\\(\\) invoked with 1 parameter, 2\\-3 required\\.$#"
+			count: 1
+			path: app/Article.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(Carbon deleted_at\\)\\: Unexpected token \"deleted_at\", expected variable at offset 240$#"
+			count: 1
+			path: app/Article.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(Collection\\<Collaborator\\> collaborators\\)\\: Unexpected token \"collaborators\", expected variable at offset 349$#"
+			count: 1
+			path: app/Article.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string content\\)\\: Unexpected token \"content\", expected variable at offset 212$#"
+			count: 1
+			path: app/Article.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string id\\)\\: Unexpected token \"id\", expected variable at offset 60$#"
+			count: 1
+			path: app/Article.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string ndla_url\\)\\: Unexpected token \"ndla_url\", expected variable at offset 299$#"
+			count: 1
+			path: app/Article.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string note_id\\)\\: Unexpected token \"note_id\", expected variable at offset 271$#"
+			count: 1
+			path: app/Article.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string original_id\\)\\: Unexpected token \"original_id\", expected variable at offset 151$#"
+			count: 1
+			path: app/Article.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string owner_id\\)\\: Unexpected token \"owner_id\", expected variable at offset 183$#"
+			count: 1
+			path: app/Article.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string parent_id\\)\\: Unexpected token \"parent_id\", expected variable at offset 83$#"
+			count: 1
+			path: app/Article.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string perent_version_id\\)\\: Unexpected token \"perent_version_id\", expected variable at offset 113$#"
+			count: 1
+			path: app/Article.php
+
+		-
+			message: "#^Property App\\\\Auth\\\\Guards\\\\EdlibGuard\\:\\:\\$user \\(Illuminate\\\\Auth\\\\GenericUser\\|null\\) does not accept Illuminate\\\\Contracts\\\\Auth\\\\Authenticatable\\|null\\.$#"
+			count: 1
+			path: app/Auth/Guards/EdlibGuard.php
+
+		-
+			message: "#^Called 'pluck' on Laravel collection, but could have been retrieved as a query\\.$#"
+			count: 1
+			path: app/Console/Commands/RemoveOldContentLocks.php
+
+		-
+			message: "#^Parameter \\#1 \\$externalUrl of method Cerpus\\\\VersionClient\\\\VersionData\\:\\:setExternalUrl\\(\\) expects Psr\\\\Http\\\\Message\\\\UriInterface, string given\\.$#"
+			count: 2
+			path: app/Console/Commands/VersionAllUnversionedContent.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Content\\:\\:\\$created_at\\.$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Content\\:\\:\\$id\\.$#"
+			count: 22
+			path: app/Content.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Content\\:\\:\\$is_draft\\.$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Content\\:\\:\\$is_private\\.$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Content\\:\\:\\$is_published\\.$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Content\\:\\:\\$license\\.$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Content\\:\\:\\$ndlaMapper\\.$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Content\\:\\:\\$title\\.$#"
+			count: 2
+			path: app/Content.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Content\\:\\:\\$updated_at\\.$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Content\\:\\:\\$version_id\\.$#"
+			count: 3
+			path: app/Content.php
+
+		-
+			message: "#^Access to an undefined property App\\\\ContentLanguageLink\\:\\:\\$link_content_id\\.$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^Access to an undefined property App\\\\ContentLanguageLink\\:\\:\\$main_content_id\\.$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Libraries\\\\DataObjects\\\\ResourceUserDataObject\\:\\:\\$lastName\\.$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$email\\.$#"
+			count: 3
+			path: app/Content.php
+
+		-
+			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(Carbon created_at\\)\\: Unexpected token \"created_at\", expected variable at offset 87$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(Carbon updated_at\\)\\: Unexpected token \"updated_at\", expected variable at offset 118$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(bool is_draft\\)\\: Unexpected token \"is_draft\", expected variable at offset 423$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(bool is_published\\)\\: Unexpected token \"is_published\", expected variable at offset 297$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(int bulk_calculated\\)\\: Unexpected token \"bulk_calculated\", expected variable at offset 263$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(int is_private\\)\\: Unexpected token \"is_private\", expected variable at offset 172$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(int\\|null max_score\\)\\: Unexpected token \"max_score\", expected variable at offset 236$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string license\\)\\: Unexpected token \"license\", expected variable at offset 330$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string node_id\\)\\: Unexpected token \"node_id\", expected variable at offset 358$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string title\\)\\: Unexpected token \"title\", expected variable at offset 149$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string version_id\\)\\: Unexpected token \"version_id\", expected variable at offset 203$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string\\|int id\\)\\: Unexpected token \"id\", expected variable at offset 64$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^Right side of && is always true\\.$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between false and true will always evaluate to false\\.$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^Ternary operator condition is always true\\.$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: app/Content.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(int content_id\\)\\: Unexpected token \"content_id\", expected variable at offset 21$#"
+			count: 1
+			path: app/ContentLanguage.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string language_code\\)\\: Unexpected token \"language_code\", expected variable at offset 52$#"
+			count: 1
+			path: app/ContentLanguage.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(Carbon updated_at\\)\\: Unexpected token \"updated_at\", expected variable at offset 24$#"
+			count: 1
+			path: app/ContentLock.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Events\\\\ArticleWasCopied\\:\\:\\$article\\.$#"
+			count: 1
+			path: app/Events/ArticleWasCopied.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Events\\\\ArticleWasCopied\\:\\:\\$reason\\.$#"
+			count: 1
+			path: app/Events/ArticleWasCopied.php
+
+		-
+			message: "#^Method App\\\\Exceptions\\\\Handler\\:\\:render\\(\\) should return Illuminate\\\\Http\\\\Response but returns Symfony\\\\Component\\\\HttpFoundation\\\\Response\\.$#"
+			count: 1
+			path: app/Exceptions/Handler.php
+
+		-
+			message: "#^Method App\\\\Exceptions\\\\Handler\\:\\:report\\(\\) with return type void returns void but should not return anything\\.$#"
+			count: 1
+			path: app/Exceptions/Handler.php
+
+		-
+			message: "#^PHPDoc type array of property App\\\\Exceptions\\\\Handler\\:\\:\\$dontReport is not covariant with PHPDoc type array\\<int, class\\-string\\<Throwable\\>\\> of overridden property Illuminate\\\\Foundation\\\\Exceptions\\\\Handler\\:\\:\\$dontReport\\.$#"
+			count: 1
+			path: app/Exceptions/Handler.php
+
+		-
+			message: "#^Result of method Illuminate\\\\Foundation\\\\Exceptions\\\\Handler\\:\\:report\\(\\) \\(void\\) is used\\.$#"
+			count: 1
+			path: app/Exceptions/Handler.php
+
+		-
+			message: "#^Access to an undefined property App\\\\File\\:\\:\\$article\\.$#"
+			count: 1
+			path: app/File.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$email\\.$#"
+			count: 1
+			path: app/Game.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(Gametype gameType\\)\\: Unexpected token \"gameType\", expected variable at offset 236$#"
+			count: 1
+			path: app/Game.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(int deleted_at\\)\\: Unexpected token \"deleted_at\", expected variable at offset 200$#"
+			count: 1
+			path: app/Game.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(object game_settings\\)\\: Unexpected token \"game_settings\", expected variable at offset 169$#"
+			count: 1
+			path: app/Game.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string gametype\\)\\: Unexpected token \"gametype\", expected variable at offset 80$#"
+			count: 1
+			path: app/Game.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string id\\)\\: Unexpected token \"id\", expected variable at offset 57$#"
+			count: 1
+			path: app/Game.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string language_code\\)\\: Unexpected token \"language_code\", expected variable at offset 109$#"
+			count: 1
+			path: app/Game.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string owner\\)\\: Unexpected token \"owner\", expected variable at offset 143$#"
+			count: 1
+			path: app/Game.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string id\\)\\: Unexpected token \"id\", expected variable at offset 24$#"
+			count: 1
+			path: app/Gametype.php
+
+		-
+			message: "#^Method App\\\\H5PCollaborator\\:\\:setUpdatedAt\\(\\) should return \\$this\\(App\\\\H5PCollaborator\\) but return statement is missing\\.$#"
+			count: 1
+			path: app/H5PCollaborator.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(int h5p_id\\)\\: Unexpected token \"h5p_id\", expected variable at offset 21$#"
+			count: 1
+			path: app/H5PCollaborator.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string email\\)\\: Unexpected token \"email\", expected variable at offset 48$#"
+			count: 1
+			path: app/H5PCollaborator.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PContent\\:\\:\\$contentLibraries\\.$#"
+			count: 1
+			path: app/H5PContent.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with App\\\\H5PContentsMetadata will always evaluate to false\\.$#"
+			count: 1
+			path: app/H5PContent.php
+
+		-
+			message: "#^Called 'Model\\:\\:make\\(\\)' which performs unnecessary work, use 'new Model\\(\\)'\\.$#"
+			count: 2
+			path: app/H5PContent.php
+
+		-
+			message: "#^Method App\\\\H5PContent\\:\\:getId\\(\\) should return string but returns int\\.$#"
+			count: 1
+			path: app/H5PContent.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(Collection\\<Collaborator\\> collaborators\\)\\: Unexpected token \"collaborators\", expected variable at offset 482$#"
+			count: 1
+			path: app/H5PContent.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(H5PLibrary library\\)\\: Unexpected token \"library\", expected variable at offset 520$#"
+			count: 1
+			path: app/H5PContent.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(int disable\\)\\: Unexpected token \"disable\", expected variable at offset 232$#"
+			count: 1
+			path: app/H5PContent.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(int library_id\\)\\: Unexpected token \"library_id\", expected variable at offset 88$#"
+			count: 1
+			path: app/H5PContent.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string author\\)\\: Unexpected token \"author\", expected variable at offset 293$#"
+			count: 1
+			path: app/H5PContent.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string content_create_mode\\)\\: Unexpected token \"content_create_mode\", expected variable at offset 381$#"
+			count: 1
+			path: app/H5PContent.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string content_type\\)\\: Unexpected token \"content_type\", expected variable at offset 260$#"
+			count: 1
+			path: app/H5PContent.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string description\\)\\: Unexpected token \"description\", expected variable at offset 349$#"
+			count: 1
+			path: app/H5PContent.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string embed_type\\)\\: Unexpected token \"embed_type\", expected variable at offset 204$#"
+			count: 1
+			path: app/H5PContent.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string filtered\\)\\: Unexpected token \"filtered\", expected variable at offset 150$#"
+			count: 1
+			path: app/H5PContent.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string keywords\\)\\: Unexpected token \"keywords\", expected variable at offset 320$#"
+			count: 1
+			path: app/H5PContent.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string parameters\\)\\: Unexpected token \"parameters\", expected variable at offset 119$#"
+			count: 1
+			path: app/H5PContent.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string slug\\)\\: Unexpected token \"slug\", expected variable at offset 179$#"
+			count: 1
+			path: app/H5PContent.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string user_id\\)\\: Unexpected token \"user_id\", expected variable at offset 63$#"
+			count: 1
+			path: app/H5PContent.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, int\\<min, \\-1\\>\\|int\\<1, max\\> given\\.$#"
+			count: 1
+			path: app/H5PContent.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$context$#"
+			count: 1
+			path: app/H5PContentsUserData.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string description\\)\\: Unexpected token \"description\", expected variable at offset 78$#"
+			count: 1
+			path: app/H5PLibrariesHubCache.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string license\\)\\: Unexpected token \"license\", expected variable at offset 110$#"
+			count: 1
+			path: app/H5PLibrariesHubCache.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string screenshots\\)\\: Unexpected token \"screenshots\", expected variable at offset 138$#"
+			count: 1
+			path: app/H5PLibrariesHubCache.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string summary\\)\\: Unexpected token \"summary\", expected variable at offset 50$#"
+			count: 1
+			path: app/H5PLibrariesHubCache.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string title\\)\\: Unexpected token \"title\", expected variable at offset 24$#"
+			count: 1
+			path: app/H5PLibrariesHubCache.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5pLti\\:\\:\\$ltiRequest\\.$#"
+			count: 1
+			path: app/H5pLti.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$created_at\\.$#"
+			count: 1
+			path: app/Http/Controllers/API/ArticleInfoController.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$email\\.$#"
+			count: 1
+			path: app/Http/Controllers/API/ArticleInfoController.php
+
+		-
+			message: "#^Relation 'collaborators' is not found in App\\\\Article model\\.$#"
+			count: 1
+			path: app/Http/Controllers/API/ArticleInfoController.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$email\\.$#"
+			count: 1
+			path: app/Http/Controllers/API/ContentInfoController.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$created_at\\.$#"
+			count: 1
+			path: app/Http/Controllers/API/H5PInfoController.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$email\\.$#"
+			count: 1
+			path: app/Http/Controllers/API/H5PInfoController.php
+
+		-
+			message: "#^Relation 'library' is not found in App\\\\H5PContent model\\.$#"
+			count: 1
+			path: app/Http/Controllers/API/H5PInfoController.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PContent\\:\\:\\$library\\.$#"
+			count: 1
+			path: app/Http/Controllers/API/H5PTypeApi.php
+
+		-
+			message: "#^Relation 'library' is not found in App\\\\H5PContent model\\.$#"
+			count: 1
+			path: app/Http/Controllers/API/H5PTypeApi.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$created_at\\.$#"
+			count: 1
+			path: app/Http/Controllers/API/LinkInfoController.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$email\\.$#"
+			count: 1
+			path: app/Http/Controllers/API/LinkInfoController.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with League\\\\Fractal\\\\Manager will always evaluate to false\\.$#"
+			count: 1
+			path: app/Http/Controllers/API/LinkInfoController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\API\\\\LinkInfoController\\:\\:buildResourceResponse\\(\\) should return Illuminate\\\\Http\\\\Response but returns Illuminate\\\\Http\\\\JsonResponse\\.$#"
+			count: 1
+			path: app/Http/Controllers/API/LinkInfoController.php
+
+		-
+			message: "#^Relation 'collaborators' is not found in App\\\\Link model\\.$#"
+			count: 1
+			path: app/Http/Controllers/API/LinkInfoController.php
+
+		-
+			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: app/Http/Controllers/API/LockStatusController.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with League\\\\Fractal\\\\Manager will always evaluate to false\\.$#"
+			count: 1
+			path: app/Http/Controllers/API/QuestionsetController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\API\\\\QuestionsetController\\:\\:buildResourceResponse\\(\\) should return Illuminate\\\\Http\\\\Response but returns Illuminate\\\\Http\\\\JsonResponse\\.$#"
+			count: 1
+			path: app/Http/Controllers/API/QuestionsetController.php
+
+		-
+			message: "#^Parameter \\#1 \\$searchParams of static method Cerpus\\\\QuestionBankClient\\\\Adapters\\\\QuestionBankAdapter\\:\\:searchAnswers\\(\\) expects null, Cerpus\\\\QuestionBankClient\\\\DataObjects\\\\SearchDataObject given\\.$#"
+			count: 2
+			path: app/Http/Controllers/API/QuestionsetController.php
+
+		-
+			message: "#^Parameter \\#1 \\$searchParams of static method Cerpus\\\\QuestionBankClient\\\\Adapters\\\\QuestionBankAdapter\\:\\:searchQuestions\\(\\) expects Illuminate\\\\Support\\\\Collection\\|null, Cerpus\\\\QuestionBankClient\\\\DataObjects\\\\SearchDataObject given\\.$#"
+			count: 2
+			path: app/Http/Controllers/API/QuestionsetController.php
+
+		-
+			message: "#^Static method Cerpus\\\\QuestionBankClient\\\\DataObjects\\\\SearchDataObject\\:\\:create\\(\\) invoked with 2 parameters, 0\\-1 required\\.$#"
+			count: 6
+			path: app/Http/Controllers/API/QuestionsetController.php
+
+		-
+			message: "#^Called 'first' on Laravel collection, but could have been retrieved as a query\\.$#"
+			count: 1
+			path: app/Http/Controllers/API/UnlockController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\API\\\\UnlockController\\:\\:index\\(\\) should return Illuminate\\\\Http\\\\Response but returns Illuminate\\\\Http\\\\JsonResponse\\.$#"
+			count: 1
+			path: app/Http/Controllers/API/UnlockController.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Article\\:\\:\\$ownerName\\.$#"
+			count: 1
+			path: app/Http/Controllers/Admin/AdminArticleController.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PContent\\:\\:\\$ownerName\\.$#"
+			count: 1
+			path: app/Http/Controllers/Admin/AdminController.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PLibrary\\:\\:\\$contents_count\\.$#"
+			count: 1
+			path: app/Http/Controllers/Admin/AdminController.php
+
+		-
+			message: "#^Called 'count' on Laravel collection, but could have been retrieved as a query\\.$#"
+			count: 1
+			path: app/Http/Controllers/Admin/AdminController.php
+
+		-
+			message: "#^Relation 'library' is not found in App\\\\H5PContent model\\.$#"
+			count: 2
+			path: app/Http/Controllers/Admin/AdminController.php
+
+		-
+			message: "#^Static call to instance method App\\\\H5PContent\\:\\:noMaxScoreScope\\(\\)\\.$#"
+			count: 1
+			path: app/Http/Controllers/Admin/AdminController.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Contracts\\\\Auth\\\\Authenticatable\\:\\:\\$id\\.$#"
+			count: 1
+			path: app/Http/Controllers/Admin/AdminUserController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\Admin\\\\AdminUserController\\:\\:destroy\\(\\) should return Illuminate\\\\Http\\\\Response but returns Illuminate\\\\Http\\\\RedirectResponse\\.$#"
+			count: 1
+			path: app/Http/Controllers/Admin/AdminUserController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\Admin\\\\AdminUserController\\:\\:index\\(\\) should return Illuminate\\\\Http\\\\Response but returns Illuminate\\\\View\\\\View\\.$#"
+			count: 1
+			path: app/Http/Controllers/Admin/AdminUserController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\Admin\\\\AdminUserController\\:\\:store\\(\\) should return Illuminate\\\\Http\\\\Response but returns Illuminate\\\\Http\\\\RedirectResponse\\.$#"
+			count: 1
+			path: app/Http/Controllers/Admin/AdminUserController.php
+
+		-
+			message: "#^Relation 'capability' is not found in App\\\\H5PLibrary model\\.$#"
+			count: 1
+			path: app/Http/Controllers/Admin/Capability.php
+
+		-
+			message: "#^Variable \\$upgrades might not be defined\\.$#"
+			count: 1
+			path: app/Http/Controllers/Admin/ContentUpgradeController.php
+
+		-
+			message: "#^Parameter \\#1 \\$zipArchiveProvider of class League\\\\Flysystem\\\\ZipArchive\\\\ZipArchiveAdapter constructor expects League\\\\Flysystem\\\\ZipArchive\\\\ZipArchiveProvider, string given\\.$#"
+			count: 1
+			path: app/Http/Controllers/Admin/GamesAdminController.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\Interfaces\\\\H5PAdapterInterface\\:\\:emptyArticleImportLog\\(\\) invoked with 0 parameters, 1 required\\.$#"
+			count: 1
+			path: app/Http/Controllers/Admin/ImportExportSettingsController.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\Interfaces\\\\H5PAdapterInterface\\:\\:resetNdlaIdTracking\\(\\) invoked with 0 parameters, 1 required\\.$#"
+			count: 1
+			path: app/Http/Controllers/Admin/ImportExportSettingsController.php
+
+		-
+			message: "#^Anonymous function has an unused use \\$hubCacheLibraries\\.$#"
+			count: 1
+			path: app/Http/Controllers/Admin/LibraryUpgradeController.php
+
+		-
+			message: "#^Parameter \\#1 \\$library of method H5PFrameworkInterface\\:\\:isPatchedLibrary\\(\\) expects object, array\\<string, mixed\\> given\\.$#"
+			count: 1
+			path: app/Http/Controllers/Admin/LibraryUpgradeController.php
+
+		-
+			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: app/Http/Controllers/Admin/LocksController.php
+
+		-
+			message: "#^If condition is always false\\.$#"
+			count: 1
+			path: app/Http/Controllers/Admin/VersioningController.php
+
+		-
+			message: "#^Function collect invoked with 2 parameters, 0\\-1 required\\.$#"
+			count: 1
+			path: app/Http/Controllers/ArticleController.php
+
+		-
+			message: "#^Cannot access property \\$resource on array\\|bool\\|float\\|int\\|object\\|string\\.$#"
+			count: 1
+			path: app/Http/Controllers/ArticleCopyrightController.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Http\\\\Controllers\\\\EmbedController\\:\\:doShow\\(\\)\\.$#"
+			count: 1
+			path: app/Http/Controllers/EmbedController.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Http\\\\Controllers\\\\EmbedController\\:\\:edit\\(\\)\\.$#"
+			count: 1
+			path: app/Http/Controllers/EmbedController.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Http\\\\Controllers\\\\GameController\\:\\:create\\(\\)\\.$#"
+			count: 1
+			path: app/Http/Controllers/GameController.php
+
+		-
+			message: "#^Left side of && is always true\\.$#"
+			count: 1
+			path: app/Http/Controllers/GameController.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PContent\\:\\:\\$library\\.$#"
+			count: 1
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PContent\\|Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, App\\\\H5PContent\\>\\:\\:\\$library\\.$#"
+			count: 1
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Call to method getCss\\(\\) on an unknown class App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Call to method setAlterParametersSettings\\(\\) on an unknown class App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Call to method setContext\\(\\) on an unknown class App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Call to method setEmail\\(\\) on an unknown class App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 3
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Call to method setName\\(\\) on an unknown class App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 2
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Call to method setPreview\\(\\) on an unknown class App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Call to method setRedirectToken\\(\\) on an unknown class App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 2
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Call to method setUserName\\(\\) on an unknown class App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 3
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\H5PController\\:\\:create\\(\\) invoked with 1 parameter, 2\\-3 required\\.$#"
+			count: 1
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\H5PController\\:\\:getContentLicense\\(\\) should return Illuminate\\\\Http\\\\Response but returns int\\|string\\|false\\.$#"
+			count: 1
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\H5PController\\:\\:get_content_privacy\\(\\) is unused\\.$#"
+			count: 1
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Parameter \\#1 \\$config of method App\\\\Libraries\\\\H5P\\\\h5p\\:\\:createView\\(\\) expects App\\\\Libraries\\\\H5P\\\\Interfaces\\\\ConfigInterface, App\\\\Libraries\\\\H5P\\\\Config given\\.$#"
+			count: 1
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Parameter \\#1 \\$config of method App\\\\Libraries\\\\H5P\\\\h5p\\:\\:getContents\\(\\) expects App\\\\Libraries\\\\H5P\\\\Interfaces\\\\ConfigInterface, App\\\\Libraries\\\\H5P\\\\Config given\\.$#"
+			count: 1
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Parameter \\#1 \\$content of method H5PExport\\:\\:deleteExport\\(\\) expects array, object given\\.$#"
+			count: 1
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, object given\\.$#"
+			count: 1
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Parameter \\#2 \\$content of method App\\\\Libraries\\\\H5P\\\\h5p\\:\\:storeContent\\(\\) expects array\\|null, object given\\.$#"
+			count: 1
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Parameter \\#2 \\$current of method H5PCore\\:\\:getStorableDisplayOptions\\(\\) expects int, null given\\.$#"
+			count: 1
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Relation 'library' is not found in App\\\\H5PContent model\\.$#"
+			count: 1
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Variable \\$emails in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Variable \\$library in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: app/Http/Controllers/H5PController.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: app/Http/Controllers/HealthController.php
+
+		-
+			message: "#^Parameter \\#1 \\$view of function view expects view\\-string\\|null, string given\\.$#"
+			count: 1
+			path: app/Http/Controllers/LinkController.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with League\\\\Fractal\\\\Manager will always evaluate to false\\.$#"
+			count: 1
+			path: app/Http/Controllers/QuestionSetController.php
+
+		-
+			message: "#^Called 'isNotEmpty' on Laravel collection, but could have been retrieved as a query\\.$#"
+			count: 1
+			path: app/Http/Controllers/QuestionSetController.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Controllers\\\\QuestionSetController\\:\\:buildResourceResponse\\(\\) should return Illuminate\\\\Http\\\\Response but returns Illuminate\\\\Http\\\\JsonResponse\\.$#"
+			count: 1
+			path: app/Http/Controllers/QuestionSetController.php
+
+		-
+			message: "#^PHPDoc type array of property App\\\\Http\\\\Kernel\\:\\:\\$middlewarePriority is not covariant with PHPDoc type array\\<string\\> of overridden property Illuminate\\\\Foundation\\\\Http\\\\Kernel\\:\\:\\$middlewarePriority\\.$#"
+			count: 1
+			path: app/Http/Kernel.php
+
+		-
+			message: "#^Variable \\$names might not be defined\\.$#"
+			count: 1
+			path: app/Http/Libraries/AuthJwtParser.php
+
+		-
+			message: "#^Class App\\\\Http\\\\Libraries\\\\ContentTypes\\\\ContentType does not have a constructor and must be instantiated without any parameters\\.$#"
+			count: 1
+			path: app/Http/Libraries/ContentTypes/ArticleContentType.php
+
+		-
+			message: "#^Return type \\(array\\) of method App\\\\Http\\\\Libraries\\\\ContentTypes\\\\ArticleContentType\\:\\:getContentTypes\\(\\) should be compatible with return type \\(App\\\\Http\\\\Libraries\\\\ContentTypes\\\\ContentType\\) of method App\\\\Http\\\\Libraries\\\\ContentTypes\\\\ContentTypeInterface\\:\\:getContentTypes\\(\\)$#"
+			count: 1
+			path: app/Http/Libraries/ContentTypes/ArticleContentType.php
+
+		-
+			message: "#^Property App\\\\Http\\\\Libraries\\\\ContentTypes\\\\ContentType\\:\\:\\$guarded is never read, only written\\.$#"
+			count: 1
+			path: app/Http/Libraries/ContentTypes/ContentType.php
+
+		-
+			message: "#^Call to function is_string\\(\\) with array will always evaluate to false\\.$#"
+			count: 1
+			path: app/Http/Libraries/ContentTypes/H5PContentType.php
+
+		-
+			message: "#^Class App\\\\Http\\\\Libraries\\\\ContentTypes\\\\ContentType does not have a constructor and must be instantiated without any parameters\\.$#"
+			count: 2
+			path: app/Http/Libraries/ContentTypes/H5PContentType.php
+
+		-
+			message: "#^Method App\\\\Http\\\\Libraries\\\\ContentTypes\\\\H5PContentType\\:\\:getContentTypes\\(\\) should return App\\\\Http\\\\Libraries\\\\ContentTypes\\\\ContentType but returns array\\<int, App\\\\Http\\\\Libraries\\\\ContentTypes\\\\ContentType\\>\\.$#"
+			count: 1
+			path: app/Http/Libraries/ContentTypes/H5PContentType.php
+
+		-
+			message: "#^Relation 'capability' is not found in App\\\\H5PLibrary model\\.$#"
+			count: 1
+			path: app/Http/Libraries/ContentTypes/InteractivityContentType.php
+
+		-
+			message: "#^PHPDoc tag @return with type array is incompatible with native type App\\\\Http\\\\Libraries\\\\ContentTypes\\\\ContentType\\.$#"
+			count: 1
+			path: app/Http/Libraries/ContentTypes/LinkContentType.php
+
+		-
+			message: "#^Anonymous function has an unused use \\$newH5P\\.$#"
+			count: 1
+			path: app/Http/Libraries/H5PFileVersioner.php
+
+		-
+			message: "#^Property App\\\\Http\\\\Middleware\\\\CheckOwnership\\:\\:\\$content is unused\\.$#"
+			count: 1
+			path: app/Http/Middleware/CheckOwnership.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Http\\\\Middleware\\\\GameAccess\\:\\:\\$request\\.$#"
+			count: 1
+			path: app/Http/Middleware/GameAccess.php
+
+		-
+			message: "#^Call to static method debug\\(\\) on an unknown class App\\\\Http\\\\Middleware\\\\Log\\.$#"
+			count: 1
+			path: app/Http/Middleware/GameAccess.php
+
+		-
+			message: "#^Call to static method error\\(\\) on an unknown class App\\\\Http\\\\Middleware\\\\Log\\.$#"
+			count: 1
+			path: app/Http/Middleware/GameAccess.php
+
+		-
+			message: "#^Variable \\$registerSettings might not be defined\\.$#"
+			count: 1
+			path: app/Http/Middleware/LtiBehaviorSettings.php
+
+		-
+			message: "#^Variable \\$validator might not be defined\\.$#"
+			count: 2
+			path: app/Http/Middleware/LtiBehaviorSettings.php
+
+		-
+			message: "#^Static method Illuminate\\\\Session\\\\Store\\:\\:put\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
+			count: 1
+			path: app/Http/Middleware/LtiRequestAuth.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Http\\\\Middleware\\\\QuestionSetAccess\\:\\:\\$request\\.$#"
+			count: 1
+			path: app/Http/Middleware/QuestionSetAccess.php
+
+		-
+			message: "#^Call to static method debug\\(\\) on an unknown class App\\\\Http\\\\Middleware\\\\Log\\.$#"
+			count: 1
+			path: app/Http/Middleware/QuestionSetAccess.php
+
+		-
+			message: "#^Call to static method error\\(\\) on an unknown class App\\\\Http\\\\Middleware\\\\Log\\.$#"
+			count: 1
+			path: app/Http/Middleware/QuestionSetAccess.php
+
+		-
+			message: "#^Method App\\\\Content\\:\\:isExternalCollaborator\\(\\) invoked with 0 parameters, 1 required\\.$#"
+			count: 1
+			path: app/Http/Middleware/QuestionSetAccess.php
+
+		-
+			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: app/Http/Middleware/SignedOauth10Request.php
+
+		-
+			message: "#^Using nullsafe method call on non\\-nullable type Symfony\\\\Component\\\\HttpFoundation\\\\InputBag\\. Use \\-\\> instead\\.$#"
+			count: 1
+			path: app/Http/Middleware/SignedOauth10Request.php
+
+		-
+			message: "#^PHPDoc type array of property App\\\\Http\\\\Middleware\\\\TrustProxies\\:\\:\\$headers is not covariant with PHPDoc type int of overridden property Illuminate\\\\Http\\\\Middleware\\\\TrustProxies\\:\\:\\$headers\\.$#"
+			count: 1
+			path: app/Http/Middleware/TrustProxies.php
+
+		-
+			message: "#^Property App\\\\Http\\\\Middleware\\\\TrustProxies\\:\\:\\$headers \\(array\\) does not accept default value of type int\\.$#"
+			count: 1
+			path: app/Http/Middleware/TrustProxies.php
+
+		-
+			message: "#^Call to an undefined static method object\\|string\\:\\:isUserPublishEnabled\\(\\)\\.$#"
+			count: 1
+			path: app/Http/Requests/ArticleRequest.php
+
+		-
+			message: "#^Called 'Model\\:\\:make\\(\\)' which performs unnecessary work, use 'new Model\\(\\)'\\.$#"
+			count: 1
+			path: app/Http/Requests/H5PStorageRequest.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with App\\\\H5PFile will always evaluate to false\\.$#"
+			count: 1
+			path: app/Jobs/H5PFileUpload.php
+
+		-
+			message: "#^Property App\\\\Jobs\\\\H5PFileUpload\\:\\:\\$filesystem \\(Illuminate\\\\Filesystem\\\\Filesystem\\) does not accept Illuminate\\\\Filesystem\\\\FilesystemAdapter\\.$#"
+			count: 1
+			path: app/Jobs/H5PFileUpload.php
+
+		-
+			message: "#^Property App\\\\Jobs\\\\H5PFilesUpload\\:\\:\\$filesystem \\(Illuminate\\\\Filesystem\\\\Filesystem\\) does not accept Illuminate\\\\Filesystem\\\\FilesystemAdapter\\.$#"
+			count: 2
+			path: app/Jobs/H5PFilesUpload.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with App\\\\H5PContent will always evaluate to false\\.$#"
+			count: 1
+			path: app/Jobs/PingVideoApi.php
+
+		-
+			message: "#^Variable \\$h5pcontent in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: app/Jobs/PingVideoApi.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$path\\.$#"
+			count: 1
+			path: app/Jobs/ReplaceVideoRefId.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\DataObjects\\\\Attribution\\:\\:getOrigin\\(\\) should return null but returns string\\.$#"
+			count: 1
+			path: app/Libraries/DataObjects/Attribution.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with League\\\\Fractal\\\\Manager will always evaluate to false\\.$#"
+			count: 1
+			path: app/Libraries/Games/GameBase.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\Games\\\\GameBase\\:\\:buildResourceResponse\\(\\) should return Illuminate\\\\Http\\\\Response but returns Illuminate\\\\Http\\\\JsonResponse\\.$#"
+			count: 1
+			path: app/Libraries/Games/GameBase.php
+
+		-
+			message: "#^Called 'Model\\:\\:make\\(\\)' which performs unnecessary work, use 'new Model\\(\\)'\\.$#"
+			count: 1
+			path: app/Libraries/Games/GameHandler.php
+
+		-
+			message: "#^Access to an undefined property App\\\\QuestionSet\\:\\:\\$questions\\.$#"
+			count: 2
+			path: app/Libraries/Games/Millionaire/Millionaire.php
+
+		-
+			message: "#^Access to an undefined property App\\\\QuestionSetQuestion\\:\\:\\$answers\\.$#"
+			count: 2
+			path: app/Libraries/Games/Millionaire/Millionaire.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Gametype\\>\\:\\:\\$id\\.$#"
+			count: 1
+			path: app/Libraries/Games/Millionaire/Millionaire.php
+
+		-
+			message: "#^Called 'Model\\:\\:make\\(\\)' which performs unnecessary work, use 'new Model\\(\\)'\\.$#"
+			count: 3
+			path: app/Libraries/Games/Millionaire/Millionaire.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$tags\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Adapters/CerpusH5PAdapter.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$tags\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Adapters/NDLAH5PAdapter.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Libraries\\\\H5P\\\\Interfaces\\\\H5PImageAdapterInterface\\:\\:isTargetType\\(\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Adapters/NDLAH5PAdapter.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PLibrary\\:\\:\\$majorVersion\\.$#"
+			count: 1
+			path: app/Libraries/H5P/AdminConfig.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PLibrary\\:\\:\\$minorVersion\\.$#"
+			count: 1
+			path: app/Libraries/H5P/AdminConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\AdminConfig\\:\\:setContext\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Libraries/H5P/AdminConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\AdminConfig\\:\\:setContext\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\AdminConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/AdminConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\AdminConfig\\:\\:setDisplayH5PHub\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 2
+			path: app/Libraries/H5P/AdminConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\AdminConfig\\:\\:setDisplayH5PHub\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\AdminConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/AdminConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\AdminConfig\\:\\:setEmail\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Libraries/H5P/AdminConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\AdminConfig\\:\\:setEmail\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\AdminConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/AdminConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\AdminConfig\\:\\:setName\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Libraries/H5P/AdminConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\AdminConfig\\:\\:setName\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\AdminConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/AdminConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\AdminConfig\\:\\:setPreview\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Libraries/H5P/AdminConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\AdminConfig\\:\\:setPreview\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\AdminConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/AdminConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\AdminConfig\\:\\:setUserId\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Libraries/H5P/AdminConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\AdminConfig\\:\\:setUserId\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\AdminConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/AdminConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\AdminConfig\\:\\:setUserName\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Libraries/H5P/AdminConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\AdminConfig\\:\\:setUserName\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\AdminConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/AdminConfig.php
+
+		-
+			message: "#^Property App\\\\Libraries\\\\H5P\\\\AdminConfig\\:\\:\\$core is never read, only written\\.$#"
+			count: 1
+			path: app/Libraries/H5P/AdminConfig.php
+
+		-
+			message: "#^Property App\\\\Libraries\\\\H5P\\\\AdminConfig\\:\\:\\$id is never read, only written\\.$#"
+			count: 1
+			path: app/Libraries/H5P/AdminConfig.php
+
+		-
+			message: "#^Call to function is_string\\(\\) with array will always evaluate to false\\.$#"
+			count: 2
+			path: app/Libraries/H5P/AjaxRequest.php
+
+		-
+			message: "#^Cannot access property \\$css on array\\.$#"
+			count: 2
+			path: app/Libraries/H5P/AjaxRequest.php
+
+		-
+			message: "#^Parameter \\#6 \\$fileDir of method H5peditor\\:\\:getLibraryData\\(\\) expects string, null given\\.$#"
+			count: 1
+			path: app/Libraries/H5P/AjaxRequest.php
+
+		-
+			message: "#^Ternary operator condition is always true\\.$#"
+			count: 1
+			path: app/Libraries/H5P/ContentType/BaseH5PContent.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PLibrariesHubCache\\:\\:\\$libraries\\.$#"
+			count: 2
+			path: app/Libraries/H5P/EditorAjax.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PLibrary\\:\\:\\$capability\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorAjax.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PLibraryLanguage\\:\\:\\$library\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorAjax.php
+
+		-
+			message: "#^Relation 'capability' is not found in App\\\\H5PLibrary model\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorAjax.php
+
+		-
+			message: "#^Relation 'libraries' is not found in App\\\\H5PLibrariesHubCache model\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorAjax.php
+
+		-
+			message: "#^Relation 'library' is not found in App\\\\H5PLibraryLanguage model\\.$#"
+			count: 2
+			path: app/Libraries/H5P/EditorAjax.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\EditorConfig\\:\\:setContext\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\EditorConfig\\:\\:setContext\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\EditorConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\EditorConfig\\:\\:setDisplayH5PHub\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 2
+			path: app/Libraries/H5P/EditorConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\EditorConfig\\:\\:setDisplayH5PHub\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\EditorConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\EditorConfig\\:\\:setEmail\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\EditorConfig\\:\\:setEmail\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\EditorConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\EditorConfig\\:\\:setName\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\EditorConfig\\:\\:setName\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\EditorConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\EditorConfig\\:\\:setPreview\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\EditorConfig\\:\\:setPreview\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\EditorConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\EditorConfig\\:\\:setUserId\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\EditorConfig\\:\\:setUserId\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\EditorConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\EditorConfig\\:\\:setUserName\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\EditorConfig\\:\\:setUserName\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\EditorConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\Interfaces\\\\CerpusStorageInterface\\:\\:getEditorDisplayPath\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorConfig.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),object\\>\\:\\:transform\\(\\) expects callable\\(object, \\(int\\|string\\)\\)\\: object, Closure\\(mixed\\)\\: mixed given\\.$#"
+			count: 3
+			path: app/Libraries/H5P/EditorConfig.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PLibrary\\:\\:\\$isOld\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorStorage.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PLibrary\\:\\:\\$majorVersion\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorStorage.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PLibrary\\:\\:\\$metadataSettings\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorStorage.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PLibrary\\:\\:\\$minorVersion\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorStorage.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PLibrary\\:\\:\\$uberName\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorStorage.php
+
+		-
+			message: "#^Called 'pluck' on Laravel collection, but could have been retrieved as a query\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorStorage.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(H5peditorFile\\)\\: Unexpected token \"\\\\n     \\* \", expected variable at offset 185$#"
+			count: 1
+			path: app/Libraries/H5P/EditorStorage.php
+
+		-
+			message: "#^Property App\\\\H5PLibrary\\:\\:\\$restricted \\(int\\) does not accept false\\.$#"
+			count: 1
+			path: app/Libraries/H5P/EditorStorage.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between int and '1' will always evaluate to false\\.$#"
+			count: 2
+			path: app/Libraries/H5P/EditorStorage.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PContent\\:\\:\\$library\\.$#"
+			count: 6
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PLibrary\\:\\:\\$count\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PLibrary\\:\\:\\$key\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^Called 'Model\\:\\:make\\(\\)' which performs unnecessary work, use 'new Model\\(\\)'\\.$#"
+			count: 3
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^Called 'isNotEmpty' on Laravel collection, but could have been retrieved as a query\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^Cannot call method fetch\\(\\) on bool\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^Default value of the parameter \\#2 \\$replacements \\(array\\) of method App\\\\Libraries\\\\H5P\\\\Framework\\:\\:t\\(\\) is incompatible with type App\\\\Libraries\\\\H5P\\\\type\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^Iterating over an object of an unknown class App\\\\Libraries\\\\H5P\\\\type\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\Framework\\:\\:getAdminUrl\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\Framework\\:\\:getLibraryId\\(\\) should return int but returns false\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\Framework\\:\\:getNumAuthors\\(\\) should return int but return statement is missing\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\Framework\\:\\:getUnsupportedLibraries\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\Framework\\:\\:hasPermission\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: """
+				#^PHPDoc tag @param has invalid value \\(array
+				  A list of unsupported libraries\\. Each list entry contains\\:
+				  \\- name\\: MachineName for the library
+				  \\- downloadUrl\\: URL to a location a new version of the library may be downloaded from
+				  \\- currentVersion\\: The unsupported version of the library installed on the system\\.
+				    This is an associative array containing\\:
+				    \\- major\\: The major version of the library
+				    \\- minor\\: The minor version of the library
+				    \\- patch\\: The patch version of the library
+				TODO\\: Check if Drupal impl has something here\\.\\)\\: Unexpected token "\\\\n     \\* ", expected variable at offset 73$#
+			"""
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$libraryData$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$libraryId$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$message$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of method Illuminate\\\\Support\\\\Collection\\<int,App\\\\H5PLibrary\\>\\:\\:transform\\(\\) expects callable\\(App\\\\H5PLibrary, int\\)\\: App\\\\H5PLibrary, Closure\\(mixed\\)\\: stdClass given\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^Parameter \\#1 \\$library of method App\\\\Libraries\\\\H5P\\\\Framework\\:\\:pathsToCsv\\(\\) expects array, object given\\.$#"
+			count: 3
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^Parameter \\#2 \\$replacements \\(App\\\\Libraries\\\\H5P\\\\type\\) of method App\\\\Libraries\\\\H5P\\\\Framework\\:\\:t\\(\\) should be compatible with parameter \\$replacements \\(array\\) of method H5PFrameworkInterface\\:\\:t\\(\\)$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^Parameter \\$replacements of method App\\\\Libraries\\\\H5P\\\\Framework\\:\\:t\\(\\) has invalid type App\\\\Libraries\\\\H5P\\\\type\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^Property App\\\\Libraries\\\\H5P\\\\Framework\\:\\:\\$adminUrl is never read, only written\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^Relation 'library' is not found in App\\\\H5PContent model\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PContent\\:\\:\\$library\\.$#"
+			count: 3
+			path: app/Libraries/H5P/H5PCopyright.php
+
+		-
+			message: "#^Call to method toArray\\(\\) on an unknown class Cerpus\\\\Helper\\\\Traits\\\\CreateTrait\\.$#"
+			count: 1
+			path: app/Libraries/H5P/H5PCopyright.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$path\\.$#"
+			count: 1
+			path: app/Libraries/H5P/H5PExport.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with App\\\\Libraries\\\\H5P\\\\Interfaces\\\\H5PExternalProviderInterface will always evaluate to false\\.$#"
+			count: 1
+			path: app/Libraries/H5P/H5PExport.php
+
+		-
+			message: "#^Property App\\\\Libraries\\\\H5P\\\\H5PExport\\:\\:\\$adapter is never read, only written\\.$#"
+			count: 1
+			path: app/Libraries/H5P/H5PExport.php
+
+		-
+			message: "#^Method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),mixed\\>\\:\\:put\\(\\) invoked with 1 parameter, 2 required\\.$#"
+			count: 1
+			path: app/Libraries/H5P/H5PImport.php
+
+		-
+			message: "#^Parameter \\#1 \\$content of method H5PStorage\\:\\:savePackage\\(\\) expects null, array given\\.$#"
+			count: 1
+			path: app/Libraries/H5P/H5PImport.php
+
+		-
+			message: "#^Parameter \\#1 \\$key of method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),mixed\\>\\:\\:put\\(\\) expects \\(int\\|string\\), array\\<string, string\\> given\\.$#"
+			count: 1
+			path: app/Libraries/H5P/H5PImport.php
+
+		-
+			message: "#^Called 'Model\\:\\:make\\(\\)' which performs unnecessary work, use 'new Model\\(\\)'\\.$#"
+			count: 1
+			path: app/Libraries/H5P/H5PLibraryAdmin.php
+
+		-
+			message: "#^Called 'pluck' on Laravel collection, but could have been retrieved as a query\\.$#"
+			count: 1
+			path: app/Libraries/H5P/H5PLibraryAdmin.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$request$#"
+			count: 1
+			path: app/Libraries/H5P/H5PLibraryAdmin.php
+
+		-
+			message: "#^Parameter \\#4 \\$options of method H5PStorage\\:\\:savePackage\\(\\) expects array, bool given\\.$#"
+			count: 1
+			path: app/Libraries/H5P/H5PLibraryAdmin.php
+
+		-
+			message: "#^Undefined variable\\: \\$dev_lib$#"
+			count: 1
+			path: app/Libraries/H5P/H5PLibraryAdmin.php
+
+		-
+			message: "#^Variable \\$dev_lib in isset\\(\\) is never defined\\.$#"
+			count: 1
+			path: app/Libraries/H5P/H5PLibraryAdmin.php
+
+		-
+			message: "#^Call to an undefined method H5PFrameworkInterface\\:\\:handleResult\\(\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/H5PProgress.php
+
+		-
+			message: "#^Call to method execute\\(\\) on an unknown class App\\\\Libraries\\\\H5P\\\\PDOStatement\\.$#"
+			count: 1
+			path: app/Libraries/H5P/H5PProgress.php
+
+		-
+			message: "#^Call to method fetchAll\\(\\) on an unknown class App\\\\Libraries\\\\H5P\\\\PDOStatement\\.$#"
+			count: 1
+			path: app/Libraries/H5P/H5PProgress.php
+
+		-
+			message: "#^Dead catch \\- Exception is never thrown in the try block\\.$#"
+			count: 1
+			path: app/Libraries/H5P/H5PProgress.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\H5PProgress\\:\\:getProgress\\(\\) should return bool\\|string but returns null\\.$#"
+			count: 1
+			path: app/Libraries/H5P/H5PProgress.php
+
+		-
+			message: "#^PHPDoc tag @var for variable \\$stmt contains unknown class App\\\\Libraries\\\\H5P\\\\PDOStatement\\.$#"
+			count: 1
+			path: app/Libraries/H5P/H5PProgress.php
+
+		-
+			message: "#^PHPDoc tag @var has invalid value \\(\\$db PDO\\)\\: Unexpected token \"\\$db\", expected type at offset 16$#"
+			count: 1
+			path: app/Libraries/H5P/H5PProgress.php
+
+		-
+			message: "#^Property App\\\\Libraries\\\\H5P\\\\H5PProgress\\:\\:\\$request is never read, only written\\.$#"
+			count: 1
+			path: app/Libraries/H5P/H5PProgress.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 3
+			path: app/Libraries/H5P/H5PProgress.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Helper/H5PPackageProvider.php
+
+		-
+			message: "#^PHPDoc tag @return with type bool is incompatible with native type void\\.$#"
+			count: 2
+			path: app/Libraries/H5P/Interfaces/H5PAdapterInterface.php
+
+		-
+			message: "#^Anonymous function has an unused use \\$slide\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Packages/CoursePresentation.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with App\\\\Libraries\\\\H5P\\\\Packages\\\\PackageInterface will always evaluate to false\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Packages/CoursePresentation.php
+
+		-
+			message: "#^Call to method canExtractAnswers\\(\\) on an unknown class App\\\\Libraries\\\\H5P\\\\Packages\\\\PackageInterface\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Packages/CoursePresentation.php
+
+		-
+			message: "#^Call to method getElements\\(\\) on an unknown class App\\\\Libraries\\\\H5P\\\\Packages\\\\PackageInterface\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Packages/CoursePresentation.php
+
+		-
+			message: "#^Call to method setAnswers\\(\\) on an unknown class App\\\\Libraries\\\\H5P\\\\Packages\\\\PackageInterface\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Packages/CoursePresentation.php
+
+		-
+			message: "#^Call to method validate\\(\\) on an unknown class App\\\\Libraries\\\\H5P\\\\Packages\\\\PackageInterface\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Packages/CoursePresentation.php
+
+		-
+			message: "#^PHPDoc tag @var for variable \\$item contains unknown class App\\\\Libraries\\\\H5P\\\\Packages\\\\PackageInterface\\.$#"
+			count: 2
+			path: app/Libraries/H5P/Packages/CoursePresentation.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),object\\>\\:\\:transform\\(\\) expects callable\\(object, \\(int\\|string\\)\\)\\: object, Closure\\(mixed\\)\\: mixed given\\.$#"
+			count: 3
+			path: app/Libraries/H5P/Packages/H5PBase.php
+
+		-
+			message: "#^Offset 'package' on array\\{package\\: App\\\\Libraries\\\\H5P\\\\Interfaces\\\\PackageInterface, index\\: mixed\\} on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Packages/InteractiveVideo.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with stdClass will always evaluate to false\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Reports/H5PPackage.php
+
+		-
+			message: "#^Access to an undefined property H5peditorFile\\:\\:\\$hash\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Storage/H5PCerpusStorage.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Contracts\\\\Filesystem\\\\Filesystem\\:\\:createDirectory\\(\\)\\.$#"
+			count: 2
+			path: app/Libraries/H5P/Storage/H5PCerpusStorage.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Contracts\\\\Filesystem\\\\Filesystem\\:\\:has\\(\\)\\.$#"
+			count: 5
+			path: app/Libraries/H5P/Storage/H5PCerpusStorage.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Contracts\\\\Filesystem\\\\Filesystem\\:\\:listContents\\(\\)\\.$#"
+			count: 3
+			path: app/Libraries/H5P/Storage/H5PCerpusStorage.php
+
+		-
+			message: "#^Called 'isNotEmpty' on Laravel collection, but could have been retrieved as a query\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Storage/H5PCerpusStorage.php
+
+		-
+			message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
+			count: 2
+			path: app/Libraries/H5P/Storage/H5PCerpusStorage.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\Storage\\\\H5PCerpusStorage\\:\\:getContent\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Storage/H5PCerpusStorage.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\Storage\\\\H5PCerpusStorage\\:\\:moveContentDirectory\\(\\) should return object but return statement is missing\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Storage/H5PCerpusStorage.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\Storage\\\\H5PCerpusStorage\\:\\:moveContentDirectory\\(\\) should return object but returns null\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Storage/H5PCerpusStorage.php
+
+		-
+			message: "#^Static call to instance method App\\\\H5PFile\\:\\:deleteContentPendingUpload\\(\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Storage/H5PCerpusStorage.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between string and null will always evaluate to false\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Storage/H5PCerpusStorage.php
+
+		-
+			message: "#^Variable \\$filePath might not be defined\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Storage/H5PCerpusStorage.php
+
+		-
+			message: "#^Cannot access property \\$document on array\\|bool\\|float\\|int\\|object\\|string\\.$#"
+			count: 1
+			path: app/Libraries/H5P/TranslationServices/NynorskrobotenAdapter.php
+
+		-
+			message: "#^Cannot access property \\$guid on array\\|bool\\|float\\|int\\|object\\|string\\.$#"
+			count: 1
+			path: app/Libraries/H5P/TranslationServices/NynorskrobotenAdapter.php
+
+		-
+			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:get\\(\\)\\.$#"
+			count: 3
+			path: app/Libraries/H5P/Video/NDLAVideoAdapter.php
+
+		-
+			message: "#^Access to an undefined property object\\:\\:\\$path\\.$#"
+			count: 1
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Call to an undefined method App\\\\Libraries\\\\H5P\\\\Interfaces\\\\PackageInterface\\:\\:alterConfig\\(\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Call to function is_null\\(\\) with Cerpus\\\\CoreClient\\\\DataObjects\\\\BehaviorSettingsDataObject will always evaluate to false\\.$#"
+			count: 2
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
+			count: 1
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\ViewConfig\\:\\:setContext\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\ViewConfig\\:\\:setContext\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\ViewConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\ViewConfig\\:\\:setDisplayH5PHub\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 2
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\ViewConfig\\:\\:setDisplayH5PHub\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\ViewConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\ViewConfig\\:\\:setEmail\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\ViewConfig\\:\\:setEmail\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\ViewConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\ViewConfig\\:\\:setName\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\ViewConfig\\:\\:setName\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\ViewConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\ViewConfig\\:\\:setPreview\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\ViewConfig\\:\\:setPreview\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\ViewConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\ViewConfig\\:\\:setUserId\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\ViewConfig\\:\\:setUserId\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\ViewConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\ViewConfig\\:\\:setUserName\\(\\) has invalid return type App\\\\Libraries\\\\H5P\\\\Config\\.$#"
+			count: 1
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\ViewConfig\\:\\:setUserName\\(\\) should return App\\\\Libraries\\\\H5P\\\\Config but returns \\$this\\(App\\\\Libraries\\\\H5P\\\\ViewConfig\\)\\.$#"
+			count: 1
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),object\\>\\:\\:transform\\(\\) expects callable\\(object, \\(int\\|string\\)\\)\\: object, Closure\\(mixed\\)\\: mixed given\\.$#"
+			count: 3
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Parameter \\#1 \\$parameters of method App\\\\Libraries\\\\H5P\\\\Interfaces\\\\H5PAdapterInterface\\:\\:alterParameters\\(\\) expects string, object given\\.$#"
+			count: 1
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Parameter \\#2 \\$type of method H5PCore\\:\\:loadContentDependencies\\(\\) expects null, string given\\.$#"
+			count: 1
+			path: app/Libraries/H5P/ViewConfig.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Libraries\\\\H5P\\\\Interfaces\\\\ConfigInterface\\:\\:\\$h5pCore\\.$#"
+			count: 1
+			path: app/Libraries/H5P/h5p.php
+
+		-
+			message: "#^Method App\\\\Libraries\\\\H5P\\\\h5p\\:\\:getContents\\(\\) should return array but returns object\\.$#"
+			count: 1
+			path: app/Libraries/H5P/h5p.php
+
+		-
+			message: "#^Parameter \\#1 \\$content of method H5peditor\\:\\:processParameters\\(\\) expects stdClass, int given\\.$#"
+			count: 1
+			path: app/Libraries/H5P/h5p.php
+
+		-
+			message: "#^Undefined variable\\: \\$library$#"
+			count: 1
+			path: app/Libraries/H5P/h5p.php
+
+		-
+			message: "#^Variable \\$library in empty\\(\\) is never defined\\.$#"
+			count: 1
+			path: app/Libraries/H5P/h5p.php
+
+		-
+			message: "#^Access to an undefined property HTMLPurifier_Definition\\:\\:\\$manager\\.$#"
+			count: 1
+			path: app/Libraries/HTMLPurify/Config/MathMLConfig.php
+
+		-
+			message: "#^Parameter \\#1 \\$config of static method App\\\\Libraries\\\\HTMLPurify\\\\Config\\\\MathMLConfig\\:\\:create\\(\\) expects array\\|HTMLPurifier_Config\\|string, null given\\.$#"
+			count: 1
+			path: app/Libraries/HTMLPurify/Config/MathMLConfig.php
+
+		-
+			message: "#^Parameter \\#1 \\$config of static method HTMLPurifier_HTML5Config\\:\\:create\\(\\) expects array\\|HTMLPurifier_Config\\|string, HTMLPurifier_ConfigSchema given\\.$#"
+			count: 1
+			path: app/Libraries/HTMLPurify/Config/MathMLConfig.php
+
+		-
+			message: "#^Parameter \\#3 \\$type of method HTMLPurifier_ConfigSchema\\:\\:add\\(\\) expects string, int given\\.$#"
+			count: 1
+			path: app/Libraries/HTMLPurify/Config/MathMLConfig.php
+
+		-
+			message: "#^Property App\\\\Libraries\\\\HTMLPurify\\\\HTMLModule\\\\MathML\\:\\:\\$mathml_prefix is never read, only written\\.$#"
+			count: 1
+			path: app/Libraries/HTMLPurify/HTMLModule/MathML.php
+
+		-
+			message: "#^Access to property \\$data on an unknown class App\\\\Libraries\\\\HTMLPurify\\\\Injector\\\\HTMLPurifier_Token\\.$#"
+			count: 3
+			path: app/Libraries/HTMLPurify/Injector/MathMLSpaceNormalize.php
+
+		-
+			message: "#^Parameter \\$token of method App\\\\Libraries\\\\HTMLPurify\\\\Injector\\\\MathMLSpaceNormalize\\:\\:handleText\\(\\) has invalid type App\\\\Libraries\\\\HTMLPurify\\\\Injector\\\\HTMLPurifier_Token\\.$#"
+			count: 1
+			path: app/Libraries/HTMLPurify/Injector/MathMLSpaceNormalize.php
+
+		-
+			message: "#^Access to an undefined property App\\\\QuestionSet\\:\\:\\$questions\\.$#"
+			count: 1
+			path: app/Libraries/QuestionSet/QuestionSetConvert.php
+
+		-
+			message: "#^Called 'Model\\:\\:make\\(\\)' which performs unnecessary work, use 'new Model\\(\\)'\\.$#"
+			count: 4
+			path: app/Libraries/QuestionSet/QuestionSetHandler.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Libraries\\\\oAuthLTI\\\\OAuthConsumer\\:\\:\\$callback_url\\.$#"
+			count: 1
+			path: app/Libraries/oAuthLTI/OAuthConsumer.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of function array_map expects \\(callable\\(mixed\\)\\: mixed\\)\\|null, array\\{'self', 'urlencode_rfc3986'\\} given\\.$#"
+			count: 1
+			path: app/Libraries/oAuthLTI/OAuthUtil.php
+
+		-
+			message: "#^Access to an undefined property App\\\\LibraryDescription\\:\\:\\$library\\.$#"
+			count: 1
+			path: app/LibraryDescription.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(Collection\\<Collaborator\\> collaborators\\)\\: Unexpected token \"collaborators\", expected variable at offset 276$#"
+			count: 1
+			path: app/Link.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(int deleted_at\\)\\: Unexpected token \"deleted_at\", expected variable at offset 165$#"
+			count: 1
+			path: app/Link.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string id\\)\\: Unexpected token \"id\", expected variable at offset 57$#"
+			count: 1
+			path: app/Link.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string link_text\\)\\: Unexpected token \"link_text\", expected variable at offset 196$#"
+			count: 1
+			path: app/Link.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string link_type\\)\\: Unexpected token \"link_type\", expected variable at offset 109$#"
+			count: 1
+			path: app/Link.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string link_url\\)\\: Unexpected token \"link_url\", expected variable at offset 80$#"
+			count: 1
+			path: app/Link.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string metadata\\)\\: Unexpected token \"metadata\", expected variable at offset 226$#"
+			count: 1
+			path: app/Link.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string owner_id\\)\\: Unexpected token \"owner_id\", expected variable at offset 139$#"
+			count: 1
+			path: app/Link.php
+
+		-
+			message: "#^PHPDoc tag @var has invalid value \\(\\$leafs VersionData\\[\\]\\)\\: Unexpected token \"\\$leafs\", expected type at offset 9$#"
+			count: 1
+			path: app/Listeners/AbstractHandleVersioning.php
+
+		-
+			message: "#^PHPDoc tag @var has invalid value \\(\\$mostRecentLeaf VersionData\\)\\: Unexpected token \"\\$mostRecentLeaf\", expected type at offset 9$#"
+			count: 1
+			path: app/Listeners/AbstractHandleVersioning.php
+
+		-
+			message: "#^Parameter \\#1 \\$externalReference of method Cerpus\\\\VersionClient\\\\VersionData\\:\\:setExternalReference\\(\\) expects null, string given\\.$#"
+			count: 1
+			path: app/Listeners/AbstractHandleVersioning.php
+
+		-
+			message: "#^Parameter \\#1 \\$userId of method Cerpus\\\\VersionClient\\\\VersionData\\:\\:setUserId\\(\\) expects null, string given\\.$#"
+			count: 1
+			path: app/Listeners/AbstractHandleVersioning.php
+
+		-
+			message: "#^Anonymous function has an unused use \\$mailer\\.$#"
+			count: 1
+			path: app/Listeners/Article/HandleCollaborationInviteEmails.php
+
+		-
+			message: "#^Property App\\\\Article\\:\\:\\$is_private \\(int\\) does not accept bool\\.$#"
+			count: 1
+			path: app/Listeners/Article/HandlePrivacy.php
+
+		-
+			message: "#^Parameter \\#1 \\$externalReference of method Cerpus\\\\VersionClient\\\\VersionData\\:\\:setExternalReference\\(\\) expects null, string given\\.$#"
+			count: 1
+			path: app/Listeners/Article/HandleVersioning.php
+
+		-
+			message: "#^Parameter \\#1 \\$externalUrl of method Cerpus\\\\VersionClient\\\\VersionData\\:\\:setExternalUrl\\(\\) expects Psr\\\\Http\\\\Message\\\\UriInterface, string given\\.$#"
+			count: 1
+			path: app/Listeners/Article/HandleVersioning.php
+
+		-
+			message: "#^Parameter \\#1 \\$userId of method Cerpus\\\\VersionClient\\\\VersionData\\:\\:setUserId\\(\\) expects null, string given\\.$#"
+			count: 1
+			path: app/Listeners/Article/HandleVersioning.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Libraries\\\\Versioning\\\\VersionableObject\\:\\:\\$id\\.$#"
+			count: 1
+			path: app/Listeners/H5P/Copy/HandleVersioning.php
+
+		-
+			message: "#^Parameter \\#1 \\$externalReference of method Cerpus\\\\VersionClient\\\\VersionData\\:\\:setExternalReference\\(\\) expects null, int given\\.$#"
+			count: 1
+			path: app/Listeners/H5P/HandleVersioning.php
+
+		-
+			message: "#^Parameter \\#1 \\$externalUrl of method Cerpus\\\\VersionClient\\\\VersionData\\:\\:setExternalUrl\\(\\) expects Psr\\\\Http\\\\Message\\\\UriInterface, string given\\.$#"
+			count: 1
+			path: app/Listeners/H5P/HandleVersioning.php
+
+		-
+			message: "#^Parameter \\#1 \\$userId of method Cerpus\\\\VersionClient\\\\VersionData\\:\\:setUserId\\(\\) expects null, string given\\.$#"
+			count: 1
+			path: app/Listeners/H5P/HandleVersioning.php
+
+		-
+			message: "#^Property App\\\\QuestionSet\\:\\:\\$is_private \\(int\\) does not accept bool\\.$#"
+			count: 1
+			path: app/Listeners/Questionset/HandlePrivacy.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\:\\:h5p\\(\\)\\.$#"
+			count: 1
+			path: app/NdlaIdMapper.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(int\\|null metadata_fetch\\)\\: Unexpected token \"metadata_fetch\", expected variable at offset 67$#"
+			count: 1
+			path: app/NdlaIdMapper.php
+
+		-
+			message: "#^Method Illuminate\\\\Foundation\\\\Support\\\\Providers\\\\AuthServiceProvider\\:\\:registerPolicies\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 1
+			path: app/Providers/AuthServiceProvider.php
+
+		-
+			message: "#^PHPDoc type array of property App\\\\Providers\\\\AuthServiceProvider\\:\\:\\$policies is not covariant with PHPDoc type array\\<class\\-string, class\\-string\\> of overridden property Illuminate\\\\Foundation\\\\Support\\\\Providers\\\\AuthServiceProvider\\:\\:\\$policies\\.$#"
+			count: 1
+			path: app/Providers/AuthServiceProvider.php
+
+		-
+			message: "#^Access to an undefined property H5PCore\\:\\:\\$aggregateAssets\\.$#"
+			count: 1
+			path: app/Providers/H5PServiceProvider.php
+
+		-
+			message: "#^Class App\\\\Libraries\\\\H5P\\\\EditorStorage constructor invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: app/Providers/H5PServiceProvider.php
+
+		-
+			message: "#^Variable \\$instance in empty\\(\\) always exists and is not falsy\\.$#"
+			count: 1
+			path: app/Providers/H5PServiceProvider.php
+
+		-
+			message: "#^Variable \\$instance on left side of \\?\\? always exists and is not nullable\\.$#"
+			count: 1
+			path: app/Providers/H5PServiceProvider.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$email\\.$#"
+			count: 1
+			path: app/QuestionSet.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(Collection\\<QuestionSetQuestion\\> questions\\)\\: Unexpected token \"questions\", expected variable at offset 213$#"
+			count: 1
+			path: app/QuestionSet.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string external_reference\\)\\: Unexpected token \"external_reference\", expected variable at offset 124$#"
+			count: 1
+			path: app/QuestionSet.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string language_code\\)\\: Unexpected token \"language_code\", expected variable at offset 64$#"
+			count: 1
+			path: app/QuestionSet.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string owner\\)\\: Unexpected token \"owner\", expected variable at offset 98$#"
+			count: 1
+			path: app/QuestionSet.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string tags\\)\\: Unexpected token \"tags\", expected variable at offset 163$#"
+			count: 1
+			path: app/QuestionSet.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(Collection\\<QuestionSetQuestionAnswer\\> answers\\)\\: Unexpected token \"answers\", expected variable at offset 141$#"
+			count: 1
+			path: app/QuestionSetQuestion.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string id\\)\\: Unexpected token \"id\", expected variable at offset 24$#"
+			count: 1
+			path: app/QuestionSetQuestion.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string image\\)\\: Unexpected token \"image\", expected variable at offset 81$#"
+			count: 1
+			path: app/QuestionSetQuestion.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string question_text\\)\\: Unexpected token \"question_text\", expected variable at offset 47$#"
+			count: 1
+			path: app/QuestionSetQuestion.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(int correct\\)\\: Unexpected token \"correct\", expected variable at offset 76$#"
+			count: 1
+			path: app/QuestionSetQuestionAnswer.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string answer_text\\)\\: Unexpected token \"answer_text\", expected variable at offset 47$#"
+			count: 1
+			path: app/QuestionSetQuestionAnswer.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string id\\)\\: Unexpected token \"id\", expected variable at offset 24$#"
+			count: 1
+			path: app/QuestionSetQuestionAnswer.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(Collection\\<Collaborator\\> collaborators\\)\\: Unexpected token \"collaborators\", expected variable at offset 42$#"
+			count: 1
+			path: app/Traits/Collaboratable.php
+
+		-
+			message: "#^PHPDoc tag @property has invalid value \\(string\\|int id\\)\\: Unexpected token \"id\", expected variable at offset 75$#"
+			count: 1
+			path: app/Traits/HasLanguage.php
+
+		-
+			message: "#^Access to an undefined property App\\\\QuestionSetQuestion\\:\\:\\$answers\\.$#"
+			count: 1
+			path: app/Transformers/QuestionSetsQuestionTransformer.php
+
+		-
+			message: "#^Access to an undefined property App\\\\QuestionSetQuestion\\:\\:\\$questionset\\.$#"
+			count: 1
+			path: app/Transformers/QuestionSetsQuestionTransformer.php
+
+		-
+			message: "#^Access to an undefined property App\\\\QuestionSet\\:\\:\\$questions\\.$#"
+			count: 1
+			path: app/Transformers/QuestionSetsTransformer.php
+
+		-
+			message: "#^PHPDoc type array of property App\\\\User\\:\\:\\$fillable is not covariant with PHPDoc type array\\<string\\> of overridden property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$fillable\\.$#"
+			count: 1
+			path: app/User.php
+
+		-
+			message: "#^PHPDoc type array of property App\\\\User\\:\\:\\$hidden is not covariant with PHPDoc type array\\<int, string\\> of overridden property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$hidden\\.$#"
+			count: 1
+			path: app/User.php
+
+		-
+			message: "#^Class Chumper\\\\Zipper\\\\Zipper not found\\.$#"
+			count: 1
+			path: config/app.php
+
+		-
+			message: "#^Class Vinelab\\\\Bowler\\\\Facades\\\\Registrator not found\\.$#"
+			count: 1
+			path: config/app.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 1
+			path: database/factories/H5PContentsMetadataFactory.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function md5 expects string, int\\<1, max\\> given\\.$#"
+			count: 1
+			path: database/migrations/2014_10_12_104748_create_administrators_table.php
+
+		-
+			message: "#^Method Illuminate\\\\Database\\\\Schema\\\\Blueprint\\:\\:text\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 2
+			path: database/migrations/2015_09_25_092958_create_h5p_contents_table.php
+
+		-
+			message: "#^Method Illuminate\\\\Database\\\\Schema\\\\Blueprint\\:\\:text\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: database/migrations/2015_09_25_092958_create_h5p_libraries_languages_table.php
+
+		-
+			message: "#^Method Illuminate\\\\Database\\\\Schema\\\\Blueprint\\:\\:text\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 4
+			path: database/migrations/2015_09_25_092958_create_h5p_libraries_table.php
+
+		-
+			message: "#^Method ChangeDefaultPassword\\:\\:createPassword\\(\\) is unused\\.$#"
+			count: 1
+			path: database/migrations/2015_12_08_073717_change_default_password.php
+
+		-
+			message: "#^Method Illuminate\\\\Database\\\\Schema\\\\Blueprint\\:\\:text\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: database/migrations/2015_12_15_081807_create_content_sharing_table.php
+
+		-
+			message: "#^Method ChangeAdminPassword\\:\\:createPassword\\(\\) is unused\\.$#"
+			count: 1
+			path: database/migrations/2016_04_19_073909_ChangeAdminPassword.php
+
+		-
+			message: "#^Called 'Model\\:\\:make\\(\\)' which performs unnecessary work, use 'new Model\\(\\)'\\.$#"
+			count: 1
+			path: database/migrations/2018_04_05_083016_add_h5p_hub_cache.php
+
+		-
+			message: "#^Called 'Model\\:\\:make\\(\\)' which performs unnecessary work, use 'new Model\\(\\)'\\.$#"
+			count: 1
+			path: database/migrations/2019_04_24_103853_update_hub_cache.php
+
+		-
+			message: "#^Called 'Model\\:\\:make\\(\\)' which performs unnecessary work, use 'new Model\\(\\)'\\.$#"
+			count: 1
+			path: database/migrations/2019_05_21_121648_add_cerpus_video_and_image_to_cache.php
+
+		-
+			message: "#^Method SetAdminPassword\\:\\:createPassword\\(\\) is unused\\.$#"
+			count: 1
+			path: database/migrations/2020_12_07_133958_set_admin_password.php
+
+		-
+			message: "#^Method SetAdminPassword\\:\\:createPassword\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: database/migrations/2020_12_07_133958_set_admin_password.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$files\\.$#"
+			count: 1
+			path: tests/Integration/Article/ArticleFileVersionerTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 1
+			path: tests/Integration/Article/ArticleFileVersionerTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:files\\(\\)\\.$#"
+			count: 1
+			path: tests/Integration/Article/ArticleFileVersionerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$newArticle of class App\\\\Http\\\\Libraries\\\\ArticleFileVersioner constructor expects App\\\\Article, Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model given\\.$#"
+			count: 3
+			path: tests/Integration/Article/ArticleFileVersionerTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 11
+			path: tests/Integration/Article/ArticleLockTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$title\\.$#"
+			count: 1
+			path: tests/Integration/Article/ArticleLockTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:collaborators\\(\\)\\.$#"
+			count: 1
+			path: tests/Integration/Article/ArticleLockTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$content\\.$#"
+			count: 1
+			path: tests/Integration/Article/ArticleTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 3
+			path: tests/Integration/Article/ArticleTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$title\\.$#"
+			count: 1
+			path: tests/Integration/Article/ArticleTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$auth_id\\.$#"
+			count: 10
+			path: tests/Integration/Article/ArticleVersioningTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$content\\.$#"
+			count: 9
+			path: tests/Integration/Article/ArticleVersioningTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$email\\.$#"
+			count: 11
+			path: tests/Integration/Article/ArticleVersioningTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 9
+			path: tests/Integration/Article/ArticleVersioningTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$license\\.$#"
+			count: 1
+			path: tests/Integration/Article/ArticleVersioningTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$title\\.$#"
+			count: 6
+			path: tests/Integration/Article/ArticleVersioningTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:collaborators\\(\\)\\.$#"
+			count: 3
+			path: tests/Integration/Article/ArticleVersioningTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:requestShouldBecomeNewVersion\\(\\)\\.$#"
+			count: 5
+			path: tests/Integration/Article/ArticleVersioningTest.php
+
+		-
+			message: "#^Called 'count' on Laravel collection, but could have been retrieved as a query\\.$#"
+			count: 2
+			path: tests/Integration/Article/ArticleVersioningTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 1
+			path: tests/Integration/Article/Handler/HandleCollaboratorsTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:collaborators\\(\\)\\.$#"
+			count: 1
+			path: tests/Integration/Article/Handler/HandleCollaboratorsTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$article of class App\\\\Events\\\\ArticleWasSaved constructor expects App\\\\Article, Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model given\\.$#"
+			count: 1
+			path: tests/Integration/Article/Handler/HandleCollaboratorsTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$is_private\\.$#"
+			count: 3
+			path: tests/Integration/Article/Handler/HandlePrivacyTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$article of class App\\\\Events\\\\ArticleWasSaved constructor expects App\\\\Article, Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model given\\.$#"
+			count: 1
+			path: tests/Integration/Article/Handler/HandlePrivacyTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$article of class App\\\\Events\\\\ArticleWasSaved constructor expects App\\\\Article, Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\|null given\\.$#"
+			count: 1
+			path: tests/Integration/Article/Handler/HandlePrivacyTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$collaborators\\.$#"
+			count: 12
+			path: tests/Integration/CollaboratableTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$email\\.$#"
+			count: 3
+			path: tests/Integration/CollaboratableTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:collaborators\\(\\)\\.$#"
+			count: 21
+			path: tests/Integration/CollaboratableTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:getCollaboratorEmails\\(\\)\\.$#"
+			count: 3
+			path: tests/Integration/CollaboratableTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:newCollaborators\\(\\)\\.$#"
+			count: 10
+			path: tests/Integration/CollaboratableTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:setCollaborators\\(\\)\\.$#"
+			count: 8
+			path: tests/Integration/CollaboratableTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$auth_id\\.$#"
+			count: 2
+			path: tests/Integration/Content/ContentTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$email\\.$#"
+			count: 2
+			path: tests/Integration/Content/ContentTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$auth_id\\.$#"
+			count: 10
+			path: tests/Integration/Content/LockStatusTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$content_id\\.$#"
+			count: 5
+			path: tests/Integration/Content/LockStatusTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$created_at\\.$#"
+			count: 2
+			path: tests/Integration/Content/LockStatusTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 6
+			path: tests/Integration/Content/LockStatusTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$updated_at\\.$#"
+			count: 3
+			path: tests/Integration/Content/LockStatusTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$auth_id\\.$#"
+			count: 5
+			path: tests/Integration/Content/UnlockTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$content_id\\.$#"
+			count: 2
+			path: tests/Integration/Content/UnlockTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$collaborators\\.$#"
+			count: 10
+			path: tests/Integration/Gdpr/Handlers/ShareProcessorTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 4
+			path: tests/Integration/Gdpr/Handlers/ShareProcessorTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:setCollaborators\\(\\)\\.$#"
+			count: 3
+			path: tests/Integration/Gdpr/Handlers/ShareProcessorTest.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PContent\\:\\:\\$library\\.$#"
+			count: 4
+			path: tests/Integration/Http/Controllers/ArticleCopyrightControllerTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 1
+			path: tests/Integration/Http/Controllers/ArticleCopyrightControllerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of class App\\\\ApiModels\\\\User constructor expects string, int given\\.$#"
+			count: 2
+			path: tests/Integration/Http/Controllers/GameControllerTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 1
+			path: tests/Integration/Http/Controllers/H5PControllerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of class App\\\\ApiModels\\\\User constructor expects string, int given\\.$#"
+			count: 1
+			path: tests/Integration/Http/Controllers/H5PControllerTest.php
+
+		-
+			message: "#^Variable \\$h5pContentLibs in PHPDoc tag @var does not exist\\.$#"
+			count: 1
+			path: tests/Integration/Http/Controllers/H5PControllerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of class App\\\\ApiModels\\\\User constructor expects string, int given\\.$#"
+			count: 2
+			path: tests/Integration/Http/Controllers/LinkControllerTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\|Illuminate\\\\Support\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\:\\:\\$id\\.$#"
+			count: 4
+			path: tests/Integration/Http/Controllers/QuestionSetControllerTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Model\\|Illuminate\\\\Support\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\:\\:questions\\(\\)\\.$#"
+			count: 2
+			path: tests/Integration/Http/Controllers/QuestionSetControllerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of method Illuminate\\\\Support\\\\Collection\\<int,Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\:\\:each\\(\\) expects callable\\(Illuminate\\\\Database\\\\Eloquent\\\\Model, int\\)\\: mixed, Closure\\(App\\\\QuestionSet, mixed\\)\\: void given\\.$#"
+			count: 2
+			path: tests/Integration/Http/Controllers/QuestionSetControllerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of class App\\\\ApiModels\\\\User constructor expects string, int given\\.$#"
+			count: 2
+			path: tests/Integration/Http/Controllers/QuestionSetControllerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$questionset of method App\\\\Http\\\\Controllers\\\\QuestionSetController\\:\\:update\\(\\) expects App\\\\QuestionSet, Illuminate\\\\Database\\\\Eloquent\\\\Model\\|Illuminate\\\\Support\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\> given\\.$#"
+			count: 8
+			path: tests/Integration/Http/Controllers/QuestionSetControllerTest.php
+
+		-
+			message: "#^Variable \\$questionSetController in PHPDoc tag @var does not match assigned variable \\$questionsetController\\.$#"
+			count: 1
+			path: tests/Integration/Http/Controllers/QuestionSetControllerTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$filtered\\.$#"
+			count: 1
+			path: tests/Integration/Jobs/PingVideoApiTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 38
+			path: tests/Integration/Jobs/PingVideoApiTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 5
+			path: tests/Integration/Jobs/PingVideoApiTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\|Illuminate\\\\Support\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\:\\:\\$id\\.$#"
+			count: 4
+			path: tests/Integration/Jobs/PingVideoApiTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:contentVideos\\(\\)\\.$#"
+			count: 5
+			path: tests/Integration/Jobs/PingVideoApiTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Model\\|Illuminate\\\\Support\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\:\\:contentVideos\\(\\)\\.$#"
+			count: 2
+			path: tests/Integration/Jobs/PingVideoApiTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$content of method Tests\\\\Integration\\\\Jobs\\\\PingVideoApiTest\\:\\:createVideoData\\(\\) expects App\\\\H5PContent, Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\|null given\\.$#"
+			count: 1
+			path: tests/Integration/Jobs/PingVideoApiTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$content of method Tests\\\\Integration\\\\Jobs\\\\PingVideoApiTest\\:\\:createVideoData\\(\\) expects App\\\\H5PContent, Illuminate\\\\Database\\\\Eloquent\\\\Model\\|null given\\.$#"
+			count: 1
+			path: tests/Integration/Jobs/PingVideoApiTest.php
+
+		-
+			message: "#^Property Tests\\\\Integration\\\\Jobs\\\\PingVideoApiTest\\:\\:\\$disk \\(Illuminate\\\\Filesystem\\\\FilesystemAdapter\\) does not accept Illuminate\\\\Contracts\\\\Filesystem\\\\Filesystem\\.$#"
+			count: 1
+			path: tests/Integration/Jobs/PingVideoApiTest.php
+
+		-
+			message: "#^Access to an undefined property App\\\\H5PContent\\:\\:\\$metadata\\.$#"
+			count: 4
+			path: tests/Integration/Libraries/H5P/API/H5PImportControllerTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$auth_id\\.$#"
+			count: 7
+			path: tests/Integration/Libraries/H5P/API/H5PImportControllerTest.php
+
+		-
+			message: "#^Relation 'metadata' is not found in App\\\\H5PContent model\\.$#"
+			count: 3
+			path: tests/Integration/Libraries/H5P/API/H5PImportControllerTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$auth_id\\.$#"
+			count: 18
+			path: tests/Integration/Libraries/H5P/CRUTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$email\\.$#"
+			count: 27
+			path: tests/Integration/Libraries/H5P/CRUTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 2
+			path: tests/Integration/Libraries/H5P/CRUTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$name\\.$#"
+			count: 14
+			path: tests/Integration/Libraries/H5P/CRUTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$title\\.$#"
+			count: 2
+			path: tests/Integration/Libraries/H5P/CRUTest.php
+
+		-
+			message: "#^Access to an undefined property Tests\\\\Integration\\\\Libraries\\\\H5P\\\\CRUTest\\:\\:\\$editorFilesDirectory\\.$#"
+			count: 1
+			path: tests/Integration/Libraries/H5P/CRUTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 7
+			path: tests/Integration/Libraries/H5P/H5PCopyrightTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$major_version\\.$#"
+			count: 2
+			path: tests/Integration/Libraries/H5P/H5PCopyrightTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$minor_version\\.$#"
+			count: 2
+			path: tests/Integration/Libraries/H5P/H5PCopyrightTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$name\\.$#"
+			count: 2
+			path: tests/Integration/Libraries/H5P/H5PCopyrightTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:content\\(\\)\\.$#"
+			count: 5
+			path: tests/Integration/Libraries/H5P/H5PCopyrightTest.php
+
+		-
+			message: "#^Call to method toArray\\(\\) on an unknown class Cerpus\\\\Helper\\\\Traits\\\\CreateTrait\\.$#"
+			count: 4
+			path: tests/Integration/Libraries/H5P/H5PCopyrightTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$content of method App\\\\Libraries\\\\H5P\\\\H5PCopyright\\:\\:getCopyrights\\(\\) expects App\\\\H5PContent, Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model given\\.$#"
+			count: 13
+			path: tests/Integration/Libraries/H5P/H5PCopyrightTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 13
+			path: tests/Integration/Libraries/H5P/H5PExportTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$slug\\.$#"
+			count: 7
+			path: tests/Integration/Libraries/H5P/H5PExportTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$content of class App\\\\Libraries\\\\H5P\\\\H5PExport constructor expects App\\\\H5PContent, Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model given\\.$#"
+			count: 7
+			path: tests/Integration/Libraries/H5P/H5PExportTest.php
+
+		-
+			message: "#^Access to an undefined property Faker\\\\Generator\\:\\:\\$mimeType\\.$#"
+			count: 1
+			path: tests/Integration/Libraries/H5P/Package/ColumnTest.php
+
+		-
+			message: "#^Access to an undefined property Faker\\\\Generator\\:\\:\\$mimeType\\.$#"
+			count: 3
+			path: tests/Integration/Libraries/H5P/Package/CoursePresentationTest.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: tests/Integration/Libraries/H5P/Package/MultiChoiceTest.php
+
+		-
+			message: "#^Access to an undefined property Faker\\\\Generator\\:\\:\\$mimeType\\.$#"
+			count: 1
+			path: tests/Integration/Libraries/H5P/Package/VideoTest.php
+
+		-
+			message: "#^Class App\\\\Libraries\\\\H5P\\\\Storage\\\\H5PCerpusStorage constructor invoked with 4 parameters, 2 required\\.$#"
+			count: 3
+			path: tests/Integration/Libraries/H5P/Storage/H5pCerpusStorage.php
+
+		-
+			message: "#^Parameter \\#1 \\$contentAuthorStorage of class App\\\\Libraries\\\\H5P\\\\Storage\\\\H5PCerpusStorage constructor expects App\\\\Libraries\\\\ContentAuthorStorage, Illuminate\\\\Contracts\\\\Filesystem\\\\Filesystem given\\.$#"
+			count: 3
+			path: tests/Integration/Libraries/H5P/Storage/H5pCerpusStorage.php
+
+		-
+			message: "#^Parameter \\#2 \\$logger of class App\\\\Libraries\\\\H5P\\\\Storage\\\\H5PCerpusStorage constructor expects Psr\\\\Log\\\\LoggerInterface, string given\\.$#"
+			count: 3
+			path: tests/Integration/Libraries/H5P/Storage/H5pCerpusStorage.php
+
+		-
+			message: "#^Parameter \\#2 \\$content of method App\\\\Libraries\\\\H5P\\\\h5p\\:\\:storeContent\\(\\) expects array\\|null, object given\\.$#"
+			count: 2
+			path: tests/Integration/Libraries/H5P/h5pTest.php
+
+		-
+			message: "#^Parameter \\$share of class App\\\\Libraries\\\\DataObjects\\\\ResourceMetadataDataObject constructor expects string\\|null, true given\\.$#"
+			count: 2
+			path: tests/Integration/Libraries/QuestionSetConverterTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 4
+			path: tests/Integration/Models/CollaboratorContextTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 3
+			path: tests/Integration/Models/ContentAttributionTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:addAttributionOriginator\\(\\)\\.$#"
+			count: 4
+			path: tests/Integration/Models/ContentAttributionTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:getAttribution\\(\\)\\.$#"
+			count: 6
+			path: tests/Integration/Models/ContentAttributionTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:getAttributionAsString\\(\\)\\.$#"
+			count: 5
+			path: tests/Integration/Models/ContentAttributionTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:setAttribution\\(\\)\\.$#"
+			count: 3
+			path: tests/Integration/Models/ContentAttributionTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:setAttributionOrigin\\(\\)\\.$#"
+			count: 2
+			path: tests/Integration/Models/ContentAttributionTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Gametype\\>\\:\\:\\$id\\.$#"
+			count: 3
+			path: tests/Integration/Models/GametypeTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Gametype\\>\\:\\:\\$major_version\\.$#"
+			count: 1
+			path: tests/Integration/Models/GametypeTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Builder\\<App\\\\Gametype\\>\\:\\:\\$minor_version\\.$#"
+			count: 1
+			path: tests/Integration/Models/GametypeTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 3
+			path: tests/Integration/Models/GametypeTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$major_version\\.$#"
+			count: 1
+			path: tests/Integration/Models/GametypeTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$minor_version\\.$#"
+			count: 1
+			path: tests/Integration/Models/GametypeTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 2
+			path: tests/Integration/Models/H5PContentRequestShouldBecomeNewVersionTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 2
+			path: tests/Integration/Models/H5PContentRequestShouldBecomeNewVersionTest.php
+
+		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$title\\.$#"
+			count: 6
+			path: tests/Integration/Models/H5PContentRequestShouldBecomeNewVersionTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:getContentLicense\\(\\)\\.$#"
+			count: 9
+			path: tests/Integration/Models/H5PContentRequestShouldBecomeNewVersionTest.php
+
+		-
+			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:requestShouldBecomeNewVersion\\(\\)\\.$#"
+			count: 14
+			path: tests/Integration/Models/H5PContentRequestShouldBecomeNewVersionTest.php
+
+		-
+			message: "#^Call to an undefined method Tests\\\\TestCase\\:\\:setUpMockMQ\\(\\)\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Method Tests\\\\TestCase\\:\\:setUpTraits\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: tests/TestCase.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),object\\>\\:\\:transform\\(\\) expects callable\\(object, \\(int\\|string\\)\\)\\: object, Closure\\(mixed\\)\\: mixed given\\.$#"
+			count: 3
+			path: tests/Unit/Traits/H5PBehaviorSettingsTest.php

--- a/sourcecode/apis/contentauthor/phpstan.neon.dist
+++ b/sourcecode/apis/contentauthor/phpstan.neon.dist
@@ -1,0 +1,15 @@
+includes:
+    - vendor/nunomaduro/larastan/extension.neon
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - app
+        - bootstrap/app.php
+        - config
+        - database
+        - public/index.php
+        - resources/lang
+        - routes
+        - tests


### PR DESCRIPTION
Adds a Github action that runs PHPStan with a generated baseline. Some of the errors couldn't be committed to the baseline, and those have been fixed in this PR so we get an error-free run.

Worth noting that PHPStorm will detect PHPStan and attempt using it automatically.

(Needs to be rebased on master once #1266 is merged)