### PR TITLE
Use HTML translation endpoint for Nynorobot

### DIFF
--- a/sourcecode/apis/contentauthor/app/Http/Requests/ApiTranslationRequest.php
+++ b/sourcecode/apis/contentauthor/app/Http/Requests/ApiTranslationRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ApiTranslationRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return [
+            'fields' => ['required', 'array'],
+            'fields.*' => ['array'],
+            'fields.*.path' => ['required', 'string'],
+            'fields.*.value' => ['required', 'string'],
+        ];
+    }
+}

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Dataobjects/H5PTranslationDataObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Dataobjects/H5PTranslationDataObject.php
@@ -9,7 +9,7 @@ use JsonSerializable;
 class H5PTranslationDataObject implements JsonSerializable
 {
     /**
-     * @param array<string, string> $fields
+     * @param string[] $fields
      */
     public function __construct(
         private readonly array $fields,
@@ -18,7 +18,7 @@ class H5PTranslationDataObject implements JsonSerializable
     }
 
     /**
-     * @return array<string, string>
+     * @return string[]
      */
     public function getFields(): array
     {

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Dataobjects/H5PTranslationDataObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Dataobjects/H5PTranslationDataObject.php
@@ -1,33 +1,35 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Libraries\H5P\Dataobjects;
 
-use Cerpus\Helper\Traits\CreateTrait;
+use JsonSerializable;
 
-/**
- * @method static H5PTranslationDataObject create($attributes = null)
- */
-class H5PTranslationDataObject
+class H5PTranslationDataObject implements JsonSerializable
 {
-    use CreateTrait;
-
-    public $id;
-    private $document = [];
-
-    public function setField($fieldId, $fieldValue)
-    {
-        $this->document[$fieldId] = $fieldValue;
+    /**
+     * @param array<string, string> $fields
+     */
+    public function __construct(
+        private readonly array $fields,
+        private readonly string|null $id = null,
+    ) {
     }
 
-    public function setFieldsFromArray(array $values)
+    /**
+     * @return array<string, string>
+     */
+    public function getFields(): array
     {
-        foreach ($values as $key => $value) {
-            $this->setField($key, $value);
-        }
+        return $this->fields;
     }
 
-    public function getDocument()
+    public function jsonSerialize(): array
     {
-        return $this->document;
+        return [
+            'id' => $this->id,
+            'document' => $this->fields,
+        ];
     }
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/TranslationServices/NynorobotAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/TranslationServices/NynorobotAdapter.php
@@ -59,10 +59,7 @@ final class NynorobotAdapter implements TranslationServiceInterface
             },
         ]))->promise()->wait();
 
