### PR TITLE
CA Admin H5P libraries cleanup and fixes

### DIFF
--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PLibraryAdmin.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PLibraryAdmin.php
@@ -44,11 +44,18 @@ class H5PLibraryAdmin
         // Move so core can validate the file extension.
         rename($path, $newPath);
 
-        if (!$this->validator->isValidPackage(true, $upgradeOnly)) {
-            @unlink($this->framework->getUploadedH5pPath());
+        try {
+            if (!$this->validator->isValidPackage(true, $upgradeOnly)) {
+                @unlink($this->framework->getUploadedH5pPath());
 
+                throw new InvalidH5pPackageException(
+                    $this->validator->h5pF->getMessages('error'),
+                );
+            }
+        } catch (\Exception $e) {
+            @unlink($this->framework->getUploadedH5pPath());
             throw new InvalidH5pPackageException(
-                $this->validator->h5pF->getMessages('error'),
+                [$e->getMessage()],
             );
         }
 

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PLibraryAdmin.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PLibraryAdmin.php
@@ -13,6 +13,7 @@ use H5PFrameworkInterface;
 use H5PStorage;
 use H5PValidator;
 use Illuminate\Http\Request;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 class H5PLibraryAdmin
@@ -26,6 +27,7 @@ class H5PLibraryAdmin
         private H5PValidator $validator,
         private H5PFrameworkInterface $framework,
         private H5PStorage $storage,
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -52,10 +54,12 @@ class H5PLibraryAdmin
                     $this->validator->h5pF->getMessages('error'),
                 );
             }
-        } catch (\Exception $e) {
+        } catch (\ErrorException $e) {
+            // The validator does not check for file existence before reading
+            $this->logger->error('Upload failed', ['exception' => $e]);
             @unlink($this->framework->getUploadedH5pPath());
             throw new InvalidH5pPackageException(
-                [$e->getMessage()],
+                ['An unexpected error occurred, check that the file you uploaded is a valid .h5p file'],
             );
         }
 

--- a/sourcecode/apis/contentauthor/resources/assets/sass/admin.scss
+++ b/sourcecode/apis/contentauthor/resources/assets/sass/admin.scss
@@ -16,3 +16,8 @@ $questionset-primary-color: #465c6c;
     border: 0;
     background-color: transparent;
 }
+
+.h5p-action-button {
+    min-width: 25px;
+    display: inline-block;
+}

--- a/sourcecode/apis/contentauthor/resources/views/admin/fragments/library-table.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/fragments/library-table.blade.php
@@ -41,7 +41,7 @@
                     <a title="Content bulk upgrade" href="{{ $library['upgradeUrl'] }}">
                         <button
                                 type="button"
-                                class="btn btn-info btn-xs"
+                                class="btn btn-info btn-xs h5p-action-button"
                                 title="Content bulk upgrade"
                         >
                             <span class="fa fa-refresh"></span>
@@ -50,7 +50,7 @@
                 @elseif ($library['hubUpgrade'] !== null)
                     <button
                             type="button"
-                            class="btn btn-success btn-xs install-btn"
+                            class="btn btn-success btn-xs install-btn h5p-action-button"
                             data-name="{{$library['machineName']}}"
                             data-ajax-url="{{route('admin.ajax')}}"
                             data-ajax-action="{{H5PEditorEndpoints::LIBRARY_INSTALL}}"
@@ -58,11 +58,13 @@
                     >
                         <span class="fa fa-cloud-download"></span>
                     </button>
+                @else
+                    <div class="h5p-action-button"></div>
                 @endif
                 @if(!empty($library['libraryId']))
                     <button
                             type="button"
-                            class="btn btn-warning btn-xs rebuild-btn"
+                            class="btn btn-warning btn-xs rebuild-btn h5p-action-button"
                             data-libraryId="{{$library['libraryId']}}"
                             data-ajax-url="{{route('admin.ajax')}}"
                             data-ajax-action="{{\App\Libraries\H5P\AjaxRequest::LIBRARY_REBUILD}}"

--- a/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/index.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/index.blade.php
@@ -4,90 +4,77 @@
     <div class="container">
         <div class="row">
             <div class="col-md-12">
