### PR TITLE
Fix deprecated passing of null to php function

### DIFF
--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/LtiToH5PLanguage.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/LtiToH5PLanguage.php
@@ -1,25 +1,29 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Libraries\H5P;
 
 class LtiToH5PLanguage
 {
-    public static function convert($ltiLanguage = 'en-gb', $defaultLanguage = 'en-gb'): string
+    public static function convert(?string $ltiLanguage = 'en-gb', ?string $defaultLanguage = 'en-gb'): string
     {
         return self::extractCode($ltiLanguage) ?: self::extractCode($defaultLanguage) ?: 'en';
     }
 
     private static function extractCode(?string $language): ?string
     {
-        $code = str_replace('_', '-', strtolower($language));
+        if ($language !== null) {
+            $code = str_replace('_', '-', strtolower($language));
 
-        if (strlen($code) === 2 && !strpos($code, '-')) {
-            return $code;
-        }
+            if (strlen($code) === 2 && !strpos($code, '-')) {
+                return $code;
+            }
 
-        if (strlen($code) > 2 && strpos($code, '-')) {
-            $pieces = explode('-', $code);
-            return strlen($pieces[0]) === 2 ? $pieces[0] : null;
+            if (strlen($code) > 2 && strpos($code, '-')) {
+                $pieces = explode('-', $code);
+                return strlen($pieces[0]) === 2 ? $pieces[0] : null;
+            }
         }
 
         return null;


### PR DESCRIPTION
Passing NULL to PHP's internal functions is [deprecated](https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg) and will stop working in PHP 9. In `LtiToH5PLanguage::convert`, the deprecation warning causes a test failure under very specific conditions (coverage with xdebug + pcov, running the entire suite).