### PR TITLE
Do not log uninteresting events

### DIFF
--- a/sourcecode/apis/contentauthor/app/Console/Commands/RemoveOldContentLocks.php
+++ b/sourcecode/apis/contentauthor/app/Console/Commands/RemoveOldContentLocks.php
@@ -50,7 +50,7 @@ class RemoveOldContentLocks extends Command
             ContentLock::whereIn('content_id', $staleLocks)->delete();
             Log::info("Removed " . count($staleLocks) . " stale locks.");
         } else {
-            Log::info("No stale locks removed.");
+            Log::debug("No stale locks removed.");
         }
     }
 }

--- a/sourcecode/apis/contentauthor/config/logging.php
+++ b/sourcecode/apis/contentauthor/config/logging.php
@@ -62,6 +62,7 @@ return [
             'with' => [
                 'stream' => 'php://stderr',
             ],
+            'level' => 'info',
         ],
         'syslog' => [
             'driver' => 'syslog',


### PR DESCRIPTION
Laravel has a logger implementing [PSR-3](https://www.php-fig.org/psr/psr-3/) which defines the `info` logging level as:

```php
/**
 * Interesting events.
 *
 * Example: User logs in, SQL logs.
 *
 * @param string $message
 * @param array $context
 * @return void
 */
public function info($message, array $context = array());
```

Yet, Content Author logs with this level what is indisputably **not** an interesting event: that nothing happened. This happens every minute, filling the logs with useless information.

To fix this, the level is adjusted to `debug`, and the minimum logging level for the stderr handler is set to `info`.