+                <div id="minor-publishing" class="panel panel-default">
+                    <div class="panel-heading">
+                        <h3>Install or update H5P content types and libraries</h3>
+                    </div>
+
+                    <div class="panel-body row">
+                        <form method="post" enctype="multipart/form-data" id="h5p-library-form" class="col-md-6">
+                            <h4>By file upload</h4>
+                            <p>File must be .h5p format.</p>
+                            <input type="file" name="h5p_file" id="h5p-file"/>
+                            <br>
+                            <div class="h5p-disable-file-check">
+                                <label><input type="checkbox" name="h5p_upgrade_only" id="h5p-upgrade-only"/> Only update existing libraries</label>
+                                <br>
+                                <label><input type="checkbox" name="h5p_disable_file_check" id="h5p-disable-file-check"/> Disable file extension check</label>
+                            </div>
+                            <br>
+                            <input type="hidden" id="lets_upgrade_that" name="lets_upgrade_that" value="228e7591a1">
+                            <input type="hidden" name="_wp_http_referer" value="/wordpress/wp-admin/admin.php?page=h5p_libraries">
+                            {!! csrf_field() !!}
+                            <div id="major-publishing-actions" class="submitbox">
+                                <input type="submit" name="submit" value="Upload" class="button button-primary button-large btn btn-primary"/>
+                            </div>
+                        </form>
+
+                        <form action="{{ route('admin.check-for-updates') }}" method="post">
+                            @csrf
+                            <h4>Content types from h5p.org</h4>
+                            <button type="submit" class="btn btn-success">Check for updates</button>
+                        </form>
+                    </div>
+
+                    @include('fragments.invalidFlashMessage')
+                </div>
+
                 <div class="panel panel-default">
-                    <div class="panel-body">
-                        <div id="minor-publishing" class="panel panel-default">
-                            <div class="panel-heading">
-                                <h3>Install or update H5P content types and libraries</h3>
-                            </div>
+                    <div class="panel-heading">
+                        <h3>Content types installed</h3>
+                    </div>
 
-                            <div class="panel-body row">
-                                <form method="post" enctype="multipart/form-data" id="h5p-library-form" class="col-md-6">
-                                    <h4>By file upload</h4>
-                                    <p>File must be .h5p format.</p>
-                                    <input type="file" name="h5p_file" id="h5p-file"/>
-                                    <br>
-                                    <div class="h5p-disable-file-check">
-                                        <label><input type="checkbox" name="h5p_upgrade_only" id="h5p-upgrade-only"/> Only update existing libraries</label>
-                                        <br>
-                                        <label><input type="checkbox" name="h5p_disable_file_check" id="h5p-disable-file-check"/> Disable file extension check</label>
-                                    </div>
-                                    <br>
-                                    <input type="hidden" id="lets_upgrade_that" name="lets_upgrade_that" value="228e7591a1">
-                                    <input type="hidden" name="_wp_http_referer" value="/wordpress/wp-admin/admin.php?page=h5p_libraries">
-                                    {!! csrf_field() !!}
-                                    <div id="major-publishing-actions" class="submitbox">
-                                        <input type="submit" name="submit" value="Upload" class="button button-primary button-large btn btn-primary"/>
-                                    </div>
-                                </form>
-
-                                <form action="{{ route('admin.check-for-updates') }}" method="post">
-                                    @csrf
-                                    <h4>Content types from h5p.org</h4>
-                                    <button type="submit" class="btn btn-success">Check for updates</button>
-                                </form>
-                            </div>
-
-                            @include('fragments.invalidFlashMessage')
-                        </div>
+                    <div class="panel-body row">
+                        @include('admin.fragments.library-table', [
+                            'libraries' => $installedContentTypes,
+                            'showCount' => true,
+                        ])
                     </div>
                 </div>
-                <div class="panel panel-default">
-                    <div class="panel-body">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                <h3>Content types installed</h3>
-                            </div>
 
-                            <div class="panel-body row">
-                                @include('admin.fragments.library-table', [
-                                    'libraries' => $installedContentTypes,
-                                    'showCount' => true,
-                                ])
-                            </div>
-                        </div>
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h3>Libraries installed</h3>
+                    </div>
+
+                    <div class="panel-body row">
+                        @include('admin.fragments.library-table', [
+                            'libraries' => $installedLibraries,
+                            'showCount' => true,
+                        ])
                     </div>
                 </div>
-                <div class="panel panel-default">
-                    <div class="panel-body">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                <h3>Libraries installed</h3>
-                            </div>
 
-                            <div class="panel-body row">
-                                @include('admin.fragments.library-table', [
-                                    'libraries' => $installedLibraries,
-                                    'showCount' => true,
-                                ])
-                            </div>
-                        </div>
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h3>Install from H5P.org</h3>
                     </div>
