### PR TITLE
remove unnecessary class/package annotations

### DIFF
--- a/sourcecode/apis/contentauthor/app/Article.php
+++ b/sourcecode/apis/contentauthor/app/Article.php
@@ -21,9 +21,6 @@ use Iso639p3;
 use Ramsey\Uuid\Uuid;
 
 /**
- * Class Article
- * @package App
- *
  * @property string $id
  * @property string $parent_id
  * @property string $parent_version_id

--- a/sourcecode/apis/contentauthor/app/Content.php
+++ b/sourcecode/apis/contentauthor/app/Content.php
@@ -24,9 +24,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Session;
 
 /**
- * Class Content
- * @package App
- *
  * @property string|int $id
  * @property Carbon $created_at
  * @property Carbon $updated_at

--- a/sourcecode/apis/contentauthor/app/Game.php
+++ b/sourcecode/apis/contentauthor/app/Game.php
@@ -13,9 +13,6 @@ use Illuminate\Http\Request;
 use Iso639p3;
 
 /**
- * Class Game
- * @package App
- *
  * @property string $id
  * @property string $gametype
  * @property string $language_code

--- a/sourcecode/apis/contentauthor/app/H5PContent.php
+++ b/sourcecode/apis/contentauthor/app/H5PContent.php
@@ -20,9 +20,6 @@ use Illuminate\Support\Str;
 use Iso639p3;
 
 /**
- * Class H5PContent
- * @package App
- *
  * @property string $user_id
  * @property int $library_id
  * @property string $parameters

--- a/sourcecode/apis/contentauthor/app/H5PContentsMetadata.php
+++ b/sourcecode/apis/contentauthor/app/H5PContentsMetadata.php
@@ -7,9 +7,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Class H5PContentsMetadata
- * @package App
- *
  * @method static self make(array $attributes = [])
  */
 class H5PContentsMetadata extends Model

--- a/sourcecode/apis/contentauthor/app/H5PFile.php
+++ b/sourcecode/apis/contentauthor/app/H5PFile.php
@@ -6,9 +6,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Class H5PFile
- * @package App
- *
  * @method static null|Builder ofFileUploadFromRequestId($requestId)
  * @method static null|Builder ofFileUploadFromContent($contentId)
  */

--- a/sourcecode/apis/contentauthor/app/Http/Libraries/ContentTypes/ContentType.php
+++ b/sourcecode/apis/contentauthor/app/Http/Libraries/ContentTypes/ContentType.php
@@ -6,9 +6,6 @@ namespace App\Http\Libraries\ContentTypes;
 use Cerpus\Helper\Traits\CreateTrait;
 
 /**
- * Class ContentType
- * @package App\Http\Libraries\ContentTypes
- *
  * @method static ContentType create($title, $createUrl, $id, $description, $icon, $mainContentType)
  */
 class ContentType

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/ArticleStateDataObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/ArticleStateDataObject.php
@@ -7,9 +7,6 @@ namespace App\Libraries\DataObjects;
 use Cerpus\Helper\Traits\CreateTrait;
 
 /**
- * Class H5PStateDataObject
- * @package App\Libraries\DataObjects
- *
  * @method static ArticleStateDataObject create($attributes = null)
  */
 class ArticleStateDataObject extends ContentStateDataObject

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/ContentLockDataObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/ContentLockDataObject.php
@@ -7,9 +7,6 @@ namespace App\Libraries\DataObjects;
 use Cerpus\Helper\Traits\CreateTrait;
 
 /**
- * Class ContentLockDataObject
- * @package App\Libraries\DataObjects
- *
  * @method static ContentLockDataObject create($attributes = null)
  */
 class ContentLockDataObject

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/ContentStorageSettings.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/ContentStorageSettings.php
@@ -2,11 +2,6 @@
 
 namespace App\Libraries\DataObjects;
 
