### PR TITLE
use bool for Content::$is_private

### DIFF
--- a/sourcecode/apis/contentauthor/app/Content.php
+++ b/sourcecode/apis/contentauthor/app/Content.php
@@ -28,8 +28,8 @@ use Illuminate\Support\Facades\Session;
  * @property Carbon $created_at
  * @property Carbon $updated_at
  * @property string $title
- * @property int $is_private
- * @property string $version_id
+ * @property bool $is_private
+ * @property string|null $version_id
  * @property int|null $max_score
  * @property int $bulk_calculated
  * @property bool $is_published
@@ -64,8 +64,13 @@ abstract class Content extends Model
     public string $editRouteName;
 
     protected $casts = [
+        'is_private' => 'boolean',
         'is_published' => 'boolean',
         'is_draft' => 'boolean',
+    ];
+
+    protected $attributes = [
+        'is_private' => false,
     ];
 
     public const RESOURCE_TYPE_CSS = '%s-resource';

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/API/ArticleInfoController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/API/ArticleInfoController.php
@@ -17,7 +17,7 @@ class ArticleInfoController extends Controller
                 return [
                     'id' => $article->id,
                     'owner_id' => $article->owner_id,
-                    'is_private' => (boolean)$article->is_private,
+                    'is_private' => $article->is_private,
                     'shares' => $article->collaborators->map(function($collaborator){
                         return [
                             'email' => $collaborator->email,

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/API/GameInfoController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/API/GameInfoController.php
@@ -18,7 +18,7 @@ class GameInfoController extends Controller
                 return [
                     'id' => $game->id,
                     'owner_id' => $game->owner,
-                    'is_private' => (boolean)$game->is_private,
+                    'is_private' => $game->is_private,
 //                    'shares' => $questionset->collaborators->map(function ($collaborator) {
 //                        return [
 //                            'email' => $collaborator->email,

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/API/H5PInfoController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/API/H5PInfoController.php
@@ -18,7 +18,7 @@ class H5PInfoController extends Controller
                 return [
                     'id' => $h5p->id,
                     'owner_id' => $h5p->user_id,
-                    'is_private' => (boolean)$h5p->is_private,
+                    'is_private' => $h5p->is_private,
                     'shares' => $h5p->collaborators->map(function ($collaborator) {
                         return [
                             'email' => $collaborator->email,

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/API/QuestionSetInfoController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/API/QuestionSetInfoController.php
@@ -17,7 +17,7 @@ class QuestionSetInfoController extends Controller
                 return [
                     'id' => $questionset->id,
                     'owner_id' => $questionset->owner,
-                    'is_private' => (boolean)$questionset->is_private,
+                    'is_private' => $questionset->is_private,
 //                    'shares' => $questionset->collaborators->map(function ($collaborator) {
 //                        return [
 //                            'email' => $collaborator->email,

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/H5PController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/H5PController.php
@@ -666,20 +666,6 @@ class H5PController extends Controller
     }
 
     /**
-     * Get content privacy status for h5p resource.
-     */
-    private function get_content_privacy(int $id): Response
-    {
-        $db = DB::connection()->getPdo();
-        $sql = 'SELECT is_private FROM h5p_contents WHERE id=:id';
-        $params = [':id' => $id];
-        $statement = $db->prepare($sql);
-        $statement->execute($params);
-        $result = $statement->fetch();
-        return $result['is_private'];
-    }
-
-    /**
      * Get content shares for h5p resource
      */
     private function get_content_shares(int $id): string

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Framework.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Framework.php
@@ -576,7 +576,7 @@ class Framework implements \H5PFrameworkInterface, Result
         $H5PContent->user_id = $content['user_id'];
         $H5PContent->content_create_mode = $adapter->getAdapterName();
         $H5PContent->is_published = $content['is_published'] ?? !$adapter->isUserPublishEnabled();
-        $H5PContent->is_private =  $content['is_private'] ?? 1;
+        $H5PContent->is_private = (bool) ($content['is_private'] ?? true);
         $H5PContent->is_draft =  $content['is_draft'] ?? 1;
         $H5PContent->language_iso_639_3 = $content['language_iso_639_3'] ?? null;
 

--- a/sourcecode/apis/contentauthor/database/factories/H5PContentFactory.php
+++ b/sourcecode/apis/contentauthor/database/factories/H5PContentFactory.php
@@ -24,7 +24,7 @@ class H5PContentFactory extends Factory
             'license' => '',
             'keywords' => null,
             'description' => null,
-            'is_private' => 1,
+            'is_private' => true,
             'version_id' => null,
             'max_score' => 0,
             'content_create_mode' => 'unitTest',

--- a/sourcecode/apis/contentauthor/database/migrations/2022_07_27_080000_add_is_private_to_links_table.php
+++ b/sourcecode/apis/contentauthor/database/migrations/2022_07_27_080000_add_is_private_to_links_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddIsPrivateToLinksTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('links', function (Blueprint $table) {
+            $table->boolean('is_private')->default(false);
+        });
+    }
+    
+    public function down(): void
+    {
+        Schema::table('links', function (Blueprint $table) {
+            $table->dropColumn('is_private');
+        });
+    }
+}

--- a/sourcecode/apis/contentauthor/phpstan-baseline.neon
+++ b/sourcecode/apis/contentauthor/phpstan-baseline.neon
@@ -6,11 +6,6 @@ parameters:
 			path: app/Article.php
 
 		-
-			message: "#^Property App\\\\Content\\:\\:\\$version_id \\(string\\) does not accept null\\.$#"
-			count: 1
-			path: app/Article.php
-
-		-
 			message: "#^Property App\\\\Auth\\\\Guards\\\\EdlibGuard\\:\\:\\$user \\(Illuminate\\\\Auth\\\\GenericUser\\|null\\) does not accept Illuminate\\\\Contracts\\\\Auth\\\\Authenticatable\\|null\\.$#"
 			count: 1
 			path: app/Auth/Guards/EdlibGuard.php
@@ -137,11 +132,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$json of function json_decode expects string, int\\<min, \\-1\\>\\|int\\<1, max\\> given\\.$#"
-			count: 1
-			path: app/H5PContent.php
-
-		-
-			message: "#^Property App\\\\Content\\:\\:\\$version_id \\(string\\) does not accept null\\.$#"
 			count: 1
 			path: app/H5PContent.php
 
@@ -421,11 +411,6 @@ parameters:
 			path: app/Http/Controllers/H5PController.php
 
 		-
-			message: "#^Method App\\\\Http\\\\Controllers\\\\H5PController\\:\\:get_content_privacy\\(\\) is unused\\.$#"
-			count: 1
-			path: app/Http/Controllers/H5PController.php
-
-		-
 			message: "#^Parameter \\#1 \\$config of method App\\\\Libraries\\\\H5P\\\\h5p\\:\\:createView\\(\\) expects App\\\\Libraries\\\\H5P\\\\Interfaces\\\\ConfigInterface, App\\\\Libraries\\\\H5P\\\\Config given\\.$#"
 			count: 1
 			path: app/Http/Controllers/H5PController.php
@@ -452,11 +437,6 @@ parameters:
 
 		-
 			message: "#^Parameter \\#2 \\$current of method H5PCore\\:\\:getStorableDisplayOptions\\(\\) expects int, null given\\.$#"
-			count: 1
-			path: app/Http/Controllers/H5PController.php
-
-		-
-			message: "#^Property App\\\\Content\\:\\:\\$is_private \\(int\\) does not accept bool\\.$#"
 			count: 1
 			path: app/Http/Controllers/H5PController.php
 
@@ -1562,16 +1542,6 @@ parameters:
 			path: app/Listeners/Article/HandleCollaborationInviteEmails.php
 
 		-
-			message: "#^Property App\\\\Content\\:\\:\\$is_private \\(int\\) does not accept bool\\.$#"
-			count: 1
-			path: app/Listeners/Article/HandlePrivacy.php
-
-		-
-			message: "#^Call to function is_null\\(\\) with string will always evaluate to false\\.$#"
-			count: 1
-			path: app/Listeners/Article/HandleVersioning.php
-
-		-
 			message: "#^Parameter \\#1 \\$externalReference of method Cerpus\\\\VersionClient\\\\VersionData\\:\\:setExternalReference\\(\\) expects null, string given\\.$#"
 			count: 1
 			path: app/Listeners/Article/HandleVersioning.php
@@ -1585,11 +1555,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$userId of method Cerpus\\\\VersionClient\\\\VersionData\\:\\:setUserId\\(\\) expects null, string given\\.$#"
 			count: 1
 			path: app/Listeners/Article/HandleVersioning.php
-
-		-
-			message: "#^Property App\\\\Content\\:\\:\\$is_private \\(int\\) does not accept bool\\.$#"
-			count: 1
-			path: app/Listeners/Game/HandlePrivacy.php
 
 		-
 			message: "#^Access to an undefined property App\\\\Libraries\\\\Versioning\\\\VersionableObject\\:\\:\\$id\\.$#"
@@ -1610,11 +1575,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$userId of method Cerpus\\\\VersionClient\\\\VersionData\\:\\:setUserId\\(\\) expects null, string given\\.$#"
 			count: 1
 			path: app/Listeners/H5P/HandleVersioning.php
-
-		-
-			message: "#^Property App\\\\Content\\:\\:\\$is_private \\(int\\) does not accept bool\\.$#"
-			count: 1
-			path: app/Listeners/Questionset/HandlePrivacy.php
 
 		-
 			message: "#^Call to an undefined method Illuminate\\\\Database\\\\Eloquent\\\\Builder\\:\\:h5p\\(\\)\\.$#"

--- a/sourcecode/apis/contentauthor/tests/Integration/Article/Handler/HandlePrivacyTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Article/Handler/HandlePrivacyTest.php
@@ -18,7 +18,7 @@ class HandlePrivacyTest extends TestCase
     {
         $authId = Str::uuid();
         $article = Article::factory()->create(['owner_id' => $authId]);
-        $this->assertNotEquals(1, $article->is_private);
+        $this->assertFalse($article->is_private);
 
         $request = new Request();
         $request->request->add(['share' => 'PRIVATE']);
@@ -26,7 +26,7 @@ class HandlePrivacyTest extends TestCase
         $privacyHandler = new HandlePrivacy();
         $privacyHandler->handle($articleSavedEvent);
         $article = $article->fresh();
-        $this->assertEquals(1, $article->is_private);
+        $this->assertTrue($article->is_private);
 
         $request = new Request();
         $request->request->add(['share' => 'share']);
@@ -34,6 +34,6 @@ class HandlePrivacyTest extends TestCase
         $privacyHandler = new HandlePrivacy();
         $privacyHandler->handle($articleSavedEvent);
         $article = $article->fresh();
-        $this->assertEquals(0, $article->is_private);
+        $this->assertFalse($article->is_private);
     }
 }

--- a/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/API/Handler/ContentTypeHandlerTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/API/Handler/ContentTypeHandlerTest.php
@@ -81,7 +81,7 @@ class ContentTypeHandlerTest extends TestCase
         $this->assertDatabaseHas('h5p_contents', [
             'title' => $title,
             'user_id' => $authId,
-            'is_private' => 1,
+            'is_private' => true,
             'max_score' => null,
             'bulk_calculated' => 0,
         ]);
@@ -93,7 +93,7 @@ class ContentTypeHandlerTest extends TestCase
         $this->assertDatabaseHas('h5p_contents', [
             'title' => $title,
             'user_id' => $authId,
-            'is_private' => 1,
+            'is_private' => true,
             'max_score' => null,
             'bulk_calculated' => 0,
         ]);
@@ -156,7 +156,7 @@ class ContentTypeHandlerTest extends TestCase
         $this->assertDatabaseHas('h5p_contents', [
             'title' => $title,
             'user_id' => $authId,
-            'is_private' => 1,
+            'is_private' => true,
             'is_published' => 0,
             'max_score' => null,
             'bulk_calculated' => 0,
@@ -169,7 +169,7 @@ class ContentTypeHandlerTest extends TestCase
         $this->assertDatabaseHas('h5p_contents', [
             'title' => $title,
             'user_id' => $authId,
-            'is_private' => 1,
+            'is_private' => true,
             'max_score' => null,
             'bulk_calculated' => 0,
             'is_published' => 0,
@@ -220,13 +220,13 @@ class ContentTypeHandlerTest extends TestCase
 
         $content = $handler->storeQuestionset($questionset->toArray());
         $this->assertNotEmpty($content);
-        $this->assertDatabaseHas('h5p_contents', ["title" => $title, 'user_id' => $authId, 'is_private' => 1, 'max_score' => 2]);
+        $this->assertDatabaseHas('h5p_contents', ["title" => $title, 'user_id' => $authId, 'is_private' => true, 'max_score' => 2]);
         $this->assertArrayHasKey("id", $content);
 
         $questionset->setSharing(true);
         $content = $handler->storeQuestionset($questionset->toArray());
         $this->assertNotEmpty($content);
-        $this->assertDatabaseHas('h5p_contents', ["title" => $title, 'user_id' => $authId, 'is_private' => 0, 'max_score' => 2]);
+        $this->assertDatabaseHas('h5p_contents', ["title" => $title, 'user_id' => $authId, 'is_private' => false, 'max_score' => 2]);
         $this->assertArrayHasKey("id", $content);
     }
 }


### PR DESCRIPTION
Make `App\Content::$is_private` a bool instead of using 0 and 1.

This also fixes an issue where $isPrivate initialised to null, which isn't valid for the column. Since the `links` table didn't have an `is_private` column, it was added so the `App\Link` model, which inherits from `App\Content`, works correctly.