-        $data = clone $data;
-        $data->setFieldsFromArray($translated);
-
-        return $data;
+        return new H5PTranslationDataObject($translated);
     }
 
     /**
@@ -70,7 +67,7 @@ final class NynorobotAdapter implements TranslationServiceInterface
      */
     private function createTranslationRequests(H5PTranslationDataObject $data): Generator
     {
-        foreach ($data->getDocument() as $key => $value) {
+        foreach ($data->getFields() as $key => $value) {
             yield $key => new Request(
                 'POST',
                 (new Uri('translateText'))->withQuery(http_build_query([

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/TranslationServices/NynorobotAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/TranslationServices/NynorobotAdapter.php
@@ -6,20 +6,11 @@ namespace App\Libraries\H5P\TranslationServices;
 
 use App\Libraries\H5P\Dataobjects\H5PTranslationDataObject;
 use App\Libraries\H5P\Interfaces\TranslationServiceInterface;
-use Generator;
+use DOMElement;
 use GuzzleHttp\ClientInterface;
-use GuzzleHttp\Pool;
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Uri;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use Masterminds\HTML5;
 use RuntimeException;
-use Throwable;
-
-use function http_build_query;
-use function json_decode;
-
-use const JSON_THROW_ON_ERROR;
 
 final class NynorobotAdapter implements TranslationServiceInterface
 {
@@ -29,52 +20,104 @@ final class NynorobotAdapter implements TranslationServiceInterface
 
     /**
      * @param self::STYLE_* $style
-     * @param int<1, max> $concurrentRequests
      */
     public function __construct(
         private readonly ClientInterface $client,
         private readonly string $style,
-        private readonly int $concurrentRequests = 5,
     ) {
     }
 
     public function getTranslations(H5PTranslationDataObject $data): H5PTranslationDataObject
     {
-        $translated = [];
-        (new Pool($this->client, $this->createTranslationRequests($data), [
-            'concurrency' => $this->concurrentRequests,
-            'fulfilled' => function (
-                ResponseInterface $response,
-                int|string $key,
-            ) use (&$translated): void {
-                $translated[$key] = json_decode(
-                    $response->getBody()->getContents(),
-                    true,
-                    flags: JSON_THROW_ON_ERROR,
-                )['responseData']['translatedText']
-                    ?? throw new RuntimeException('Invalid JSON payload');
-            },
-            'rejected' => function (Throwable $e) {
-                throw new RuntimeException('Translation failed', 0, $e);
-            },
-        ]))->promise()->wait();
+        $html = $this->convertFieldsToHtml($data->getFields());
+
+        try {
+            $response = $this->client->request('POST', 'translateNHtml', [
+                'headers' => [
+                    'Accept' => 'text/html',
+                ],
+                'multipart' => [
+                    [
+                        'name' => 'file',
+                        'contents' => $html,
+                        'filename' => 'tmp.html',
+                        'headers' => [
+                            'Content-Type' => 'text/html',
+                        ],
+                    ]
+                ],
+                'query' => [
+                    'stilmal' => $this->style,
+                ],
+            ]);
+        } catch (GuzzleException $e) {
+            throw new RuntimeException('Error from translation service', 0, $e);
+        }
+
+        $translated = $this->extractTranslationFromHtml(
+            $response->getBody()->getContents(),
+        );
 
         return new H5PTranslationDataObject($translated);
     }
 
     /**
-     * @return Generator<array-key, RequestInterface>
+     * Convert fields to an HTML document, with each path represented as its own
+     * div tag.
+     *
+     * Example:
+     *
+     * ```html
+     * <html><body>
+     * <div edlib-translation-path="foo"><p>One fragment</p></div>
+     * <div edlib-translation-path="bar"><p>Another fragment</p></div>
+     * </body></html>
+     * ```
+     *
+     * @param string[] $fields
      */
-    private function createTranslationRequests(H5PTranslationDataObject $data): Generator
+    private function convertFieldsToHtml(array $fields): string
     {
-        foreach ($data->getFields() as $key => $value) {
-            yield $key => new Request(
-                'POST',
-                (new Uri('translateText'))->withQuery(http_build_query([
-                    'stilmal' => $this->style,
-                    'q' => $value,
-                ])),
-            );
+        $html5 = new HTML5(['disable_html_ns' => true]);
+        $dom = $html5->parse('<html><body></body></html>');
+        $root = $dom->getElementsByTagName('body')->item(0);
+        assert($root instanceof DOMElement);
+
+        foreach ($fields as $path => $value) {
+            $node = $dom->createElement('div');
+            $node->setAttribute('edlib-translation-path', (string) $path);
+            $node->appendChild($dom->importNode($html5->parseFragment($value), true));
+            $root->appendChild($node);
         }
+
+        return $dom->saveHTML();
+    }
+
+    /**
+     * Convert the fields from HTML converted by {@link self::convertFieldsToHtml()}
+     * and translated by the translation service back to an associative
+     * `path => html` array.
+     */
+    private function extractTranslationFromHtml(string $html): array
+    {
+        $fields = [];
+        $dom = (new HTML5(['disable_html_ns' => true]))->parse($html);
+        $body = $dom->getElementsByTagName('body')->item(0);
+
+        if (!$body instanceof DOMElement) {
+            throw new RuntimeException('The HTML was expected to contain a <body> tag');
+        }
+
+        $node = $body->firstElementChild;
+        do {
+            $path = $node->getAttribute('edlib-translation-path');
+            $value = '';
+            foreach ($node->childNodes as $subNode) {
+                $value .= $dom->saveHTML($subNode);
+            }
+            $fields[$path] = $value;
+        } while ($node = $node->nextElementSibling);
+
+        return $fields;
     }
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/TranslationServices/NynorskrobotenAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/TranslationServices/NynorskrobotenAdapter.php
@@ -5,46 +5,37 @@ namespace App\Libraries\H5P\TranslationServices;
 use App\Libraries\H5P\Dataobjects\H5PTranslationDataObject;
 use App\Libraries\H5P\Interfaces\TranslationServiceInterface;
 use GuzzleHttp\Client;
-use GuzzleHttp\Utils as GuzzleUtils;
+use const JSON_THROW_ON_ERROR;
 
 class NynorskrobotenAdapter implements TranslationServiceInterface
 {
-    public const MACHINENAME = 'nynorskroboten';
-    public const TRANSLATE_ENDPOINT = '/translate';
-
-    private $client;
-    private $apiToken;
-
-    public function __construct(Client $client, $apiToken)
-    {
-        $this->client = $client;
-        $this->apiToken = $apiToken;
+    public function __construct(
+        private readonly Client $client,
+        private readonly string $apiToken,
+    ) {
     }
 
-    public function getTranslations(H5PTranslationDataObject $translatable): H5PTranslationDataObject
+    public function getTranslations(H5PTranslationDataObject $data): H5PTranslationDataObject
     {
-        $response = $this->client->post(self::TRANSLATE_ENDPOINT, [
-            'json' => $this->convertSourceToObject($translatable),
+        $response = $this->client->post('translate', [
+            'json' => $this->convertSourceToObject($data),
         ]);
-        $responseJSONData = GuzzleUtils::jsonDecode($response->getBody()->getContents());
-        $returnData = clone $translatable;
-        $returnData->id = $responseJSONData->guid;
-        $returnData->setFieldsFromArray((array)$responseJSONData->document);
+        $responseData = json_decode(
+            $response->getBody()->getContents(),
+            true,
+            flags: JSON_THROW_ON_ERROR,
+        );
 
-        return $returnData;
+        return new H5PTranslationDataObject($responseData['document'], $responseData['guid']);
     }
 
-    /**
-     * @param H5PTranslationDataObject $data
-     * @return array
-     */
-    private function convertSourceToObject($data)
+    private function convertSourceToObject(H5PTranslationDataObject $data): array
     {
         return [
             'token' => $this->apiToken,
-            'guid' => $data->id ?? "",
+            'guid' => $data['id'] ?? '',
             'fileType' => 'htmlp',
-            'document' => $data->getDocument(),
+            'document' => $data->getFields(),
         ];
     }
 }

--- a/sourcecode/apis/contentauthor/composer.json
+++ b/sourcecode/apis/contentauthor/composer.json
@@ -9,8 +9,8 @@
     "require": {
         "php": "8.1.*",
         "ext-dom": "*",
-        "ext-json": "*",
         "ext-iconv": "*",
+        "ext-json": "*",
         "ext-libxml": "*",
         "ext-oauth": "*",
         "ext-pdo": "*",
@@ -39,7 +39,7 @@
         "league/flysystem-ziparchive": "^3.0",
         "league/fractal": "^0.20",
         "league/mime-type-detection": "^1.9",
-        "masterminds/html5": "^2.6",
+        "masterminds/html5": "^2.7",
         "matthiasmullie/minify": "^1.3",
         "predis/predis": "^1.1",
         "ramsey/uuid": "^4.2",

--- a/sourcecode/apis/contentauthor/composer.lock
+++ b/sourcecode/apis/contentauthor/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "13b8a8147d1e6cacd5bcc60834ccaf25",
+    "content-hash": "8bece1d57b552b9f7495dbe3f30ec8a8",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -11167,8 +11167,8 @@
     "platform": {
         "php": "8.1.*",
         "ext-dom": "*",
-        "ext-json": "*",
         "ext-iconv": "*",
+        "ext-json": "*",
         "ext-libxml": "*",
         "ext-oauth": "*",
         "ext-pdo": "*",

--- a/sourcecode/apis/contentauthor/phpstan-baseline.neon
+++ b/sourcecode/apis/contentauthor/phpstan-baseline.neon
@@ -1077,16 +1077,6 @@ parameters:
 			path: app/Libraries/H5P/Storage/H5PCerpusStorage.php
 
 		-
-			message: "#^Cannot access property \\$document on array\\|bool\\|float\\|int\\|object\\|string\\.$#"
-			count: 1
-			path: app/Libraries/H5P/TranslationServices/NynorskrobotenAdapter.php
-
-		-
-			message: "#^Cannot access property \\$guid on array\\|bool\\|float\\|int\\|object\\|string\\.$#"
-			count: 1
-			path: app/Libraries/H5P/TranslationServices/NynorskrobotenAdapter.php
-
-		-
 			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:get\\(\\)\\.$#"
 			count: 3
 			path: app/Libraries/H5P/Video/NDLAVideoAdapter.php

--- a/sourcecode/apis/contentauthor/tests/Unit/Libraries/H5P/TranslationServices/NynorobotAdapterTest.php
+++ b/sourcecode/apis/contentauthor/tests/Unit/Libraries/H5P/TranslationServices/NynorobotAdapterTest.php
@@ -60,7 +60,7 @@ final class NynorobotAdapterTest extends TestCase
             'foo' => 'Några saker',
             'att översätta',
             'bar' => 'och testa',
-        ], $translated->getDocument());
+        ], $translated->getFields());
     }
 
     public function testThrowsOnHttpFailure(): void

--- a/sourcecode/apis/contentauthor/tests/Unit/Libraries/H5P/TranslationServices/NynorobotAdapterTest.php
+++ b/sourcecode/apis/contentauthor/tests/Unit/Libraries/H5P/TranslationServices/NynorobotAdapterTest.php
@@ -14,8 +14,6 @@ use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 
-use function json_encode;
-
 final class NynorobotAdapterTest extends TestCase
 {
     private MockHandler $mockedResponses;
@@ -36,14 +34,17 @@ final class NynorobotAdapterTest extends TestCase
     public function testCanTranslateTheStuff(): void
     {
         $this->mockedResponses->append(
-            $this->translatedResponse('Några saker'),
-            $this->translatedResponse('att översätta'),
-            $this->translatedResponse('och testa'),
+            new Response(200, ['Content-Type' => 'text/html'], <<<EOHTML
+            <html><body>
+            <div edlib-translation-path="foo"><p>Några saker</p></div>
+            <div edlib-translation-path="0">att översätta</div>
+            <div edlib-translation-path="bar"><h1>och testa</h1></div>
+            </body></html>
+            EOHTML),
         );
 
-        $data = new H5PTranslationDataObject();
-        $data->setFieldsFromArray([
-            'foo' => 'Noen greier',
+        $data = new H5PTranslationDataObject([
+            'foo' => '<p>Noen greier</p>',
             'å oversette',
             'bar' => 'og teste',
         ]);
@@ -51,36 +52,25 @@ final class NynorobotAdapterTest extends TestCase
         $adapter = new NynorobotAdapter(
             $this->client,
             NynorobotAdapter::STYLE_RADICAL,
-            2,
         );
         $translated = $adapter->getTranslations($data);
 
         $this->assertNotSame($data, $translated);
         $this->assertSame([
-            'foo' => 'Några saker',
+            'foo' => "<p>Några saker</p>",
             'att översätta',
-            'bar' => 'och testa',
+            'bar' => '<h1>och testa</h1>',
         ], $translated->getFields());
     }
 
     public function testThrowsOnHttpFailure(): void
     {
         $this->mockedResponses->append(new Response(500, [], ''));
-        $data = new H5PTranslationDataObject();
-        $data->setFieldsFromArray(['foo']);
+        $data = new H5PTranslationDataObject(['foo' => 'bar']);
         $adapter = new NynorobotAdapter($this->client, NynorobotAdapter::STYLE_MODERATE);
 
-        $this->expectExceptionMessage('Translation failed');
+        $this->expectExceptionMessage('Error from translation service');
 
         $adapter->getTranslations($data);
-    }
-
-    private function translatedResponse(string $text): Response
-    {
-        return new Response(200, [], json_encode([
-            'responseData' => ['translatedText' => $text],
-            'responseDetails' => null,
-            'responseStatus' => 200,
-        ]));
     }
 }


### PR DESCRIPTION
Switch to using Nynorobot's HTML translation endpoint, as the endpoint in CA receives HTML input. To avoid multiple requests, each field becomes its own element in the HTML that is sent off to be translated, and the HTML response is then converted back into `path => value` array elements.

In a separate commit, request validation was added and some general cleanup was performed. It might be best to review these commits separately.