-/**
- * Class ContentStorageSettings
- * @package App\Libraries\DataObjects
- *
- */
 class ContentStorageSettings
 {
     const STORAGE_PREFIX = 'h5p/';

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/EditorConfigObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/EditorConfigObject.php
@@ -7,9 +7,6 @@ namespace App\Libraries\DataObjects;
 use Cerpus\Helper\Traits\CreateTrait;
 
 /**
- * Class EditorConfigObject
- * @package App\Libraries\DataObjects
- *
  * @method static EditorConfigObject create($attributes = null)
  */
 class EditorConfigObject

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/EmbedStateDataObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/EmbedStateDataObject.php
@@ -7,9 +7,6 @@ namespace App\Libraries\DataObjects;
 use Cerpus\Helper\Traits\CreateTrait;
 
 /**
- * Class H5PStateDataObject
- * @package App\Libraries\DataObjects
- *
  * @method static EmbedStateDataObject create($attributes = null)
  */
 class EmbedStateDataObject extends ContentStateDataObject

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/H5PEditorConfigObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/H5PEditorConfigObject.php
@@ -7,9 +7,6 @@ namespace App\Libraries\DataObjects;
 use Cerpus\Helper\Traits\CreateTrait;
 
 /**
- * Class H5PEditorConfigObject
- * @package App\Libraries\DataObjects
- *
  * @method static H5PEditorConfigObject create($attributes = null)
  */
 class H5PEditorConfigObject extends EditorConfigObject

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/H5PStateDataObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/H5PStateDataObject.php
@@ -7,9 +7,6 @@ namespace App\Libraries\DataObjects;
 use Cerpus\Helper\Traits\CreateTrait;
 
 /**
- * Class H5PStateDataObject
- * @package App\Libraries\DataObjects
- *
  * @method static H5PStateDataObject create($attributes = null)
  */
 class H5PStateDataObject extends ContentStateDataObject

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/LockedDataObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/LockedDataObject.php
@@ -7,9 +7,6 @@ namespace App\Libraries\DataObjects;
 use Cerpus\Helper\Traits\CreateTrait;
 
 /**
- * Class LockedDataObject
- * @package App\Libraries\DataObjects
- *
  * @method static LockedDataObject create($attributes = null)
  */
 class LockedDataObject

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/QuestionSetStateDataObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/QuestionSetStateDataObject.php
@@ -7,9 +7,6 @@ namespace App\Libraries\DataObjects;
 use Cerpus\Helper\Traits\CreateTrait;
 
 /**
- * Class H5PStateDataObject
- * @package App\Libraries\DataObjects
- *
  * @method static QuestionSetStateDataObject create($attributes = null)
  */
 class QuestionSetStateDataObject extends ContentStateDataObject

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/ResourceInfoDataObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/ResourceInfoDataObject.php
@@ -6,9 +6,6 @@ namespace App\Libraries\DataObjects;
 use Cerpus\Helper\Traits\CreateTrait;
 
 /**
- * Class ResourceInfoDataObject
- * @package App\Libraries\DataObjects
- *
  * @method static ResourceInfoDataObject create($attributes = null)
  */
 class ResourceInfoDataObject

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/ResourceUserDataObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/ResourceUserDataObject.php
@@ -6,9 +6,6 @@ namespace App\Libraries\DataObjects;
 use Cerpus\Helper\Traits\CreateTrait;
 
 /**
- * Class ResourceUserDataObject
- * @package App\Libraries\DataObjects
- *
  * @method static ResourceUserDataObject create($attributes = null)
  */
 class ResourceUserDataObject

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Dataobjects/H5PAlterParametersSettingsDataObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Dataobjects/H5PAlterParametersSettingsDataObject.php
@@ -7,9 +7,6 @@ namespace App\Libraries\H5P\Dataobjects;
 use Cerpus\Helper\Traits\CreateTrait;
 
 /**
- * Class H5PAlterParametersSettingsDataObject
- * @package App\Libraries\H5P\Dataobjects
- *
  * @method static H5PAlterParametersSettingsDataObject create($attributes = null)
  */
 class H5PAlterParametersSettingsDataObject

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Dataobjects/H5PCopyrightDataObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Dataobjects/H5PCopyrightDataObject.php
@@ -7,9 +7,6 @@ namespace App\Libraries\H5P\Dataobjects;
 use Cerpus\Helper\Traits\CreateTrait;
 
 /**
- * Class H5PCopyrightDataObject
- * @package App\Libraries\H5P\Dataobjects
- *
  * @method static H5PCopyrightDataObject create($attributes = null)
  */
 class H5PCopyrightDataObject

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Dataobjects/H5PImportDataObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Dataobjects/H5PImportDataObject.php
@@ -7,9 +7,6 @@ namespace App\Libraries\H5P\Dataobjects;
 use Cerpus\Helper\Traits\CreateTrait;
 
 /**
- * Class H5PImportDataObject
- * @package App\Libraries\H5P\Dataobjects
- *
  * @method static H5PImportDataObject create($h5pId = null, $h5pType = null, $title = null, $maxScore = null)
  */
 class H5PImportDataObject

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Dataobjects/H5PMetadataObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Dataobjects/H5PMetadataObject.php
@@ -5,9 +5,6 @@ namespace App\Libraries\H5P\Dataobjects;
 use Cerpus\Helper\Traits\CreateTrait;
 
 /**
- * Class H5PMetadataObject
- * @package App\Libraries\H5P\Dataobjects
- *
  * @method static H5PMetadataObject create($attributes = null)
  */
 class H5PMetadataObject

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Dataobjects/H5PTranslationDataObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Dataobjects/H5PTranslationDataObject.php
@@ -7,9 +7,6 @@ namespace App\Libraries\H5P\Dataobjects;
 use Cerpus\Helper\Traits\CreateTrait;
 
 /**
- * Class H5PTranslationDataObject
- * @package App\Libraries\H5P\Dataobjects
- *
  * @method static H5PTranslationDataObject create($attributes = null)
  */
 class H5PTranslationDataObject

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/H5PBase.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/H5PBase.php
@@ -9,9 +9,6 @@ use Cerpus\CoreClient\DataObjects\BehaviorSettingsDataObject;
 use Cerpus\CoreClient\DataObjects\EditorBehaviorSettingsDataObject;
 
 /**
- * Class H5PBase
- * @package App\Libraries\H5P\Packages
- *
  * @method applyEditorBehaviorSettings(EditorBehaviorSettingsDataObject $settingsDataObject)
  * @method applyBehaviorSettings(BehaviorSettingsDataObject $settingsDataObject)
  * @method getPackageStructure($asJson = false)

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Traits/FileUploadTrait.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Traits/FileUploadTrait.php
@@ -11,9 +11,6 @@ use App\Libraries\H5P\Interfaces\H5PFileInterface;
 use Carbon\Carbon;
 
 /**
- * Trait FileUploadTrait
- * @package App\Traits
- *
  * @method release($delay = 0)
  */
 trait FileUploadTrait

--- a/sourcecode/apis/contentauthor/app/Libraries/oAuthLTI/OAuthRequest.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/oAuthLTI/OAuthRequest.php
@@ -1,10 +1,6 @@
 <?php
 namespace App\Libraries\oAuthLTI;
 
-/**
- * Class OAuthRequest
- * @package App\Http\Controllers\oAuthLTI
- */
 class OAuthRequest
 {
     /**

--- a/sourcecode/apis/contentauthor/app/Link.php
+++ b/sourcecode/apis/contentauthor/app/Link.php
@@ -10,9 +10,6 @@ use Illuminate\Http\Request;
 use Iso639p3;
 
 /**
- * Class Link
- * @package App
- *
  * @property string $id
  * @property string $link_url
  * @property string $link_type

--- a/sourcecode/apis/contentauthor/app/NdlaIdMapper.php
+++ b/sourcecode/apis/contentauthor/app/NdlaIdMapper.php
@@ -6,9 +6,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Builder;
 
 /**
- * Class NdlaIdMapper
- * @package App
- *
  * @property int|null $metadata_fetch
  *
  * @method static Builder withH5PMetadata()

--- a/sourcecode/apis/contentauthor/app/QuestionSet.php
+++ b/sourcecode/apis/contentauthor/app/QuestionSet.php
@@ -11,9 +11,6 @@ use Illuminate\Http\Request;
 use Iso639p3;
 
 /**
- * Class QuestionSet
- * @package App
- *
  * @property string $language_code
  * @property string $owner
  * @property string $external_reference

--- a/sourcecode/apis/contentauthor/app/SessionKeys.php
+++ b/sourcecode/apis/contentauthor/app/SessionKeys.php
@@ -3,9 +3,6 @@
 namespace App;
 
 /**
- * Class SessionKeys
- * @package App
- *
  * A central place to name session keys, use if one key is used in more than one source file.
  */
 class SessionKeys

--- a/sourcecode/apis/contentauthor/app/Traits/Attributable.php
+++ b/sourcecode/apis/contentauthor/app/Traits/Attributable.php
@@ -6,9 +6,7 @@ use App\ContentAttribution;
 use App\Libraries\DataObjects\Attribution;
 
 /**
- * Trait HasAttribution
  * Provides easy access to our current implementation of Attributions.
- * @package App\Traits
  */
 trait Attributable
 {

--- a/sourcecode/apis/contentauthor/app/Traits/HasLanguage.php
+++ b/sourcecode/apis/contentauthor/app/Traits/HasLanguage.php
@@ -6,9 +6,6 @@ use Illuminate\Support\Facades\Session;
 use App\ContentLanguage;
 
 /**
- * Trait HasLanguage
- * @package App\Traits
- *
  * @property string|int $id
  */
 trait HasLanguage

--- a/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/API/H5PImportControllerTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/API/H5PImportControllerTest.php
@@ -34,10 +34,6 @@ namespace Tests\Integration\Libraries\H5P\API {
     use function base_path;
     use function fopen;
 
-    /**
-     * Class H5PImportControllerTest
-     * @package Tests\H5P\API
-     */
     class H5PImportControllerTest extends TestCase
     {
         use RefreshDatabase, MockVersioningTrait, WithFaker;


### PR DESCRIPTION
These annotations serve no purpose and are highly likely to be cargo-culted by inexperienced contributors, so let's get rid of them.