### PR TITLE
Use wildcard certificates, remove unused alt names

### DIFF
--- a/localSetup/projects/certs/generate-certs.sh
+++ b/localSetup/projects/certs/generate-certs.sh
@@ -6,19 +6,10 @@ CERTS_DIR=/etc/ssl/private
 
 DOMAINS="\
 DNS:localhost, \
-DNS:edlib.internal.url.local, \
-DNS:edlib.internal.auth.local, \
-DNS:edlib.internal.resource.local, \
-DNS:edlib.internal.lti.local, \
-DNS:edlib.internal.doku.local, \
-DNS:edlib.internal.version.local, \
 DNS:edlibfacade.local, \
-DNS:test.edlibfacade.local, \
+DNS:*.edlibfacade.local, \
 DNS:contentauthor.local, \
-DNS:ca.edlib.local, \
-DNS:api.edlib.local, \
-DNS:docs.edlib.local, \
-DNS:www.edlib.local, \
+DNS:*.edlib.local, \
 DNS:npm.components.edlib.local \
 "
 


### PR DESCRIPTION
Makes it easier to access the dev environment in case you cannot or don't want to accept a self-signed root CA.