-                </div>
-                <div class="panel panel-default">
-                    <div class="panel-body">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                <h3>Install from H5P.org</h3>
-                            </div>
 
-                            <div class="panel-body row">
-                                @include('admin.fragments.library-table', [
-                                    'libraries' => $available,
-                                    'showSummary' => true,
-                                ])
-                            </div>
-                        </div>
+                    <div class="panel-body row">
+                        @include('admin.fragments.library-table', [
+                            'libraries' => $available,
+                            'showSummary' => true,
+                        ])
                     </div>
                 </div>
             </div>

--- a/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/library-check.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/library-check.blade.php
@@ -4,250 +4,234 @@
         <div class="row">
             <div class="col-md-12">
                 <div class="panel panel-default">
-                    <div class="panel-body">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                <h3>Details for {{ $library->runnable ? 'content type' : 'library' }} "<strong>{{ $library->name }}</strong>"</h3>
-                            </div>
+                    <div class="panel-heading">
+                        <h3>Details for {{ $library->runnable ? 'content type' : 'library' }} "<strong>{{ $library->name }}</strong>"</h3>
+                    </div>
 
-                            <div class="panel-body row">
-                                @if (count($info) > 0 || count($error) > 0)
-                                    @foreach ($info as $msg)
-                                        <div class="alert alert-info">
-                                            {{ $msg }}
-                                        </div>
-                                    @endforeach
-                                    @foreach ($error as $msg)
-                                        <div class="alert alert-danger">
-                                            {{ $msg }}
-                                        </div>
-                                    @endforeach
-                                @endif
-                                @if (is_array($libData) === false)
-                                    <div class="alert alert-info">
-                                        Data from 'libary.json' and 'semantics.json' may not be displayed since the
-                                        library failed validation
-                                    </div>
-                                @else
-                                    @if (array_key_exists('semantics', $libData) && $libData['semantics'] !== $library->semantics)
-                                        <div class="alert alert-danger">
-                                            Semantics data in database does not match the 'semantics.json' file.
-                                            Rebuild the library to update the database
-                                        </div>
+                    <div class="panel-body row">
+                        @if (count($info) > 0 || count($error) > 0)
+                            @foreach ($info as $msg)
+                                <div class="alert alert-info">
+                                    {{ $msg }}
+                                </div>
+                            @endforeach
+                            @foreach ($error as $msg)
+                                <div class="alert alert-danger">
+                                    {{ $msg }}
+                                </div>
+                            @endforeach
+                        @endif
+                        @if (is_array($libData) === false)
+                            <div class="alert alert-info">
+                                Data from 'libary.json' and 'semantics.json' may not be displayed since the
+                                library failed validation
+                            </div>
+                        @else
+                            @if (array_key_exists('semantics', $libData) && $libData['semantics'] !== $library->semantics)
+                                <div class="alert alert-danger">
+                                    Semantics data in database does not match the 'semantics.json' file.
+                                    Rebuild the library to update the database
+                                </div>
+                            @endif
+                            @if ($library && $libData && (
+                                    $library->major_version !== $libData['majorVersion'] ||
+                                    $library->minor_version !== $libData['minorVersion'] ||
+                                    $library->patch_version !== $libData['patchVersion']
+                                )
+                            )
+                                <div class="alert alert-danger">
+                                    Library version in database does not match version in 'library.json'
+                                </div>
+                            @endif
+                        @endif
+
+                        <table class="table table-striped">
+                            <tr>
+                                <th>Field</th>
+                                <th>Database</th>
+                                <th>library.json</th>
+                            </tr>
+                            <tr>
+                                <th>Library id</th>
+                                <td>{{ $library->id }}</td>
+                            </tr>
+                            <tr>
+                                <th>Machine name</th>
+                                <td>{{ $library->name }}</td>
+                                <td>{{ $libData['machineName'] ?? '' }}</td>
+                            </tr>
+                            <tr>
+                                <th>Title</th>
+                                <td>{{ $library->title }}</td>
+                                <td>{{ $libData['title'] ?? '' }}</td>
+                            </tr>
+                            <tr>
+                                <th>Description</th>
+                                <td></td>
+                                <td>{{ $libData['description'] ?? '' }}</td>
+                            </tr>
+                            <tr>
+                                <th>Major version</th>
+                                <td>{{ $library->major_version }}</td>
+                                <td>{{ $libData['majorVersion'] ?? '' }}</td>
+                            </tr>
+                            <tr>
+                                <th>Minor version</th>
+                                <td>{{ $library->minor_version }}</td>
+                                <td>{{ $libData['minorVersion'] ?? '' }}</td>
+                            </tr>
+                            <tr>
+                                <th>Patch version</th>
+                                <td>{{ $library->patch_version }}</td>
+                                <td>{{ $libData['patchVersion'] ?? '' }}</td>
+                            </tr>
+                            <tr>
+                                <th>Author</th>
+                                <td></td>
+                                <td>{{ $libData['author'] ?? '' }}</td>
+                            </tr>
+                            <tr>
+                                <th>License</th>
+                                <td></td>
+                                <td>{{ $libData['license'] ?? '' }}</td>
+                            </tr>
+                            <tr>
+                                <th>Content type</th>
+                                <td></td>
+                                <td>{{ $libData['contentType'] ?? '' }}</td>
+                            </tr>
+                            <tr>
+                                <th>Embed types</th>
+                                <td>{{ $library->embed_types }}</td>
+                                <td>{{ implode(', ', $libData['embedTypes'] ?? [])}}</td>
+                            </tr>
+                            <tr>
+                                <th>Created time</th>
+                                <td>{{ $library->created_at->format('Y-m-d H:i:s e') }}</td>
+                                <td></td>
+                            </tr>
+                            <tr>
+                                <th>Updated time</th>
+                                <td>{{ $library->updated_at->format('Y-m-d H:i:s e') }}</td>
+                                <td></td>
+                            </tr>
+                            <tr>
+                                <th>Runnable</th>
+                                <td>{{ $library->runnable }}</td>
+                                <td>{{ $libData['runnable'] ?? '' }}</td>
+                            </tr>
+                            <tr>
+                                <th>Fullscreen</th>
+                                <td>{{ $library->fullscreen }}</td>
+                                <td>{{ $libData['fullscreen'] ?? '' }}</td>
+                            </tr>
+                            <tr>
+                                <th>preloadedJs</th>
+                                <td>{!! str_replace(',', '<br>', $library->preloaded_js) !!}</td>
+                                <td>
+                                    @isset ($libData['preloadedJs'])
+                                        @foreach ($libData['preloadedJs'] as $pjs)
+                                            {{$pjs['path']}}
+                                            @if (!$loop->last)<br>@endif
+                                        @endforeach
+                                    @endisset
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>preloadedCss</th>
+                                <td>{!! str_replace(',', '<br>', $library->preloaded_css) !!}</td>
+                                <td>
+                                    @isset ($libData['preloadedCss'])
+                                        @foreach ($libData['preloadedCss'] as $pjs)
+                                            {{$pjs['path']}}
+                                            @if (!$loop->last)<br>@endif
+                                        @endforeach
+                                    @endisset
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+                </div>
+
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h3>Semantics</h3>
+                    </div>
+
+                    <div class="panel-body row">
+                        <table class="table table-striped">
+                            <tr>
+                                <th>Database</th>
+                                <th>semantics.json</th>
+                            </tr>
+                            <tr>
+                                <td>
+                                    @if(!empty($library->semantics))
+                                        <textarea wrap="off" readonly style="width:400px;height:300px;">{!!$library->semantics!!}</textarea>
                                     @endif
