### PR TITLE
Refactor handling of H5PFrameworkInterface messages

### DIFF
--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Framework.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Framework.php
@@ -21,6 +21,7 @@ use H5PCore;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Request;
+use InvalidArgumentException;
 use PDO;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Process\Exception\RuntimeException;
@@ -28,8 +29,12 @@ use TypeError;
 
 class Framework implements \H5PFrameworkInterface, Result
 {
-    private $errorMessages;
-    private $infoMessage;
+    /** @var array<string> */
+    private array $errorMessages = [];
+
+    /** @var array<string> */
+    private array $infoMessages = [];
+
     private $adminUrl;
 
     public function __construct(
@@ -165,68 +170,24 @@ class Framework implements \H5PFrameworkInterface, Result
         }
     }
 
-    /**
-     * Show the user an error message
-     *
-     * @param string $message
-     *   The error message
-     *
-     */
-    public function setErrorMessage($message, $code = null)
+    public function setErrorMessage($message, $code = null): void
     {
+        // It isn't clear how $code should be used, so we just ignore it.
         $this->errorMessages[] = $message;
     }
 
-    /**
-     * Get error message
-     *
-     * @return string The error message, empty string if no message exist
-     *
-     */
-
-    public function getErrorMessage($asString = true)
+    public function setInfoMessage($message): void
     {
-        return $asString === true ? implode(" ", $this->errorMessages) : $this->errorMessages;
+        $this->infoMessages[] = $message;
     }
 
-    /**
-     * Get error message
-     *
-     * @return string The error message, empty string if no message exist
-     *
-     */
-
-    public function getErrorMessages()
+    public function getMessages($type): array
     {
-        return $this->getErrorMessage(false);
-    }
-
-    /**
-     * Show the user an information message
-     *
-     * @param string $message
-     *  The error message
-     */
-    public function setInfoMessage($message)
-    {
-        $this->infoMessage = $message;
-    }
-
-    /**
-     * Get info message
-     *
-     * @return string The info message, empty string if no message exist
-     *
-     */
-
-    public function getInfoMessage()
-    {
-        return $this->infoMessage;
-    }
-
-    public function getMessages($type)
-    {
-        return $this->infoMessage;
+        return match ($type) {
+            'info' => $this->infoMessages,
+            'error' => $this->errorMessages,
+            default => throw new InvalidArgumentException('Unknown message type'),
+        };
     }
 
     /**

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PImport.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PImport.php
@@ -38,7 +38,7 @@ class H5PImport
         };
 
         if (!$this->isPackageValid()) {
-            throw new H5pImportException($core->h5pF->getErrorMessage());
+            throw new H5pImportException(implode('; ', $core->h5pF->getMessages('error')));
         }
 
         $displayOptions = $core->getDisplayOptionsForEdit();

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PLibraryAdmin.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PLibraryAdmin.php
@@ -48,7 +48,7 @@ class H5PLibraryAdmin
             @unlink($this->framework->getUploadedH5pPath());
 
             throw new InvalidH5pPackageException(
-                (array) $this->validator->h5pF->getErrorMessages(),
+                $this->validator->h5pF->getMessages('error'),
             );
         }
 

--- a/sourcecode/apis/contentauthor/tests/Unit/Libraries/H5P/FrameworkTest.php
+++ b/sourcecode/apis/contentauthor/tests/Unit/Libraries/H5P/FrameworkTest.php
@@ -104,4 +104,38 @@ final class FrameworkTest extends TestCase
 
         $this->framework->fetchExternalData('http://www.example.com');
     }
+
+    public function testGetInfoMessages(): void
+    {
+        $this->assertSame([], $this->framework->getMessages('info'));
+    }
+
+    public function testAddInfoMessage(): void
+    {
+        $this->framework->setInfoMessage('this is some info');
+        $this->framework->setInfoMessage('this is more info');
+        $this->framework->setErrorMessage('this is not info');
+
+        $this->assertSame([
+            'this is some info',
+            'this is more info',
+        ], $this->framework->getMessages('info'));
+    }
+
+    public function testGetErrorMessages(): void
+    {
+        $this->assertSame([], $this->framework->getMessages('error'));
+    }
+
+    public function testAddErrorMessage(): void
+    {
+        $this->framework->setErrorMessage('this is an error');
+        $this->framework->setErrorMessage('this is another error');
+        $this->framework->setInfoMessage('this is not an error');
+
+        $this->assertSame([
+            'this is an error',
+            'this is another error',
+        ], $this->framework->getMessages('error'));
+    }
 }

--- a/sourcecode/apis/contentauthor/tests/Unit/Libraries/H5P/FrameworkTest.php
+++ b/sourcecode/apis/contentauthor/tests/Unit/Libraries/H5P/FrameworkTest.php
@@ -14,6 +14,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Contracts\Filesystem\Filesystem;
+use InvalidArgumentException;
 use PDO;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
@@ -137,5 +138,12 @@ final class FrameworkTest extends TestCase
             'this is an error',
             'this is another error',
         ], $this->framework->getMessages('error'));
+    }
+
+    public function testGetMessagesOfUnknownType(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->framework->getMessages('unknown');
     }
 }


### PR DESCRIPTION
* Remove implementation-specific methods that could cause warnings about polymorphic calls.
* Turn `setInfoMessage`/`setErrorMessage` into adder methods (I think this was the interface's intention anyway, the methods are just named incorrectly)
* Make `getMessages` adhere to the interface.