### PR TITLE
Use class literals

### DIFF
--- a/sourcecode/apis/contentauthor/app/Article.php
+++ b/sourcecode/apis/contentauthor/app/Article.php
@@ -59,7 +59,7 @@ class Article extends Content implements VersionableObject
 
     public function collaborators()
     {
-        return $this->hasMany('App\ArticleCollaborator');
+        return $this->hasMany(ArticleCollaborator::class);
     }
 
     public function files()

--- a/sourcecode/apis/contentauthor/app/H5PContent.php
+++ b/sourcecode/apis/contentauthor/app/H5PContent.php
@@ -65,7 +65,7 @@ class H5PContent extends Content implements VersionableObject
 
     public function collaborators(): HasMany
     {
-        return $this->hasMany('App\H5PCollaborator', 'h5p_id');
+        return $this->hasMany(H5PCollaborator::class, 'h5p_id');
     }
 
     public function library()

--- a/sourcecode/apis/contentauthor/app/H5PLibrary.php
+++ b/sourcecode/apis/contentauthor/app/H5PLibrary.php
@@ -55,12 +55,12 @@ class H5PLibrary extends Model
 
     public function capability()
     {
-        return $this->hasOne('App\H5PLibraryCapability', 'library_id');
+        return $this->hasOne(H5PLibraryCapability::class, 'library_id');
     }
 
     public function description()
     {
-        return $this->hasOne('App\LibraryDescription', 'library_id');
+        return $this->hasOne(LibraryDescription::class, 'library_id');
     }
 
     public function contents()

--- a/sourcecode/apis/contentauthor/app/H5PLibraryCapability.php
+++ b/sourcecode/apis/contentauthor/app/H5PLibraryCapability.php
@@ -13,7 +13,7 @@ class H5PLibraryCapability extends Model
 
     public function library()
     {
-        return $this->belongsTo('App\H5PLibrary');
+        return $this->belongsTo(H5PLibrary::class);
     }
 
     public function scopeActive($query)

--- a/sourcecode/apis/contentauthor/app/LibraryDescription.php
+++ b/sourcecode/apis/contentauthor/app/LibraryDescription.php
@@ -10,7 +10,7 @@ class LibraryDescription extends Model
 
     public function library()
     {
-        return $this->belongsTo('App\H5PLibrary');
+        return $this->belongsTo(H5PLibrary::class);
     }
 
     public function getCapabilityIdAttribute()

--- a/sourcecode/apis/contentauthor/app/Link.php
+++ b/sourcecode/apis/contentauthor/app/Link.php
@@ -44,7 +44,7 @@ class Link extends Content implements VersionableObject
 
     public function collaborators()
     {
-        return $this->hasMany('App\ArticleCollaborator', 'article_id');
+        return $this->hasMany(ArticleCollaborator::class, 'article_id');
     }
 
     public function getContentOwnerId(): string

