### PR TITLE
common api: don't overwrite default nginx vhost

### DIFF
--- a/sourcecode/apis/common/Dockerfile
+++ b/sourcecode/apis/common/Dockerfile
@@ -65,7 +65,7 @@ ENV APP_ENV=production \
 FROM nginx:1.19-alpine AS web
 ENV PHP_FPM_HOST "localhost:9000"
 COPY --from=base /var/www/edlibcommon/public /var/www/edlibcommon/public
-COPY docker/nginx/common.conf.template /etc/nginx/templates/default.conf.template
+COPY docker/nginx/common.conf.template /etc/nginx/templates/common.conf.template
 
 FROM prod AS deploy
 CMD [ "php", "artisan", "migrate", "--force" ]


### PR DESCRIPTION
Fixes healthcheck, which relies on nginx's placeholder page.