### PR TITLE
Fix auth startup properly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -351,7 +351,7 @@ services:
       - ./localSetup/.env
     environment:
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
-    command: "/bin/sh -c 'wait-for mysql:3306 && wait-for rabbitmq:5672 && wait-for redis:6379 && update-ca-certificates && yarn && yarn migrate && yarn dev'"
+    command: [sh, -c, 'yarn && yarn wait && yarn migrate && yarn dev']
     healthcheck:
       test: [CMD, curl, -f, "http://localhost/_ah/health"]
     volumes:
@@ -360,7 +360,6 @@ services:
       - ./sourcecode/apis/auth/.env.defaults:/var/www/app/.env.defaults
       - ./sourcecode/apis/auth/package.json:/var/www/app/package.json
       - ./sourcecode/apis/auth/yarn.lock:/var/www/app/yarn.lock
-      - ./localSetup/helpers/start-scripts/wait-for.sh:/usr/local/bin/wait-for
     #      - ./sourcecode/npm/nodeUtils:/var/www/app/node_modules/@cerpus/edlib-node-utils:ro
     depends_on:
       - mysql

--- a/sourcecode/apis/auth/Dockerfile
+++ b/sourcecode/apis/auth/Dockerfile
@@ -3,8 +3,8 @@
 #
 FROM node:16-alpine AS base
 WORKDIR /var/www/app
-RUN apk --no-cache add --virtual .builds-deps build-base python3 curl
-RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN apk --no-cache add build-base ca-certificates python3 curl
+RUN ln -s python3 /usr/bin/python
 
 #
 # appbase container, contains app and dependencies
@@ -34,3 +34,10 @@ CMD [ "yarn", "migrate" ]
 FROM appbase as prod
 EXPOSE 80
 CMD [ "yarn", "start" ]
+
+#
+# Dev
+#
+FROM base AS dev
+COPY ./docker-entrypoint-dev.sh /usr/local/bin/docker-entrypoint
+ENTRYPOINT ["docker-entrypoint"]

--- a/sourcecode/apis/auth/docker-entrypoint-dev.sh
+++ b/sourcecode/apis/auth/docker-entrypoint-dev.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+update-ca-certificates
+
+exec "$@"

--- a/sourcecode/apis/auth/package.json
+++ b/sourcecode/apis/auth/package.json
@@ -6,7 +6,8 @@
     "dev": "nodemon -L src/api.js",
     "start": "node src/api.js",
     "migrate": "node src/runMigrations.js",
-    "test": "jest --config=./jest.config.json"
+    "test": "jest --config=./jest.config.json",
+    "wait": "wait-on tcp:mysql:3306 tcp:redis:6379 tcp:rabbitmq:5672"
   },
   "engines": {
     "node": ">= 16.0.0"
@@ -30,6 +31,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "nodemon": "^2.0.19"
+    "nodemon": "^2.0.19",
+    "wait-on": "^6.0.1"
   }
 }

--- a/sourcecode/apis/auth/yarn.lock
+++ b/sourcecode/apis/auth/yarn.lock
@@ -2059,6 +2059,13 @@ await-lock@^2.1.0:
   resolved "https://registry.yarnpkg.com/await-lock/-/await-lock-2.1.0.tgz#bc78c51d229a34d5d90965a1c94770e772c6145e"
   integrity sha512-t7Zm5YGgEEc/3eYAicF32m/TNvL+XOeYZy9CvBUeJY/szM7frLolFylhrlZNWV/ohWhcUXygrBGjYmoQdxF4CQ==
 
+axios@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.25.0.tgz#349cfbb31331a9b4453190791760a8d35b093e0a"
+  integrity sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==
+  dependencies:
+    follow-redirects "^1.14.7"
+
 axios@^0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
@@ -2936,6 +2943,11 @@ fn.name@1.x.x:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
+
+follow-redirects@^1.14.7:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
+  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
 
 follow-redirects@^1.14.8:
   version "1.14.9"
@@ -4705,6 +4717,13 @@ rimraf@^3.0.0:
   dependencies:
     glob "^7.1.3"
 
+rxjs@^7.5.4:
+  version "7.5.6"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.6.tgz#0446577557862afd6903517ce7cae79ecb9662bc"
+  integrity sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==
+  dependencies:
+    tslib "^2.1.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1, safe-buffer@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -5128,6 +5147,11 @@ triple-beam@^1.3.0:
   resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
   integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
+tslib@^2.1.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
@@ -5261,6 +5285,17 @@ w3c-xmlserializer@^2.0.0:
   integrity sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
   dependencies:
     xml-name-validator "^3.0.0"
+
+wait-on@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-6.0.1.tgz#16bbc4d1e4ebdd41c5b4e63a2e16dbd1f4e5601e"
+  integrity sha512-zht+KASY3usTY5u2LgaNqn/Cd8MukxLGjdcZxT2ns5QzDmTFc4XoWBgC+C/na+sMRZTuVygQoMYwdcVjHnYIVw==
+  dependencies:
+    axios "^0.25.0"
+    joi "^17.6.0"
+    lodash "^4.17.21"
+    minimist "^1.2.5"
+    rxjs "^7.5.4"
 
 walker@^1.0.7:
   version "1.0.8"


### PR DESCRIPTION
The shell-based wait script would fail on authapi for some reason, so we replace it with the `wait-on` npm package.