--- a/sourcecode/apis/contentauthor/app/Providers/AuthServiceProvider.php
+++ b/sourcecode/apis/contentauthor/app/Providers/AuthServiceProvider.php
@@ -16,7 +16,7 @@ class AuthServiceProvider extends ServiceProvider
      * @var array
      */
     protected $policies = [
-        'App\Model' => 'App\Policies\ModelPolicy',
+        // \App\Model::class => App\Policies\ModelPolicy::class,
     ];
 
     /**

--- a/sourcecode/apis/contentauthor/app/Providers/EventServiceProvider.php
+++ b/sourcecode/apis/contentauthor/app/Providers/EventServiceProvider.php
@@ -21,46 +21,46 @@ class EventServiceProvider extends ServiceProvider
      * @var array
      */
     protected $listen = [
-        'App\Events\SomeEvent' => [
-            'App\Listeners\EventListener',
+        \App\Events\SomeEvent::class => [
+            \App\Listeners\EventListener::class,
         ],
 
-        'App\Events\ArticleWasSaved' => [
-            'App\Listeners\Article\HandleVersioning',
-            'App\Listeners\Article\HandleCollaborators',
-            'App\Listeners\Article\HandlePrivacy',
-            'App\Listeners\Article\HandleCollaborationInviteEmails',
+        \App\Events\ArticleWasSaved::class => [
+            \App\Listeners\Article\HandleVersioning::class,
+            \App\Listeners\Article\HandleCollaborators::class,
+            \App\Listeners\Article\HandlePrivacy::class,
+            \App\Listeners\Article\HandleCollaborationInviteEmails::class,
         ],
 
-        'App\Events\ArticleWasCopied' => [
-            'App\Listeners\Article\HandleVersioning',
+        \App\Events\ArticleWasCopied::class => [
+            \App\Listeners\Article\HandleVersioning::class,
         ],
 
-        'App\Events\H5PWasCopied' => [
-            'App\Listeners\H5P\Copy\HandleVersioning',
+        \App\Events\H5PWasCopied::class => [
+            \App\Listeners\H5P\Copy\HandleVersioning::class,
         ],
 
-        'App\Events\H5PWasSaved' => [
-            'App\Listeners\H5P\HandleVersioning',
+        \App\Events\H5PWasSaved::class => [
+            \App\Listeners\H5P\HandleVersioning::class,
             HandleExport::class,
         ],
 
-        'App\Events\LinkWasSaved' => [
-            'App\Listeners\Link\HandleVersioning',
+        \App\Events\LinkWasSaved::class => [
+            \App\Listeners\Link\HandleVersioning::class,
         ],
 
-        'App\Events\VideoSourceChanged' => [
-            'App\Listeners\H5P\HandleVideoSource',
+        \App\Events\VideoSourceChanged::class => [
+            \App\Listeners\H5P\HandleVideoSource::class,
         ],
 
-        'App\Events\QuestionsetWasSaved' => [
-            'App\Listeners\Questionset\HandlePrivacy',
-            'App\Listeners\Questionset\HandleQuestionbank',
+        \App\Events\QuestionsetWasSaved::class => [
+            \App\Listeners\Questionset\HandlePrivacy::class,
+            \App\Listeners\Questionset\HandleQuestionbank::class,
         ],
 
-        'App\Events\GameWasSaved' => [
-            'App\Listeners\Game\HandlePrivacy',
-            'App\Listeners\Game\HandleVersioning',
+        \App\Events\GameWasSaved::class => [
+            \App\Listeners\Game\HandlePrivacy::class,
+            \App\Listeners\Game\HandleVersioning::class,
 //            'App\Listeners\ResourceEventSubscriber@onGameSaved', //TODO Comment in when H5P also has 'on...Saved' logic
         ],
 

--- a/sourcecode/apis/contentauthor/app/Traits/Collaboratable.php
+++ b/sourcecode/apis/contentauthor/app/Traits/Collaboratable.php
@@ -19,7 +19,7 @@ trait Collaboratable
 
     public function collaborators()
     {
-        return $this->morphMany('App\Collaborator', 'collaboratable');
+        return $this->morphMany(Collaborator::class, 'collaboratable');
     }
 
     public function setCollaborators($collaborators = [])

--- a/sourcecode/apis/contentauthor/routes/admin.php
+++ b/sourcecode/apis/contentauthor/routes/admin.php
@@ -5,6 +5,7 @@
 
 use App\Http\Controllers\Admin\AdminArticleController;
 use App\Http\Controllers\Admin\AdminController;
+use App\Http\Controllers\Admin\AdminUserController;
 use App\Http\Controllers\Admin\CapabilityController;
 use App\Http\Controllers\Admin\ContentUpgradeController;
 use App\Http\Controllers\Admin\GamesAdminController;
@@ -75,7 +76,7 @@ Route::middleware('edlib.auth:superadmin')->namespace('Admin')->prefix('admin')-
         Route::post('ndla-import-export/settings/run-presave', [ImportExportSettingsController::class, 'runPresave'])->name('admin.importexport.run-presave');
 
         // More general Admin Backend routes
-        Route::resource('admin-users', 'AdminUserController')->only(['index', 'store', 'destroy']);
+        Route::resource('admin-users', AdminUserController::class)->only(['index', 'store', 'destroy']);
 
         Route::get('support/versioning', [VersioningController::class, 'index'])->name('admin.support.versioning');
 

--- a/sourcecode/apis/contentauthor/routes/api.php
+++ b/sourcecode/apis/contentauthor/routes/api.php
@@ -1,15 +1,16 @@
 <?php
 
-use App\Libraries\H5P\Dataobjects\H5PTranslationDataObject;
-use App\Libraries\H5P\Interfaces\TranslationServiceInterface;
+use App\Http\Controllers\API\QuestionsetController;
+use App\Http\Controllers\API\TranslationController;
+use App\Http\Controllers\API\H5PFileUploadController;
 
-Route::get('questionsets/', 'API\QuestionsetController@getQuestionsets')->name('api.get.questionsets');
-Route::get('questionsets/search/answers', 'API\QuestionsetController@searchAnswers')->name('api.search.answers');
-Route::get('questionsets/search/questions', 'API\QuestionsetController@searchQuestions')->name('api.search.questions');
-Route::get('questionsets/{questionsetId}', 'API\QuestionsetController@getQuestionset')->name('api.get.questionset');
-Route::get('questionsets/{questionsetId}/questions', 'API\QuestionsetController@getQuestions')->name('api.get.questions');
-Route::get('h5p-libraries/{id}', 'API\H5PLibraryController@getLibraryById');
+Route::get('questionsets/', [QuestionsetController::class, 'getQuestionsets'])->name('api.get.questionsets');
+Route::get('questionsets/search/answers', [QuestionsetController::class, 'searchAnswers'])->name('api.search.answers');
+Route::get('questionsets/search/questions', [QuestionsetController::class, 'searchQuestions'])->name('api.search.questions');
+Route::get('questionsets/{questionsetId}', [QuestionsetController::class, 'getQuestionset'])->name('api.get.questionset');
+Route::get('questionsets/{questionsetId}/questions', [QuestionsetController::class, 'getQuestions'])->name('api.get.questions');
+Route::get('h5p-libraries/{id}', [QuestionsetController::class, 'getLibraryById']);
 
-Route::post('translate', 'API\TranslationController')->name('translate');
+Route::post('translate', TranslationController::class)->name('translate');
 
-Route::get('status/{requestId}', 'API\H5PFileUploadController')->name("api.get.filestatus");
+Route::get('status/{requestId}', H5PFileUploadController::class)->name("api.get.filestatus");

--- a/sourcecode/apis/contentauthor/routes/api.php
+++ b/sourcecode/apis/contentauthor/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\API\H5PLibraryController;
 use App\Http\Controllers\API\QuestionsetController;
 use App\Http\Controllers\API\TranslationController;
 use App\Http\Controllers\API\H5PFileUploadController;
@@ -9,7 +10,7 @@ Route::get('questionsets/search/answers', [QuestionsetController::class, 'search
 Route::get('questionsets/search/questions', [QuestionsetController::class, 'searchQuestions'])->name('api.search.questions');
 Route::get('questionsets/{questionsetId}', [QuestionsetController::class, 'getQuestionset'])->name('api.get.questionset');
 Route::get('questionsets/{questionsetId}/questions', [QuestionsetController::class, 'getQuestions'])->name('api.get.questions');
-Route::get('h5p-libraries/{id}', [QuestionsetController::class, 'getLibraryById']);
+Route::get('h5p-libraries/{id}', [H5PLibraryController::class, 'getLibraryById']);
 
 Route::post('translate', TranslationController::class)->name('translate');
 

--- a/sourcecode/apis/contentauthor/routes/web.php
+++ b/sourcecode/apis/contentauthor/routes/web.php
@@ -1,37 +1,60 @@
 <?php
 
+use App\Http\Controllers\API\ArticleInfoController;
 use App\Http\Controllers\API\ContentInfoController;
+use App\Http\Controllers\API\ContentTypeController;
+use App\Http\Controllers\API\EmbedlyController;
+use App\Http\Controllers\API\GameInfoController;
+use App\Http\Controllers\API\GdprSubjectDataController;
 use App\Http\Controllers\API\H5PImportController;
+use App\Http\Controllers\API\H5PInfoController;
+use App\Http\Controllers\API\H5PTypeApi;
+use App\Http\Controllers\API\LinkInfoController;
+use App\Http\Controllers\API\LockStatusController;
+use App\Http\Controllers\API\PublishResourceController;
+use App\Http\Controllers\API\QuestionSetInfoController;
+use App\Http\Controllers\API\SessionTestController;
+use App\Http\Controllers\API\UnlockController;
 use App\Http\Controllers\ArticleController;
+use App\Http\Controllers\ArticleCopyrightController;
+use App\Http\Controllers\ArticleUploadController;
+use App\Http\Controllers\ContentAssetController;
 use App\Http\Controllers\ContentController;
 use App\Http\Controllers\EmbedController;
 use App\Http\Controllers\GameController;
 use App\Http\Controllers\H5PController;
+use App\Http\Controllers\HealthController;
+use App\Http\Controllers\InternalController;
+use App\Http\Controllers\JWTUpdateController;
 use App\Http\Controllers\LinkController;
 use App\Http\Controllers\LtiContentController;
+use App\Http\Controllers\Progress;
 use App\Http\Controllers\QuestionSetController;
+use App\Http\Controllers\SafariHackController;
+use App\Http\Controllers\SessionTestHostController;
+use App\Http\Controllers\SingleLogoutController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('h5p/adapter', function () {
     return ["url" => route('create')];
 })->name('h5p.adapter')->middleware('adaptermode');
-Route::get('h5p/{h5p}/copyright', 'H5PController@getCopyright');
-Route::resource('/h5p', "H5PController", ['except' => ['destroy']]);
+Route::get('h5p/{h5p}/copyright', [H5PController::class, 'getCopyright']);
+Route::resource('/h5p', H5PController::class, ['except' => ['destroy']]);
 
-Route::get('images/browse', 'H5PController@browseImages');
-Route::get('images/browse/{imageId}', 'H5PController@getImage');
+Route::get('images/browse', [H5PController::class, 'browseImages']);
+Route::get('images/browse/{imageId}', [H5PController::class, 'getImage']);
 
-Route::get('videos/browse', 'H5PController@browseVideos');
-Route::get('videos/browse/{videoId}', 'H5PController@getVideo');
+Route::get('videos/browse', [H5PController::class, 'browseVideos']);
+Route::get('videos/browse/{videoId}', [H5PController::class, 'getVideo']);
 
-Route::get('audios/browse', 'H5PController@browseAudios');
-Route::get('audios/browse/{audioId}', 'H5PController@getAudio');
+Route::get('audios/browse', [H5PController::class, 'browseAudios']);
+Route::get('audios/browse/{audioId}', [H5PController::class, 'getAudio']);
 
-Route::get('h5p/{h5p}/download', 'H5PController@downloadContent')->name('content-download')->middleware(['adaptermode']);
-Route::get('content/upgrade/library', 'H5PController@contentUpgradeLibrary')->name('content-upgrade-library');
+Route::get('h5p/{h5p}/download', [H5PController::class, 'downloadContent'])->name('content-download')->middleware(['adaptermode']);
+Route::get('content/upgrade/library', [H5PController::class, 'contentUpgradeLibrary'])->name('content-upgrade-library');
 
 Route::group(['middleware' => ['internal.handle-jwt']], function () {
-    Route::get('/view', 'InternalController@view');
+    Route::get('/view', [InternalController::class, 'view']);
 });
 
 Route::group(['middleware' => ['core.return', 'core.ltiauth', 'core.locale', 'adaptermode']], function () {
@@ -61,10 +84,10 @@ Route::group(['middleware' => ['core.return', 'core.ltiauth', 'core.locale', 'ad
 
     Route::match(['GET', 'POST'], '/create/{contenttype?}', [ContentController::class, 'index'])->middleware(["core.auth", "lti.question-set", 'core.behavior-settings:editor'])->name('create');
 
-    Route::resource('questionset', 'QuestionSetController', ['except' => ['destroy']]);
+    Route::resource('questionset', QuestionSetController::class, ['except' => ['destroy']]);
     Route::post('questionset/{id}/edit', [QuestionSetController::class, 'ltiEdit']);
 
-    Route::resource('game', 'GameController', ['except' => ['destroy']]);
+    Route::resource('game', GameController::class, ['except' => ['destroy']]);
     Route::post('game/{id}/edit', [GameController::class, 'ltiEdit']);
 
     Route::group(['middleware' => ['core.ownership']], function () {
@@ -74,64 +97,64 @@ Route::group(['middleware' => ['core.return', 'core.ltiauth', 'core.locale', 'ad
 
 });
 
-Route::post('/jwt/update', 'JWTUpdateController@updateJwtEndpoint');
+Route::post('/jwt/update', [JWTUpdateController::class, 'updateJwtEndpoint']);
 
-Route::get('/hack/safari', 'SafariHackController@index');
-Route::get('/modern/safari/safari', 'SafariHackController@jailBreakDialog');
-Route::get('/modern/safari/sessiontest', 'SessionTestHostController@sessionTestPage');
+Route::get('/hack/safari', [SafariHackController::class, 'index']);
+Route::get('/modern/safari/safari', [SafariHackController::class, 'jailBreakDialog']);
+Route::get('/modern/safari/sessiontest', [SessionTestHostController::class, 'sessionTestPage']);
 
-Route::get('/slo', 'SingleLogoutController@index')->name('slo'); // Single logout route
+Route::get('/slo', [SingleLogoutController::class, 'index'])->name('slo'); // Single logout route
 
-Route::resource('/article', 'ArticleController', ['except' => ['destroy']]);
-Route::resource('/link', 'LinkController', ['except' => ['destroy']]);
-Route::resource('/embed', 'EmbedController', ['except' => ['destroy']]);
+Route::resource('/article', ArticleController::class, ['except' => ['destroy']]);
+Route::resource('/link', LinkController::class, ['except' => ['destroy']]);
+Route::resource('/embed', EmbedController::class, ['except' => ['destroy']]);
 
-Route::post('/article/create/upload', 'ArticleUploadController@uploadToNewArticle')->name('article-upload.new');
-Route::post('/article/{id}/upload', 'ArticleUploadController@uploadToExistingArticle')->name('article-upload.existing');
+Route::post('/article/create/upload', [ArticleUploadController::class, 'uploadToNewArticle'])->name('article-upload.new');
+Route::post('/article/{id}/upload', [ArticleUploadController::class, 'uploadToExistingArticle'])->name('article-upload.existing');
 
 
 // *************************
 // API Endpoints     TODO: clean up!
 // *************************
-Route::get('api/h5p-type/{ids}', 'API\H5PTypeApi@getTypes');
+Route::get('api/h5p-type/{ids}', [H5PTypeApi::class, 'getTypes']);
 
 Route::get('v1/content/{id}', [ContentInfoController::class, 'index']);
 Route::get('v1/content', [ContentInfoController::class, 'list']);
-Route::get('v1/h5p/{id}/info', 'API\H5PInfoController@index');
-Route::get('v1/article/{id}/info', 'API\ArticleInfoController@index');
-Route::get('v1/link/{id}/info', 'API\LinkInfoController@index');
-Route::get('v1/questionset/{id}/info', 'API\QuestionSetInfoController@index');
-Route::get('v1/game/{id}/info', 'API\GameInfoController@index');
-Route::get('v1/link/embeddata', 'API\LinkInfoController@embed');
-Route::get('v1/embed/embedly', 'API\EmbedlyController@get');
+Route::get('v1/h5p/{id}/info', [H5PInfoController::class, 'index']);
+Route::get('v1/article/{id}/info', [ArticleInfoController::class, 'index']);
+Route::get('v1/link/{id}/info', [LinkInfoController::class, 'index']);
+Route::get('v1/questionset/{id}/info', [QuestionSetInfoController::class, 'index']);
+Route::get('v1/game/{id}/info', [GameInfoController::class, 'index']);
+Route::get('v1/link/embeddata', [LinkInfoController::class, 'embed']);
+Route::get('v1/embed/embedly', [EmbedlyController::class, 'get']);
 
 
-Route::get('v1/content/{id}/lock-status', 'API\LockStatusController@index')->name('lock.status');
-Route::post('v1/content/{id}/lock-status', 'API\LockStatusController@pulse')->name('lock.status');
-Route::match(['GET', 'POST'], 'v1/content/{id}/unlock', 'API\UnlockController@index')->name('lock.unlock');
+Route::get('v1/content/{id}/lock-status', [LockStatusController::class, 'index'])->name('lock.status');
+Route::post('v1/content/{id}/lock-status', [LockStatusController::class, 'pulse'])->name('lock.status');
+Route::match(['GET', 'POST'], 'v1/content/{id}/unlock', [UnlockController::class, 'index'])->name('lock.unlock');
 
 Route::group(['middleware' => ['core.auth']], function () {
-    Route::get('v1/gdpr/user/byemail', 'API\GdprSubjectDataController@getUserDataByEmail')->name('gdpr.user.data.byemail');
-    Route::get('v1/gdpr/user/{userId}', 'API\GdprSubjectDataController@getUserData')->name('gdpr.user.data');
+    Route::get('v1/gdpr/user/byemail', [GdprSubjectDataController::class, 'getUserDataByEmail'])->name('gdpr.user.data.byemail');
+    Route::get('v1/gdpr/user/{userId}', [GdprSubjectDataController::class, 'getUserData'])->name('gdpr.user.data');
 });
 
 // AJAX and REST(ish) routes
-Route::post('api/progress', 'Progress@storeProgress')->name("setProgress");
-Route::get('api/progress', 'Progress@getProgress')->name("getProgress");
+Route::post('api/progress', [Progress::class, 'storeProgress'])->name("setProgress");
+Route::get('api/progress', [Progress::class, 'getProgress'])->name("getProgress");
 
 Route::match(['GET', 'POST'], '/ajax', [H5PController::class, 'ajaxLoading'])->middleware("adaptermode"); // TODO: Refactor into its own controller
 
-Route::post('v1/sessiontest/{id}', 'API\SessionTestController@setValue');
-Route::get('v1/sessiontest/{id}', 'API\SessionTestController@getValue');
+Route::post('v1/sessiontest/{id}', [SessionTestController::class, 'setValue']);
+Route::get('v1/sessiontest/{id}', [SessionTestController::class, 'getValue']);
 
 Route::group(['prefix' => 'api', 'middleware' => ['signed.oauth10-request']], function () {
-    Route::post('v1/contenttypes/questionsets', 'API\ContentTypeController@storeH5PQuestionset');
-    Route::put('v1/resources/{resourceId}/publish', 'API\PublishResourceController@publishResource')->name('api.resource.publish');
+    Route::post('v1/contenttypes/questionsets', [ContentTypeController::class, 'storeH5PQuestionset']);
+    Route::put('v1/resources/{resourceId}/publish', [PublishResourceController::class, 'publishResource'])->name('api.resource.publish');
     Route::post('v1/h5p/import', [H5PImportController::class, 'importH5P'])->name('api.import.h5p');
 });
 
-Route::get('article/{article}/copyright', 'ArticleCopyrightController@copyright')->name('article.copyright');
+Route::get('article/{article}/copyright', [ArticleCopyrightController::class, 'copyright'])->name('article.copyright');
 
-Route::get('/health', 'HealthController@index');
+Route::get('/health', [HealthController::class, 'index']);
 
-Route::get('content/assets/{path?}', 'ContentAssetController')->where('path', '.*')->name('content.asset')->middleware('adaptermode');
+Route::get('content/assets/{path?}', ContentAssetController::class)->where('path', '.*')->name('content.asset')->middleware('adaptermode');


### PR DESCRIPTION
Use `::class` instead of strings with class names. This makes it easier to spot unused code, navigate around using PHPStorm, etc.