### PR TITLE
Fix upgrade script URL

### DIFF
--- a/sourcecode/apis/contentauthor/config/h5p.php
+++ b/sourcecode/apis/contentauthor/config/h5p.php
@@ -7,7 +7,7 @@ return [
         'useRichText' => env("H5P_DC_USE_RICH_TEXT", false),
     ],
     'storage' => [
-        'publicPath' => env('CDN_WITH_PREFIX') ? '' : '/h5pstorage',
+        'publicPath' => '',
         'path' => env("UPLOAD_STORAGE_PATH_H5P", public_path() . '/h5pstorage'),
     ],
     'video' => [


### PR DESCRIPTION
`h5p.storage.publicPath` is used by H5P core as a prefix for some scripts. This breaks the URL for the upgrade script, so we just blank it out.