### PR TITLE
Proper fix for the view counts

### DIFF
--- a/sourcecode/apis/resources/src/services/elasticSearch.js
+++ b/sourcecode/apis/resources/src/services/elasticSearch.js
@@ -67,7 +67,7 @@ export const syncResource = async (context, resource, waitForIndex) => {
             ...latestVersionCollaborators.map((c) => c.tenantId),
             ...resourceCollaborators.map((rc) => rc.tenantId),
         ]),
-        views: viewCount.count,
+        views: viewCount,
     };
 
     await context.services.elasticsearch.updateOrCreate(

--- a/sourcecode/apis/resources/src/services/resource.js
+++ b/sourcecode/apis/resources/src/services/resource.js
@@ -387,13 +387,6 @@ const transformElasticResources = async (
         return capabilities;
     }
 
-    const esrViewCountMap = Object.fromEntries(await Promise.all(
-        elasticsearchResources.map(({ _source: { id }}) => (async () => [
-            id,
-            await context.db.trackingResourceVersion.getCountForResource(id),
-        ])()),
-    ));
-
     let results = elasticsearchResources
         .map((esr) => {
             return {
@@ -411,7 +404,7 @@ const transformElasticResources = async (
                       )
                     : [resourceCapabilities.VIEW, resourceCapabilities.EDIT],
                 analytics: {
-                    viewCount: esrViewCountMap[esr._source.id],
+                    viewCount: esr._source.views,
                 },
             };
         })


### PR DESCRIPTION
It turns out the view count is meant to be populated upon reindexing search, but the code was mistakenly accessing the `count` property on a number.