### PR TITLE
Cleaner rewriting of cloud paths

### DIFF
--- a/sourcecode/apis/contentauthor/app/Article.php
+++ b/sourcecode/apis/contentauthor/app/Article.php
@@ -4,12 +4,13 @@ namespace App;
 
 use App\Http\Libraries\ArticleFileVersioner;
 use App\Libraries\ContentAuthorStorage;
-use App\Libraries\DataObjects\ContentStorageSettings;
 use App\Libraries\DataObjects\ContentTypeDataObject;
 use App\Libraries\Versioning\VersionableObject;
 use Carbon\Carbon;
 use Cerpus\Helper\Clients\Client;
 use Cerpus\Helper\DataObjects\OauthSetup;
+use DOMDocument;
+use DOMElement;
 use Exception;
 use GuzzleHttp\Utils as GuzzleUtils;
 use Illuminate\Database\Eloquent\Builder;
@@ -19,6 +20,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Iso639p3;
 use Ramsey\Uuid\Uuid;
+use const LIBXML_HTML_NOIMPLIED;
 
 /**
  * @property string $id
@@ -56,6 +58,15 @@ class Article extends Content implements VersionableObject
 
     protected $dates = ['deleted_at', "updated_at", "created_at"];
     protected $fillable = ['title', 'content'];
+
+    public function render(): string
+    {
+        if (!$this->content) {
+            return '';
+        }
+
+        return self::rewriteUploadUrls($this->content);
+    }
 
     public function collaborators()
     {
@@ -237,14 +248,31 @@ class Article extends Content implements VersionableObject
         return false;
     }
 
-    public function convertToCloudPaths()
-    {
-        $contentAuthorStorage = app(ContentAuthorStorage::class);
-        $this->content = str_replace('/h5pstorage/article-uploads', $contentAuthorStorage->getAssetUrl(ContentStorageSettings::ARTICLE_DIR), $this->content);
-    }
-
     public static function getContentTypeInfo(string $contentType): ?ContentTypeDataObject
     {
         return new ContentTypeDataObject('Article', $contentType, 'Article', "fa:newspaper-o");
+    }
+
+    private static function rewriteUploadUrls(string $content): string
+    {
+        $cas = app()->make(ContentAuthorStorage::class);
+        assert($cas instanceof ContentAuthorStorage);
+
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $dom->loadHTML($content, LIBXML_HTML_NODEFDTD | LIBXML_HTML_NOIMPLIED);
+
+        collect($dom->getElementsByTagName('img'))
+            ->filter(fn(DOMElement $node) => $node->hasAttribute('src'))
+            ->each(function (DOMElement $node) use ($cas) {
+                $asset = preg_replace(
+                    '@^/h5pstorage/article-uploads/@',
+                    '',
+                    $node->getAttribute('src'),
+                );
+
+                $node->setAttribute('src', $cas->getAssetUrl($asset));
+            });
+
+        return $dom->saveHTML();
     }
 }

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/ArticleController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/ArticleController.php
@@ -192,7 +192,6 @@ class ArticleController extends Controller
             Session::flash(SessionKeys::EXT_CSS_URL, $customCSS);
         }
 
-        $article->convertToCloudPaths();
         $ndlaArticle = $article->isImported();
         $inDraftState = !$article->isActuallyPublished();
         $resourceType = sprintf($article::RESOURCE_TYPE_CSS, $article->getContentType());
@@ -224,8 +223,6 @@ class ArticleController extends Controller
         $originators = $article->getAttribution()->getOriginators();
 
         $ownerName = $article->getOwnerName($article->owner_id);
-
-        $article->convertToCloudPaths();
 
         $emails = $this->getCollaboratorsEmails($article);
 
@@ -275,7 +272,7 @@ class ArticleController extends Controller
         $state = ArticleStateDataObject::create([
             'id' => $article->id,
             'title' => $article->title,
-            'content' => $article->content,
+            'content' => $article->render(),
             'license' => $article->license,
             'isPublished' => $article->isPublished(),
             'isDraft' => $article->isDraft(),

--- a/sourcecode/apis/contentauthor/phpstan-baseline.neon
+++ b/sourcecode/apis/contentauthor/phpstan-baseline.neon
@@ -1732,17 +1732,7 @@ parameters:
 			path: tests/Integration/Article/ArticleLockTest.php
 
 		-
-			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$content\\.$#"
-			count: 1
-			path: tests/Integration/Article/ArticleTest.php
-
-		-
 			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
-			count: 3
-			path: tests/Integration/Article/ArticleTest.php
-
-		-
-			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Collection\\<int, Illuminate\\\\Database\\\\Eloquent\\\\Model\\>\\|Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$title\\.$#"
 			count: 1
 			path: tests/Integration/Article/ArticleTest.php
 

--- a/sourcecode/apis/contentauthor/resources/views/article/show.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/article/show.blade.php
@@ -9,7 +9,7 @@
 @section('title') {{ $article->title }} @endsection
 
 @section('content')
-    {!! $article->content  !!}
+    {!! $article->render() !!}
 @endsection
 
 @push('js')

--- a/sourcecode/apis/contentauthor/tests/Integration/Article/ArticleTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Article/ArticleTest.php
@@ -30,7 +30,20 @@ class ArticleTest extends TestCase
         ]);
 
         $this->assertSame(
-            "<p>This is an image: <img src=\"http://localhost/content/assets/foo.jpg\"></p>\n",
+            "<p>This is an image: <img src=\"http://localhost/content/assets/article-uploads/foo.jpg\"></p>\n",
+            $article->render(),
+        );
+    }
+
+    public function testLeavesNonUploadUrlsAlone(): void
+    {
+        /** @var Article $article */
+        $article = Article::factory()->create([
+            'content' => '<p>This is an image: <img src="http://example.com/foo.jpg"></p>',
+        ]);
+
+        $this->assertSame(
+            "<p>This is an image: <img src=\"http://example.com/foo.jpg\"></p>\n",
             $article->render(),
         );
     }

