### PR TITLE
GH #781: Reserve space for scrollbar

### DIFF
--- a/sourcecode/apis/contentauthor/resources/assets/sass/app.scss
+++ b/sourcecode/apis/contentauthor/resources/assets/sass/app.scss
@@ -248,6 +248,7 @@ select[name="h5peditor-library"] {
     padding-right: 0;
 
     & > div {
+      scrollbar-gutter: stable both-edges;
       @include respond-to('desktop') {
         overflow-y: auto;
         max-height: calc(100vh - 7rem);


### PR DESCRIPTION
If a scrollbar could be displayed, reserve space space for it. Equal space is reserved on the opposite side to make the content centered.