-                                    @if ($library && $libData && (
-                                            $library->major_version !== $libData['majorVersion'] ||
-                                            $library->minor_version !== $libData['minorVersion'] ||
-                                            $library->patch_version !== $libData['patchVersion']
-                                        )
-                                    )
-                                        <div class="alert alert-danger">
-                                            Library version in database does not match version in 'library.json'
-                                        </div>
+                                </td>
+                                <td>
+                                    @if($libData && array_key_exists('semantics', $libData) && !empty($libData['semantics']))
+                                        <textarea wrap="off" readonly style="width:400px;height:300px;">{!! $libData['semantics'] !!}</textarea>
                                     @endif
-                                @endif
-                            </div>
-
-                            <div class="panel-body row">
-                                <table class="table table-striped">
-                                    <tr>
-                                        <th>Field</th>
-                                        <th>Database</th>
-                                        <th>library.json</th>
-                                    </tr>
-                                    <tr>
-                                        <th>Library id</th>
-                                        <td>{{ $library->id }}</td>
-                                    </tr>
-                                    <tr>
-                                        <th>Machine name</th>
-                                        <td>{{ $library->name }}</td>
-                                        <td>{{ $libData['machineName'] ?? '' }}</td>
-                                    </tr>
-                                    <tr>
-                                        <th>Title</th>
-                                        <td>{{ $library->title }}</td>
-                                        <td>{{ $libData['title'] ?? '' }}</td>
-                                    </tr>
-                                    <tr>
-                                        <th>Description</th>
-                                        <td></td>
-                                        <td>{{ $libData['description'] ?? '' }}</td>
-                                    </tr>
-                                    <tr>
-                                        <th>Major version</th>
-                                        <td>{{ $library->major_version }}</td>
-                                        <td>{{ $libData['majorVersion'] ?? '' }}</td>
-                                    </tr>
-                                    <tr>
-                                        <th>Minor version</th>
-                                        <td>{{ $library->minor_version }}</td>
-                                        <td>{{ $libData['minorVersion'] ?? '' }}</td>
-                                    </tr>
-                                    <tr>
-                                        <th>Patch version</th>
-                                        <td>{{ $library->patch_version }}</td>
-                                        <td>{{ $libData['patchVersion'] ?? '' }}</td>
-                                    </tr>
-                                    <tr>
-                                        <th>Author</th>
-                                        <td></td>
-                                        <td>{{ $libData['author'] ?? '' }}</td>
-                                    </tr>
-                                    <tr>
-                                        <th>License</th>
-                                        <td></td>
-                                        <td>{{ $libData['license'] ?? '' }}</td>
-                                    </tr>
-                                    <tr>
-                                        <th>Content type</th>
-                                        <td></td>
-                                        <td>{{ $libData['contentType'] ?? '' }}</td>
-                                    </tr>
-                                    <tr>
-                                        <th>Embed types</th>
-                                        <td>{{ $library->embed_types }}</td>
-                                        <td>{{ implode(', ', $libData['embedTypes'] ?? [])}}</td>
-                                    </tr>
-                                    <tr>
-                                        <th>Created time</th>
-                                        <td>{{ $library->created_at->format('Y-m-d H:i:s e') }}</td>
-                                        <td></td>
-                                    </tr>
-                                    <tr>
-                                        <th>Updated time</th>
-                                        <td>{{ $library->updated_at->format('Y-m-d H:i:s e') }}</td>
-                                        <td></td>
-                                    </tr>
-                                    <tr>
-                                        <th>Runnable</th>
-                                        <td>{{ $library->runnable }}</td>
-                                        <td>{{ $libData['runnable'] ?? '' }}</td>
-                                    </tr>
-                                    <tr>
-                                        <th>Fullscreen</th>
-                                        <td>{{ $library->fullscreen }}</td>
-                                        <td>{{ $libData['fullscreen'] ?? '' }}</td>
-                                    </tr>
-                                    <tr>
-                                        <th>preloadedJs</th>
-                                        <td>{!! str_replace(',', '<br>', $library->preloaded_js) !!}</td>
-                                        <td>
-                                            @isset ($libData['preloadedJs'])
-                                                @foreach ($libData['preloadedJs'] as $pjs)
-                                                    {{$pjs['path']}}
-                                                    @if (!$loop->last)<br>@endif
-                                                @endforeach
-                                            @endisset
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <th>preloadedCss</th>
-                                        <td>{!! str_replace(',', '<br>', $library->preloaded_css) !!}</td>
-                                        <td>
-                                            @isset ($libData['preloadedCss'])
-                                                @foreach ($libData['preloadedCss'] as $pjs)
-                                                    {{$pjs['path']}}
-                                                    @if (!$loop->last)<br>@endif
-                                                @endforeach
-                                            @endisset
-                                        </td>
-                                    </tr>
-                                </table>
-                            </div>
-                        </div>
+                                </td>
+                            </tr>
+                        </table>
                     </div>
                 </div>
