### PR TITLE
Watch CA assets for change in dev environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -225,7 +225,7 @@ services:
 
   contentauthor-watch:
     image: node:16-alpine
-    command: [sh, -c, 'npm install && npm run watch']
+    command: [sh, -c, 'npm install --legacy-peer-deps && npm run watch']
     volumes:
       - ./sourcecode/apis/contentauthor:/app
     working_dir: /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -223,6 +223,13 @@ services:
     depends_on:
       - contentauthor-fpm
 
+  contentauthor-watch:
+    image: node:16-alpine
+    command: [sh, -c, 'npm install && npm run watch']
+    volumes:
+      - ./sourcecode/apis/contentauthor:/app
+    working_dir: /app
+
   docs:
     image: node:16-alpine
     command: [sh, -c, 'yarn && yarn run start --host=0.0.0.0 --port=80']

--- a/sourcecode/apis/contentauthor/Dockerfile
+++ b/sourcecode/apis/contentauthor/Dockerfile
@@ -75,7 +75,7 @@ FROM buildresult AS phpfpm
 CMD [ "php-fpm", "-R", "-F", "-O" ]
 
 
-FROM buildresult AS phpfpm-dev
+FROM php_base AS phpfpm-dev
 RUN install-php-extensions \
         xdebug-stable
 COPY docker/php/docker-entrypoint-dev.sh /docker-entrypoint-dev.sh


### PR DESCRIPTION
This also skips the redundant building of assets in the dev Docker image.