### PR TITLE
Improvements to contribution docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,7 @@
 # Contributing to the Edlib Open Source Project
 
-Cerpus welcomes contributions to our [open source projects on Github](https://github.com/cerpus/Edlib). When contributing, please follow the [Cerpus Community Code of Conduct](CODE_OF_CONDUCT.md).
+Cerpus welcomes contributions to our [open source projects on Github][1]. You
+can [learn more about contributing][2] on our documentation website.
 
-## Issues
-
-Feel free to submit [issues and enhancement](https://github.com/cerpus/Edlib/issues) requests.
-
-## Contributing
-
-Please refer to each project's style and contribution guidelines for submitting patches and additions. In general, we follow the "fork-and-pull" Git workflow.
-
- 1. **Fork** the repo on GitHub.
- 2. **Clone** the project to your own machine.
- 3. **Commit** changes to your own branch.
- 4. **Push** your work back up to your fork.
- 5. Submit a **Pull request** so that we can review your changes.
-
-NOTE: Be sure to merge the latest from "upstream" before making a pull request!
-
-## Copyright and Licensing
-
-Edlib is licensed under the [GPL 3.0 license](https://www.gnu.org/licenses/gpl-3.0-standalone.html).
-
-Cerpus does not require you to assign the copyright of your contributions, you retain the copyright. Cerpus does require that you make your contributions available under the Apache GPL 3.0 license in order for it be included in the main repo.
-
-If appropriate, include the GPL 3.0 license summary at the top of each file along with the copyright info. If you are adding a new file that you wrote, include your name in the copyright notice in the license summary at the top of the file.
+[1]: https://github.com/cerpus/
+[2]: https://docs.edlib.com/docs/developers/contributing/

--- a/sourcecode/docs/docs.edlib.com/docs/developers/contributing/contributing.mdx
+++ b/sourcecode/docs/docs.edlib.com/docs/developers/contributing/contributing.mdx
@@ -45,3 +45,11 @@ To ease review, try to limit your commits to a single, self-contained issue. Thi
 :::
 
 For more information and tips on how to write good commit messages, see the GitHub [guide](https://github.com/erlang/otp/wiki/writing-good-commit-messages).
+
+## Copyright and Licensing
+
+Edlib is licensed under the [GNU General Public License, version 3.0](https://www.gnu.org/licenses/gpl-3.0-standalone.html).
+
+Cerpus does not require you to assign the copyright of your contributions, you retain the copyright. Cerpus does require that you make your contributions available under the GNU GPL 3.0 license in order for it be included in the main repo.
+
+If appropriate, include the GNU GPL 3.0 license summary at the top of each file along with the copyright info. If you are adding a new file that you wrote, include your name in the copyright notice in the license summary at the top of the file.


### PR DESCRIPTION
* Remove information in CONTRIBUTING.md that's redundant with the documentation, direct readers to documentation instead.

* Fix strange reference to "Apache GPL"