-                <div class="panel panel-default">
-                    <div class="panel-body">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                <h3>Semantics</h3>
-                            </div>
 
-                            <div class="panel-body row">
-                                <table class="table table-striped">
-                                    <tr>
-                                        <th>Database</th>
-                                        <th>semantics.json</th>
-                                    </tr>
-                                    <tr>
-                                        <td>
-                                            @if(!empty($library->semantics))
-                                                <textarea wrap="off" readonly style="width:400px;height:300px;">{!!$library->semantics!!}</textarea>
-                                            @endif
-                                        </td>
-                                        <td>
-                                            @if($libData && array_key_exists('semantics', $libData) && !empty($libData['semantics']))
-                                                <textarea wrap="off" readonly style="width:400px;height:300px;">{!! $libData['semantics'] !!}</textarea>
-                                            @endif
-                                        </td>
-                                    </tr>
-                                </table>
-                            </div>
-                        </div>
-                    </div>
                 <div class="panel panel-default">
-                    <div class="panel-body">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                <h3>Editor dependencies</h3>
-                            </div>
-                            @include ('admin.fragments.dependency-table', [
-                                'dependencies' => $libData['editorDependencies'] ?? [],
-                                'extraDependencies' => $editorDeps,
-                                'haveLibData' => $libData !== false,
-                            ])
-                        </div>
+                    <div class="panel-heading">
+                        <h3>Editor dependencies</h3>
+                    </div>
+                    @include ('admin.fragments.dependency-table', [
+                        'dependencies' => $libData['editorDependencies'] ?? [],
+                        'extraDependencies' => $editorDeps,
+                        'haveLibData' => $libData !== false,
+                    ])
+                </div>
+
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h3>Preload dependencies</h3>
+                    </div>
+
+                    @include ('admin.fragments.dependency-table', [
+                        'dependencies' => $libData['preloadedDependencies'] ?? [],
+                        'extraDependencies' => $preloadDeps,
+                        'haveLibData' => $libData !== false,
+                    ])
+                </div>
+
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h3>Referenced by</h3>
+                    </div>
+
+                    <div class="panel-body row">
+                        <table class="table table-striped">
+                            <tr>
+                                <th>DB id</th>
+                                <th>Machine name</th>
+                                <th>Type</th>
+                                <th>Version</th>
+                                <th>Dependency type</th>
+                            </tr>
+                            @foreach ($usedBy as $dep)
+                                <tr>
+                                    <td>{{ $dep->library->id }}</td>
+                                    <td>
+                                        <a href="{{ route('admin.check-library', [$dep->library->id]) }}">{{ $dep->library->name }}</a>
+                                    </td>
+                                    <td>{{ $dep->library->runnable ? 'Content type' : 'Library' }}</td>
+                                    <td>{{ $dep->library->major_version . '.' . $dep->library->minor_version . '.' . $dep->library->patch_version}}</td>
+                                    <td>{{ $dep->dependency_type }}</td>
+                                </tr>
+                            @endforeach
+                        </table>
                     </div>
                 </div>
