### PR TITLE
Fix H5PFrameworkInterface::loadLibrary

### DIFF
--- a/sourcecode/apis/contentauthor/app/H5PLibrary.php
+++ b/sourcecode/apis/contentauthor/app/H5PLibrary.php
@@ -4,6 +4,7 @@ namespace App;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -71,7 +72,7 @@ class H5PLibrary extends Model
         return $this->hasMany(H5PLibraryLanguage::class, 'library_id');
     }
 
-    public function libraries()
+    public function libraries(): HasMany
     {
         return $this->hasMany(H5PLibraryLibrary::class, 'library_id');
     }

--- a/sourcecode/apis/contentauthor/app/H5PLibrary.php
+++ b/sourcecode/apis/contentauthor/app/H5PLibrary.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Builder;
@@ -9,8 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Storage;
 
 /**
- * Class H5PLibrary
- * @package App
+ * @property-read Collection<array-key, H5PLibraryLibrary> $libraries
  *
  * @see H5PLibrary::scopeFromLibrary()
  * @method static Builder fromLibrary($value)

--- a/sourcecode/apis/contentauthor/app/H5PLibraryLibrary.php
+++ b/sourcecode/apis/contentauthor/app/H5PLibraryLibrary.php
@@ -2,9 +2,15 @@
 
 namespace App;
 
-
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
+/**
+ * @property string $dependency_type
+ * @property-read H5PLibrary $library
+ * @property-read H5PLibrary $requiredLibrary
+ */
 class H5PLibraryLibrary extends Model
 {
     protected $table = 'h5p_libraries_libraries';
@@ -13,4 +19,13 @@ class H5PLibraryLibrary extends Model
 
     public $timestamps = false;
 
+    public function library(): BelongsTo
+    {
+        return $this->belongsTo(H5PLibrary::class, 'id', 'library_id');
+    }
+
+    public function requiredLibrary(): HasOne
+    {
+        return $this->hasOne(H5PLibrary::class, 'id', 'required_library_id');
+    }
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Framework.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Framework.php
@@ -856,85 +856,43 @@ class Framework implements \H5PFrameworkInterface, Result
         return $usage;
     }
 
