### PR TITLE
CA Admin: Improve bulk updating content by using new 'skipped' value

### DIFF
--- a/sourcecode/apis/contentauthor/phpstan-baseline.neon
+++ b/sourcecode/apis/contentauthor/phpstan-baseline.neon
@@ -1722,6 +1722,11 @@ parameters:
 			path: tests/Integration/Libraries/H5P/H5PExportTest.php
 
 		-
+			message: "#^Access to an undefined property Illuminate\\\\Database\\\\Eloquent\\\\Model\\:\\:\\$id\\.$#"
+			count: 13
+			path: tests/Integration/Libraries/H5P/H5PLibraryAdminTest.php
+
+		-
 			message: "#^Access to an undefined property Faker\\\\Generator\\:\\:\\$mimeType\\.$#"
 			count: 1
 			path: tests/Integration/Libraries/H5P/Package/ColumnTest.php

--- a/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PLibraryAdminTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PLibraryAdminTest.php
@@ -24,12 +24,12 @@ class H5PLibraryAdminTest extends TestCase
             ->post(route('admin.content-upgrade', ['id' => $fromLib->id]), [
                 'libraryId' => $toLib->id,
             ])
+            ->assertOk()
             ->assertJson([
                 'left' => 2,
                 'skipped' => [],
                 'params' => [],
-            ])
-            ->assertOk();
+            ]);
 
         $content = $ret->decodeResponseJson();
         $this->assertCount(2, $content['params']);
@@ -65,12 +65,12 @@ class H5PLibraryAdminTest extends TestCase
                     ]),
                 ]),
             ])
+            ->assertOk()
             ->assertJson([
                 'left' => 0,
                 'skipped' => $skipped,
                 'params' => [],
-            ])
-            ->assertOk();
+            ]);
 
         $content = $ret->decodeResponseJson();
         $this->assertCount(0, $content['params']);

--- a/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PLibraryAdminTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PLibraryAdminTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Integration\Libraries\H5P;
+
+use App\H5PContent;
+use App\H5PLibrary;
+use Illuminate\Auth\GenericUser;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class H5PLibraryAdminTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_upgradeProgress_firstRequest(): void
+    {
+        $fromLib = H5PLibrary::factory()->create();
+        $toLib = H5PLibrary::factory()->create(['major_version' => 2]);
+        H5PContent::factory(2)->create([
+            'library_id' => $fromLib->id,
+        ]);
+
+        $ret = $this->withSession(['user' => new GenericUser(['roles' => ['superadmin']])])
+            ->post(route('admin.content-upgrade', ['id' => $fromLib->id]), [
+                'libraryId' => $toLib->id,
+            ])
+            ->assertJson([
+                'left' => 2,
+                'skipped' => [],
+                'params' => [],
+            ])
+            ->assertOk();
+
+        $content = $ret->decodeResponseJson();
+        $this->assertCount(2, $content['params']);
+    }
+
+    public function test_upgradeProgress_updateRequest(): void
+    {
+        $fromLib = H5PLibrary::factory()->create();
+        $toLib = H5PLibrary::factory()->create(['major_version' => 2]);
+        $libContent = H5PContent::factory(2)->create([
+            'library_id' => $fromLib->id,
+            'parameters' => 'old params',
+            'filtered' => 'old filtered',
+        ]);
+        $skipped = [$libContent[1]->id];
+
+        $ret = $this->withSession(['user' => new GenericUser(['roles' => ['superadmin']])])
+            ->post(route('admin.content-upgrade', ['id' => $fromLib->id]), [
+                'libraryId' => $toLib->id,
+                'skipped' => json_encode($skipped),
+                'params' => json_encode([
+                    $libContent[0]->id => json_encode((object) [
+                        'params' => 'new params',
+                        'metadata' => (object)[
+                            'title' => 'title',
+                            'authors' => [
+                                (object) [
+                                    'name' => 'D.F. Duck',
+                                    'role' => 'Tester',
+                                ],
+                            ],
+                        ],
+                    ]),
+                ]),
+            ])
+            ->assertJson([
+                'left' => 0,
+                'skipped' => $skipped,
+                'params' => [],
+            ])
+            ->assertOk();
+
+        $content = $ret->decodeResponseJson();
+        $this->assertCount(0, $content['params']);
+        $this->assertDatabaseHas('h5p_contents', [
+            'id' => $libContent[0]->id,
+            'library_id' => $toLib->id,
+            'parameters' => '"new params"',
+            'filtered' => '',
+        ]);
+        $this->assertDatabaseHas('h5p_contents_metadata', [
+            'content_id' => $libContent[0]->id,
+            'authors' => '[{"name":"D.F. Duck","role":"Tester"}]',
+        ]);
+        $this->assertDatabaseHas('h5p_contents', [
+            'id' => $libContent[1]->id,
+            'library_id' => $fromLib->id,
+        ]);
+    }
+}


### PR DESCRIPTION
`skipped` contains IDs of content that failed to update, it's used to filter already failed content from being sent to the client again