-                <div class="panel panel-default">
-                    <div class="panel-body">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                <h3>Preload dependencies</h3>
-                            </div>
 
-                            @include ('admin.fragments.dependency-table', [
-                                'dependencies' => $libData['preloadedDependencies'] ?? [],
-                                'extraDependencies' => $preloadDeps,
-                                'haveLibData' => $libData !== false,
-                            ])
-                        </div>
-                    </div>
-                </div>
-                <div class="panel panel-default">
-                    <div class="panel-body">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                <h3>Referenced by</h3>
-                            </div>
-
-                            <div class="panel-body row">
-                                <table class="table table-striped">
-                                    <tr>
-                                        <th>DB id</th>
-                                        <th>Machine name</th>
-                                        <th>Type</th>
-                                        <th>Version</th>
-                                        <th>Dependency type</th>
-                                    </tr>
-                                    @foreach ($usedBy as $dep)
-                                        <tr>
-                                            <td>{{ $dep->library->id }}</td>
-                                            <td>
-                                                <a href="{{ route('admin.check-library', [$dep->library->id]) }}">{{ $dep->library->name }}</a>
-                                            </td>
-                                            <td>{{ $dep->library->runnable ? 'Content type' : 'Library' }}</td>
-                                            <td>{{ $dep->library->major_version . '.' . $dep->library->minor_version . '.' . $dep->library->patch_version}}</td>
-                                            <td>{{ $dep->dependency_type }}</td>
-                                        </tr>
-                                    @endforeach
-                                </table>
-                            </div>
-                        </div>
-                    </div>
-                </div>
             </div>
         </div>
     </div>

--- a/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/library-check.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/library-check.blade.php
@@ -171,7 +171,7 @@
                                     @endif
                                 </td>
                                 <td>
-                                    @if($libData && array_key_exists('semantics', $libData) && !empty($libData['semantics']))
+                                    @if(!empty($libData['semantics']))
                                         <textarea wrap="off" readonly style="width:400px;height:300px;">{!! $libData['semantics'] !!}</textarea>
                                     @endif
                                 </td>


### PR DESCRIPTION
- Cleanup HTML and remove excessive wrapping
- Align Action buttons
- Catch exceptions thrown by validator when uploading .h5p library