### PR TITLE
fix misc issues with so-called www's docker setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -388,8 +388,10 @@ services:
       context: ./sourcecode/www
       dockerfile: Dockerfile
       target: dev
+    command: [sh, -c, 'yarn && yarn start']
     environment:
       CLIENT_PUBLIC_PATH: https://www.edlib.local/
+      NODE_EXTRA_CA_CERTS: '/usr/local/share/ca-certificates/cacert.pem'
       PUBLIC_PATH: https://www.edlib.local/
     env_file:
       - ./localSetup/.env
@@ -397,6 +399,7 @@ services:
       test: [CMD, curl, -f, http://localhost:3000]
     volumes:
       - www_nodemodules:/app/node_modules
+      - ./data/nginx/ca:/usr/local/share/ca-certificates:ro
       - ./sourcecode/www/src:/app/src
       - ./sourcecode/www/public:/app/public
       - ./sourcecode/www/package.json:/app/package.json

--- a/sourcecode/www/Dockerfile
+++ b/sourcecode/www/Dockerfile
@@ -1,17 +1,22 @@
-FROM node:16.13 as base
+FROM node:16-alpine as base
 WORKDIR /app
 COPY . .
 RUN yarn
 
 FROM base as build
-WORKDIR /app
 RUN yarn build --noninteractive
 
 FROM build as prod
 EXPOSE 80
 CMD yarn start:prod
 
-FROM node:16.13 as dev
+FROM node:16-alpine as dev
+RUN set -eux; \
+    apk add --no-cache \
+        curl \
+        ca-certificates \
+    ;
+COPY ./docker-entrypoint-dev.sh /usr/local/bin/docker-entrypoint
+ENTRYPOINT ["docker-entrypoint"]
 WORKDIR /app
 EXPOSE 3000
-CMD yarn; yarn start

--- a/sourcecode/www/docker-entrypoint-dev.sh
+++ b/sourcecode/www/docker-entrypoint-dev.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+update-ca-certificates
+
+exec "$@"


### PR DESCRIPTION
* Use Alpine instead of Debian-based image
* Don't lock to a particular minor version of the `node` image
* Handle certificates properly
* Let docker-compose.yml define the command that's run