### PR TITLE
Remove unhelpful disabling of access logs

### DIFF
--- a/localSetup/projects/nginx/nginx-conf.d/doku.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/doku.conf
@@ -1,7 +1,6 @@
 server {
   listen       80;
   server_name  doku-api.local;
-  access_log   off;
 
   location / {
     set $upstream http://dokuapi;

--- a/localSetup/projects/nginx/nginx-conf.d/edlib-api.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/edlib-api.conf
@@ -12,7 +12,6 @@ server {
   ssl_certificate_key  /etc/ssl/private/cerpus.key;
 
   server_name  api.edlib.local;
-  access_log   off;
 
   location /resources {
     set $upstream  http://proxy-resource;

--- a/localSetup/projects/nginx/nginx-conf.d/edlib-internal-apis.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/edlib-internal-apis.conf
@@ -15,7 +15,6 @@ server {
   ssl_certificate_key  /etc/ssl/private/cerpus.key;
 
   server_name  edlib.internal.auth.local;
-  access_log   off;
 
   location / {
     set $upstream  http://authapi;
@@ -32,7 +31,6 @@ server {
   ssl_certificate_key  /etc/ssl/private/cerpus.key;
 
   server_name  edlib.internal.common.local;
-  access_log   off;
 
   location / {
     set $upstream  http://common;
@@ -49,7 +47,6 @@ server {
   ssl_certificate_key  /etc/ssl/private/cerpus.key;
 
   server_name  edlib.internal.resource.local;
-  access_log   off;
 
   location / {
     set $upstream  http://resourceapi;
@@ -66,7 +63,6 @@ server {
   ssl_certificate_key  /etc/ssl/private/cerpus.key;
 
   server_name  edlib.internal.doku.local;
-  access_log   off;
 
   location / {
     set $upstream  http://dokuapi;
@@ -83,7 +79,6 @@ server {
   ssl_certificate_key  /etc/ssl/private/cerpus.key;
 
   server_name  edlib.internal.lti.local;
-  access_log   off;
 
   location / {
     set $upstream  http://ltiapi;
@@ -100,7 +95,6 @@ server {
   ssl_certificate_key  /etc/ssl/private/cerpus.key;
 
   server_name  edlib.internal.url.local;
-  access_log   off;
 
   location / {
     set $upstream  http://urlapi;
@@ -117,7 +111,6 @@ server {
   ssl_certificate_key  /etc/ssl/private/cerpus.key;
 
   server_name  edlib.internal.version.local;
-  access_log   off;
 
   location / {
     set $upstream  http://versionapi;

--- a/localSetup/projects/nginx/nginx-conf.d/npm-components-storybook.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/npm-components-storybook.conf
@@ -12,7 +12,6 @@ server {
   ssl_certificate_key  /etc/ssl/private/cerpus.key;
 
   server_name  npm.components.edlib.local;
-  access_log   on;
 
   location /sockjs-node {
     set $upstream http://npm-components-storybook:9009;

--- a/localSetup/projects/nginx/nginx-conf.d/re-recommender.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/re-recommender.conf
@@ -1,7 +1,6 @@
 server {
   listen       80;
   server_name  re-recommender;
-  access_log   off;
 
   location / {
     set $upstream  http://re-recommender;
@@ -15,7 +14,6 @@ server {
 server {
   listen       80;
   server_name  re-content-index;
-  access_log   off;
 
   location / {
     set $upstream  http://re-content-index;

--- a/localSetup/projects/nginx/nginx-conf.d/www.conf
+++ b/localSetup/projects/nginx/nginx-conf.d/www.conf
@@ -12,7 +12,6 @@ server {
   ssl_certificate_key  /etc/ssl/private/cerpus.key;
 
   server_name  www.edlib.local;
-  access_log   off;
 
   location /ws {
     set $upstream  http://www:3001;

--- a/sourcecode/apis/contentauthor/docker/contentAuthor.conf.template
+++ b/sourcecode/apis/contentauthor/docker/contentAuthor.conf.template
@@ -10,12 +10,10 @@ server {
     client_max_body_size 2G;
 
     location / {
-        access_log off;
         try_files $uri $uri/ /index.php$is_args$args;
     }
 
     location ~ \.php$ {
-        access_log on;
         include fastcgi.conf;
         fastcgi_pass php;
         fastcgi_param  HTTPS 'on';


### PR DESCRIPTION
For whatever reason, the local nginx instances had access logs disabled in many cases. This only serves to make debugging harder, so we re-enable them.

There were also a few instances of `access_log on` which actually causes logs to be output to /etc/nginx/on instead of re-enabling logging to the previous used path. These are removed, too.