-    /**
-     * Loads a library
-     *
-     * @param string $machineName
-     *   The library's machine name
-     * @param int $majorVersion
-     *   The library's major version
-     * @param int $minorVersion
-     *   The library's minor version
-     * @return array|FALSE
-     *   FALSE if the library doesn't exist.
-     *   Otherwise an associative array containing:
-     *   - libraryId: The id of the library if it is an existing library.
-     *   - title: The library's name
-     *   - machineName: The library machineName
-     *   - majorVersion: The library's majorVersion
-     *   - minorVersion: The library's minorVersion
-     *   - patchVersion: The library's patchVersion
-     *   - runnable: 1 if the library is a content type, 0 otherwise
-     *   - fullscreen(optional): 1 if the library supports fullscreen, 0 otherwise
-     *   - embedTypes(optional): list of supported embed types
-     *   - preloadedJs(optional): comma separated string with js file paths
-     *   - preloadedCss(optional): comma separated sting with css file paths
-     *   - dropLibraryCss(optional): list of associative arrays containing:
-     *     - machineName: machine name for the librarys that are to drop their css
-     *   - semantics(optional): Json describing the content structure for the library
-     *   - preloadedDependencies(optional): list of associative arrays containing:
-     *     - machineName: Machine name for a library this library is depending on
-     *     - majorVersion: Major version for a library this library is depending on
-     *     - minorVersion: Minor for a library this library is depending on
-     *   - dynamicDependencies(optional): list of associative arrays containing:
-     *     - machineName: Machine name for a library this library is depending on
-     *     - majorVersion: Major version for a library this library is depending on
-     *     - minorVersion: Minor for a library this library is depending on
-     *   - editorDependencies(optional): list of associative arrays containing:
-     *     - machineName: Machine name for a library this library is depending on
-     *     - majorVersion: Major version for a library this library is depending on
-     *     - minorVersion: Minor for a library this library is depending on
-     * TODO: handle dependencies too...
-     */
-    public function loadLibrary($machineName, $majorVersion, $minorVersion)
+    public function loadLibrary($machineName, $majorVersion, $minorVersion): array|false
     {
-        $sql = "select
-            id as libraryId,
-            title as title,
-            name as machineName,
-            major_version as majorVersion,
-            minor_version as minorVersion,
-            patch_version as patchVersion,
-            runnable,
-            fullscreen,
-            embed_types as embedTypes,
-            preloaded_js as preloadedJs,
-            preloaded_css as preloadedCss,
-            drop_library_css as dropLibraryCss,
-            semantics
-        from h5p_libraries
-        where
-            name = ?
-            and major_version = ?
-            and minor_version = ?";
+        $h5pLibrary = H5PLibrary::with(['libraries' => ['requiredLibrary']])
+            ->where([
+                'name' => $machineName,
+                'major_version' => $majorVersion,
+                'minor_version' => $minorVersion,
+            ])
+            ->orderBy('patch_version', 'desc')
+            ->first();
 
-        $libraryStatement = $this->db->prepare($sql);
-        $libraryStatement->execute([$machineName, $majorVersion, $minorVersion]);
-        $library = $libraryStatement->fetch(PDO::FETCH_ASSOC);
+        if (!$h5pLibrary instanceof H5PLibrary) {
+            return false;
+        }
 
-        $dependenciesStatement = $this->db->prepare(
-            "SELECT hl.name as machineName, hl.major_version as majorVersion, hl.minor_version as minorVersion, hll.dependency_type as dependencyType
-        FROM h5p_libraries_libraries hll
-        JOIN h5p_libraries hl ON hll.required_library_id = hl.id
-        WHERE hll.library_id = ?");
-        $dependenciesStatement->execute([$library['libraryId']]);
-        $dependencies = $dependenciesStatement->fetchAll(PDO::FETCH_OBJ);
-        foreach ($dependencies as $dependency) {
-            $library[$dependency->dependencyType . 'Dependencies'][] = array(
-                'machineName' => $dependency->machineName,
-                'majorVersion' => $dependency->majorVersion,
-                'minorVersion' => $dependency->minorVersion,
-            );
+        $library = [
+            'libraryId' => $h5pLibrary->id,
+            'title' => $h5pLibrary->title,
+            'machineName' => $h5pLibrary->name,
+            'majorVersion' => $h5pLibrary->major_version,
+            'minorVersion' => $h5pLibrary->minor_version,
+            'patchVersion' => $h5pLibrary->patch_version,
+            'runnable' => $h5pLibrary->runnable,
+            'fullscreen' => $h5pLibrary->fullscreen,
+            'embedTypes' => $h5pLibrary->embed_types,
+            'preloadedJs' => $h5pLibrary->preloaded_js,
+            'preloadedCss' => $h5pLibrary->preloaded_css,
+            'dropLibraryCss' => $h5pLibrary->drop_library_css,
+            'semantics' => $h5pLibrary->semantics,
+        ];
+
+        foreach ($h5pLibrary->libraries as $dependency) {
+            $library[$dependency->dependency_type . 'Dependencies'][] = [
+                'machineName' => $dependency->requiredLibrary->name,
+                'majorVersion' => $dependency->requiredLibrary->major_version,
+                'minorVersion' => $dependency->requiredLibrary->minor_version,
+            ];
         }
 
         return $library;

--- a/sourcecode/apis/contentauthor/phpstan-baseline.neon
+++ b/sourcecode/apis/contentauthor/phpstan-baseline.neon
@@ -1112,6 +1112,11 @@ parameters:
 			path: app/Libraries/H5P/Framework.php
 
 		-
+			message: "#^Parameter \\#1 \\$relations of static method Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:with\\(\\) expects array\\<int\\|string, Closure\\|string\\>\\|string, array\\{libraries\\: array\\{'requiredLibrary'\\}\\} given\\.$#"
+			count: 1
+			path: app/Libraries/H5P/Framework.php
+
+		-
 			message: "#^Parameter \\#2 \\$replacements \\(App\\\\Libraries\\\\H5P\\\\type\\) of method App\\\\Libraries\\\\H5P\\\\Framework\\:\\:t\\(\\) should be compatible with parameter \\$replacements \\(array\\) of method H5PFrameworkInterface\\:\\:t\\(\\)$#"
 			count: 1
 			path: app/Libraries/H5P/Framework.php


### PR DESCRIPTION
H5PFrameworkInterface::loadLibrary requires that FALSE be returned if a library cannot be loaded, but our implementation in App\Libraries\H5P\Framework would assume the existence of a database entry, causing errors. This PR fixes that, and also replaces the use of PDO/SQL with much simpler use of Eloquent.