### PR TITLE
Fix streamed downloads

### DIFF
--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Interfaces/H5PDownloadInterface.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Interfaces/H5PDownloadInterface.php
@@ -2,7 +2,9 @@
 
 namespace App\Libraries\H5P\Interfaces;
 
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
 interface H5PDownloadInterface
 {
-    public function downloadContent($filename, $title);
+    public function downloadContent(string $filename, string $title): StreamedResponse;
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Storage/H5PCerpusStorage.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Storage/H5PCerpusStorage.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Facades\Log;
 use League\Flysystem\FilesystemException;
 use League\Flysystem\StorageAttributes;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class H5PCerpusStorage implements H5PFileStorage, H5PDownloadInterface, CerpusStorageInterface
 {
@@ -536,16 +537,11 @@ class H5PCerpusStorage implements H5PFileStorage, H5PDownloadInterface, CerpusSt
         return $upload;
     }
 
-    /**
-     * @return \Symfony\Component\HttpFoundation\StreamedResponse
-     * @throws Exception
-     */
-    public function downloadContent($filename, $title)
+    public function downloadContent(string $filename, string $title): StreamedResponse
     {
-        return response()->streamDownload(function () use ($filename) {
-            $path = sprintf(ContentStorageSettings::EXPORT_PATH, $filename);
-            echo $this->filesystem->response($path)->sendContent();
-        }, $filename);
+        $path = sprintf(ContentStorageSettings::EXPORT_PATH, $filename);
+
+        return $this->filesystem->response($path);
     }
 
     public function getDisplayPath(bool $fullUrl = true)


### PR DESCRIPTION
Fixes (hopefully) an out-of-memory caused by converting a huge response to a string.

Laravel is in charge of calling the `sendContent()` method on a streamed response. We just need to return the response object. Because the streamed response was echoed, the response was converted to a string containing the entire response body.

While we're at it, we demystify `H5PDownloadInterface` by adding types.