--- a/sourcecode/apis/contentauthor/tests/Integration/Article/ArticleTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Article/ArticleTest.php
@@ -24,6 +24,7 @@ class ArticleTest extends TestCase
 
     public function testRewriteUploadUrls(): void
     {
+        /** @var Article $article */
         $article = Article::factory()->create([
             'content' => '<p>This is an image: <img src="/h5pstorage/article-uploads/foo.jpg"></p>',
         ]);
@@ -152,6 +153,7 @@ class ArticleTest extends TestCase
         ]);
         Event::fake();
         $authId = Str::uuid();
+        /** @var Article $article */
         $article = Article::factory()->create([
             'owner_id' => $authId,
             'is_published' => 1,
@@ -256,6 +258,8 @@ class ArticleTest extends TestCase
     public function testViewArticle()
     {
         $this->setupVersion();
+
+        /** @var Article $article */
         $article = Article::factory()->create([
             'is_published' => 1,
             'license' => 'BY',

--- a/sourcecode/apis/contentauthor/tests/Integration/Article/ArticleTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Article/ArticleTest.php
@@ -22,6 +22,18 @@ class ArticleTest extends TestCase
 {
     use RefreshDatabase, MockVersioningTrait, MockResourceApi, MockAuthApi;
 
+    public function testRewriteUploadUrls(): void
+    {
+        $article = Article::factory()->create([
+            'content' => '<p>This is an image: <img src="/h5pstorage/article-uploads/foo.jpg"></p>',
+        ]);
+
+        $this->assertSame(
+            "<p>This is an image: <img src=\"http://localhost/content/assets/foo.jpg\"></p>\n",
+            $article->render(),
+        );
+    }
+
     public function testEditArticleAccessDenied()
     {
         $this->setUpResourceApi();
@@ -171,7 +183,7 @@ class ArticleTest extends TestCase
 
         $this->get(route('article.show', $newArticle->id))
             ->assertSee($newArticle->title)
-            ->assertSee($newArticle->content);
+            ->assertSee($newArticle->render());
     }
 
     public function testEditArticleWithDraftEnabled()
@@ -238,7 +250,7 @@ class ArticleTest extends TestCase
             ->first();
         $this->get(route('article.show', $article->id))
             ->assertSee($article->title)
-            ->assertSee($article->content);
+            ->assertSee($article->render());
     }
 
     public function testViewArticle()
@@ -251,7 +263,7 @@ class ArticleTest extends TestCase
 
         $this->get(route('article.show', $article->id))
             ->assertSee($article->title)
-            ->assertSee($article->content);
+            ->assertSee($article->render());
     }
 
     public function testMustBeLoggedInToCreateArticle()

--- a/sourcecode/apis/contentauthor/tests/Integration/Article/ArticleTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Article/ArticleTest.php
@@ -185,7 +185,7 @@ class ArticleTest extends TestCase
 
         $this->get(route('article.show', $newArticle->id))
             ->assertSee($newArticle->title)
-            ->assertSee($newArticle->render());
+            ->assertSee($newArticle->render(), false);
     }
 
     public function testEditArticleWithDraftEnabled()
@@ -252,7 +252,7 @@ class ArticleTest extends TestCase
             ->first();
         $this->get(route('article.show', $article->id))
             ->assertSee($article->title)
-            ->assertSee($article->render());
+            ->assertSee($article->render(), false);
     }
 
     public function testViewArticle()
@@ -267,7 +267,7 @@ class ArticleTest extends TestCase
 
         $this->get(route('article.show', $article->id))
             ->assertSee($article->title)
-            ->assertSee($article->render());
+            ->assertSee($article->render(), false);
     }
 
     public function testMustBeLoggedInToCreateArticle()


### PR DESCRIPTION
Adds an `App\Article::render()` intended to be used whenever an article is displayed to the end-user. Currently, this only rewrites article upload paths using a new approach.

The previous approach would leave dangling changes to the Article model, possibly leading to those being accidentally persisted somewhere down the line. Also, the use of `str_replace()` has been removed in favour of actually parsing the HTML to change only the `src` attributes.