### PR TITLE
fix content lock expiry seconds/minutes confusion

### DIFF
--- a/sourcecode/apis/contentauthor/app/Console/Commands/RemoveOldContentLocks.php
+++ b/sourcecode/apis/contentauthor/app/Console/Commands/RemoveOldContentLocks.php
@@ -43,7 +43,7 @@ class RemoveOldContentLocks extends Command
         // The MySQL replication in test and prod can have problems
         // with transactions that does not use primary keys.
         $staleLocks = ContentLock::select('content_id')
-            ->where('updated_at', '<', Carbon::now()->subMinutes(ContentLock::EXPIRES))
+            ->where('updated_at', '<', Carbon::now()->subSeconds(ContentLock::EXPIRES_SECONDS))
             ->get()
             ->pluck('content_id')
             ->all();

--- a/sourcecode/apis/contentauthor/app/ContentLock.php
+++ b/sourcecode/apis/contentauthor/app/ContentLock.php
@@ -15,7 +15,8 @@ class ContentLock extends Model
 {
     use HasFactory;
 
-    const EXPIRES = 90; // seconds
+    const EXPIRES_SECONDS = 90 * 60;
+
     public $incrementing = false;
     protected $primaryKey = 'content_id';
 
@@ -83,6 +84,6 @@ class ContentLock extends Model
 
     public function scopeActive($query)
     {
-       return $query->where('updated_at', '>', Carbon::now()->subSeconds(self::EXPIRES));
+       return $query->where('updated_at', '>', Carbon::now()->subSeconds(self::EXPIRES_SECONDS));
     }
 }

--- a/sourcecode/apis/contentauthor/tests/Integration/Commands/RemoveOldLocksTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Commands/RemoveOldLocksTest.php
@@ -16,8 +16,8 @@ class RemoveOldLocksTest extends TestCase
     {
         ContentLock::factory()->count(2)->create(
             [
-                'created_at' => Carbon::now()->subMinutes(ContentLock::EXPIRES),
-                'updated_at' => Carbon::now()->subMinutes(ContentLock::EXPIRES - 2),
+                'created_at' => Carbon::now()->subSeconds(ContentLock::EXPIRES_SECONDS),
+                'updated_at' => Carbon::now()->subSeconds(ContentLock::EXPIRES_SECONDS - 2),
             ]);
 
         $this->assertCount(2, ContentLock::all());
@@ -28,8 +28,8 @@ class RemoveOldLocksTest extends TestCase
 
         ContentLock::factory()->count(3)->create(
             [
-                'created_at' => Carbon::now()->subMinutes(ContentLock::EXPIRES + 1),
-                'updated_at' => Carbon::now()->subMinutes(ContentLock::EXPIRES + 1),
+                'created_at' => Carbon::now()->subSeconds(ContentLock::EXPIRES_SECONDS + 1),
+                'updated_at' => Carbon::now()->subSeconds(ContentLock::EXPIRES_SECONDS + 1),
             ]);
 
         $this->assertCount(5, ContentLock::all());


### PR DESCRIPTION
Despite being commented with `// seconds`, the expiry time for content locks was being treated as minutes in the scheduled job that removes the locks.

To avoid future confusion, the constant is renamed to make the unit of time explicit. Since no one complained about the 90 minute expiry time, we assume this was the original intention and leave it as is.