### PR TITLE
Remove dependency to cerpus/coreclient

### DIFF
--- a/sourcecode/apis/contentauthor/app/Http/Middleware/LtiBehaviorSettings.php
+++ b/sourcecode/apis/contentauthor/app/Http/Middleware/LtiBehaviorSettings.php
@@ -3,9 +3,9 @@
 namespace App\Http\Middleware;
 
 use App\Http\Requests\LTIRequest;
+use App\Libraries\DataObjects\BehaviorSettingsDataObject;
+use App\Libraries\DataObjects\EditorBehaviorSettingsDataObject;
 use App\SessionKeys;
-use Cerpus\CoreClient\DataObjects\BehaviorSettingsDataObject;
-use Cerpus\CoreClient\DataObjects\EditorBehaviorSettingsDataObject;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Session;

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/Answer.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/Answer.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Libraries\DataObjects;
+
+use Cerpus\Helper\Traits\CreateTrait;
+
+class Answer
+{
+    use CreateTrait;
+
+    /**
+     * @var string
+     */
+    public $text;
+
+    /**
+     * @var bool
+     */
+    public $correct = false;
+}

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/BaseDataObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/BaseDataObject.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Libraries\DataObjects;
+
+abstract class BaseDataObject
+{
+    protected $guarded = [];
+}

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/BehaviorSettingsDataObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/BehaviorSettingsDataObject.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Libraries\DataObjects;
+
+use Cerpus\Helper\Traits\CreateTrait;
+
+/**
+ * @method static BehaviorSettingsDataObject create($attributes = null)
+ */
+class BehaviorSettingsDataObject extends BaseDataObject
+{
+    use CreateTrait;
+
+    /**
+     * Setting to override the logic to retry a H5P in the learners view.
+     * True = enables retry
+     * False = disables retry
+     * Null = use value set on the resource(default)
+     *
+     * @var bool|null
+     */
+    public $enableRetry;
+
+    /**
+     * Setting to override the logic to enable instant checking of answers in the learners view
+     * True = enables auto checking of answers
+     * False = disables auto checking of answers
+     * Null = use value set on the resource(default)
+
+     * @var bool|null
+     */
+    public $autoCheck;
+
+    /**
+     * Setting to preset a mode for behavior settings.
+     *
+     * Supported modes are 'exam' and 'score'
+     *
+     * Mode 'exam' equals {
+     *      enableRetry: false,
+     *      autoCheck: false
+     * }
+     *
+     * Mode 'score' equals {
+     *      enableRetry: true,
+     *      autoCheck: false
+     * }
+     */
+    public $presetmode;
+
+    /**
+     * Setting to override the logic to enable or disable showint the solution in the learners view
+     * True = enables showing of solution
+     * False = disables showing of solution
+     * Null = use value set on the resource(default)
+     * @var bool|null
+     */
+    public $showSolution;
+
+    /**
+     * Setting to skip including the previous answers when loading a resource
+     * True = include answers
+     * False = exclude answers
+     * @var bool
+     */
+    public $includeAnswers = true;
+
+    /**
+     * Setting to be able to override the setting of hide/show the summary
+     * True = summary is shown
+     * False = summari is suppressed
+     */
+    public $showSummary;
+
+    public static $rules = [
+        'enableRetry' => 'boolean|nullable',
+        'autoCheck' => 'boolean|nullable',
+        'presetmode' => ['regex:/^(exam|score)$/', 'nullable'],
+        'showSolution' => 'boolean|nullable',
+        'includeAnswers' => 'boolean|nullable',
+        'showSummary' => 'boolean|nullable',
+    ];
+}

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/EditorBehaviorSettingsDataObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/EditorBehaviorSettingsDataObject.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Libraries\DataObjects;
+
+use JsonSerializable;
+use Cerpus\Helper\Traits\CreateTrait;
+
+/**
+ * @method static EditorBehaviorSettingsDataObject create($attributes = null)
+ */
+class EditorBehaviorSettingsDataObject extends BaseDataObject implements JsonSerializable
+{
+    use CreateTrait;
+
+    /**
+     * Setting to display "Text overrides and translations".
+     * True = hide in editor(default)
+     * False = show in editor
+     *
+     * @var bool
+     */
+    public $hideTextAndTranslations = true;
+
+    private $behaviorSettings;
+
+    public static $rules = [
+        'hideTextAndTranslations' => 'boolean',
+    ];
+
+    public function setBehaviorSettings(BehaviorSettingsDataObject $settingsDataObject)
+    {
+        $this->behaviorSettings = $settingsDataObject;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/MultiChoiceQuestion.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/MultiChoiceQuestion.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Libraries\DataObjects;
+
+use Cerpus\Helper\Traits\CreateTrait;
+
+class MultiChoiceQuestion extends Question
+{
+    use CreateTrait;
+
+    /**
+     * @var string
+     */
+    protected $type = 'H5P.MultiChoice';
+}

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/Question.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/Question.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Libraries\DataObjects;
+
+use Illuminate\Support\Collection;
+
+abstract class Question
+{
+    /**
+     * @var string
+     */
+    public $text;
+
+    /**
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * @var Collection
+     */
+    protected $answers;
+
+    public function __construct()
+    {
+        $this->answers = collect();
+    }
+
+    public function addAnswer(Answer $answer)
+    {
+        $this->answers->push($answer);
+    }
+
+    public function addAnswers(Collection $answers)
+    {
+        $that = $this;
+        $answers->each(function($answer) use ($that) {
+            $that->addAnswer($answer);
+        });
+    }
+
+    /**
+     * @return Collection
+     */
+    public function getAnswers()
+    {
+        return $this->answers;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+}

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/Question.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/Question.php
@@ -34,7 +34,7 @@ abstract class Question
     public function addAnswers(Collection $answers)
     {
         $that = $this;
-        $answers->each(function($answer) use ($that) {
+        $answers->each(function ($answer) use ($that) {
             $that->addAnswer($answer);
         });
     }

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/Questionset.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/Questionset.php
@@ -14,7 +14,9 @@ class Questionset
     /** @var string $authId */
     /** @var string $licence */
     /** @var string $title */
-    public $authId, $license, $title;
+    public $authId;
+    public $license;
+    public $title;
 
     protected $type = 'H5P.QuestionSet';
 
@@ -34,18 +36,14 @@ class Questionset
         $this->questions = collect();
     }
 
-    /**
-     * @param MultiChoiceQuestion $question
-     */
+
     public function addQuestion(MultiChoiceQuestion $question)
     {
         $this->questions->push($question);
         $this->updateScore($question);
     }
 
-    /**
-     * @param bool $sharing
-     */
+
     public function setSharing(bool $sharing)
     {
         $this->sharing = $sharing;

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/Questionset.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/Questionset.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Libraries\DataObjects;
+
+use Cerpus\Helper\Traits\CreateTrait;
+
+/**
+ * @method static Questionset create($attributes = null)
+ */
+class Questionset
+{
+    use CreateTrait;
+
+    /** @var string $authId */
+    /** @var string $licence */
+    /** @var string $title */
+    public $authId, $license, $title;
+
+    protected $type = 'H5P.QuestionSet';
+
+    /** @var \Illuminate\Support\Collection */
+    private $questions;
+    /** @var bool */
+    private $sharing = false;
+
+    /** @var int */
+    private $score = 0;
+
+    /** @var bool */
+    public $published = true;
+
+    public function __construct()
+    {
+        $this->questions = collect();
+    }
+
+    /**
+     * @param MultiChoiceQuestion $question
+     */
+    public function addQuestion(MultiChoiceQuestion $question)
+    {
+        $this->questions->push($question);
+        $this->updateScore($question);
+    }
+
+    /**
+     * @param bool $sharing
+     */
+    public function setSharing(bool $sharing)
+    {
+        $this->sharing = $sharing;
+    }
+
+    /**
+     * @return \Illuminate\Support\Collection
+     */
+    public function getQuestions()
+    {
+        return $this->questions;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getSharing()
+    {
+        return $this->sharing;
+    }
+
+    public function getScore()
+    {
+        return $this->score;
+    }
+
+    private function updateScore(MultiChoiceQuestion $question)
+    {
+        $this->score += $question->getAnswers()
+            ->filter(function ($answer) {
+                return $answer->correct;
+            })
+            ->count();
+    }
+}

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Interfaces/ContentTypeInterface.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Interfaces/ContentTypeInterface.php
@@ -2,8 +2,8 @@
 
 namespace App\Libraries\H5P\Interfaces;
 
-use Cerpus\CoreClient\DataObjects\BehaviorSettingsDataObject;
-use Cerpus\CoreClient\DataObjects\EditorBehaviorSettingsDataObject;
+use App\Libraries\DataObjects\BehaviorSettingsDataObject;
+use App\Libraries\DataObjects\EditorBehaviorSettingsDataObject;
 
 interface ContentTypeInterface
 {

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/H5PBase.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Packages/H5PBase.php
@@ -2,11 +2,11 @@
 
 namespace App\Libraries\H5P\Packages;
 
+use App\Libraries\DataObjects\BehaviorSettingsDataObject;
+use App\Libraries\DataObjects\EditorBehaviorSettingsDataObject;
 use App\Libraries\H5P\Interfaces\ContentTypeInterface;
 use App\Libraries\H5P\Interfaces\PackageInterface;
 use App\Traits\H5PBehaviorSettings;
-use Cerpus\CoreClient\DataObjects\BehaviorSettingsDataObject;
-use Cerpus\CoreClient\DataObjects\EditorBehaviorSettingsDataObject;
 
 /**
  * @method applyEditorBehaviorSettings(EditorBehaviorSettingsDataObject $settingsDataObject)

--- a/sourcecode/apis/contentauthor/app/Libraries/QuestionSet/QuestionSetConvert.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/QuestionSet/QuestionSetConvert.php
@@ -4,14 +4,14 @@ namespace App\Libraries\QuestionSet;
 
 use App\Content;
 use App\Http\Controllers\API\Handler\ContentTypeHandler;
+use App\Libraries\DataObjects\Answer;
+use App\Libraries\DataObjects\MultiChoiceQuestion;
+use App\Libraries\DataObjects\Questionset as QuestionSetData;
 use App\Libraries\DataObjects\ResourceMetadataDataObject;
 use App\Libraries\Games\GameHandler;
 use App\Libraries\Games\Millionaire\Millionaire;
 use App\Libraries\H5P\Packages\QuestionSet as H5PQuestionSet;
 use App\QuestionSet as QuestionSetModel;
-use Cerpus\CoreClient\DataObjects\Answer;
-use Cerpus\CoreClient\DataObjects\MultiChoiceQuestion;
-use Cerpus\CoreClient\DataObjects\Questionset as CoreClientQuestionset;
 
 class QuestionSetConvert
 {
@@ -34,7 +34,7 @@ class QuestionSetConvert
 
     public function createH5PQuestionSet(QuestionSetModel $questionSet, ResourceMetadataDataObject $metaData): array
     {
-        $h5pQuiz = CoreClientQuestionset::create([
+        $h5pQuiz = QuestionSetData::create([
             'title' => $questionSet->title,
             'license' => $metaData->license,
             'share' => $metaData->share,

--- a/sourcecode/apis/contentauthor/app/Traits/H5PBehaviorSettings.php
+++ b/sourcecode/apis/contentauthor/app/Traits/H5PBehaviorSettings.php
@@ -2,16 +2,14 @@
 
 namespace App\Traits;
 
-use Cerpus\CoreClient\DataObjects\BehaviorSettingsDataObject;
-use Cerpus\CoreClient\DataObjects\EditorBehaviorSettingsDataObject;
+use App\Libraries\DataObjects\BehaviorSettingsDataObject;
+use App\Libraries\DataObjects\EditorBehaviorSettingsDataObject;
 
 trait H5PBehaviorSettings
 {
-    /** @var BehaviorSettingsDataObject */
-    protected $behaviorSettings;
+    protected BehaviorSettingsDataObject|null $behaviorSettings = null;
 
-    /** @var EditorBehaviorSettingsDataObject */
-    protected $editorBehaviorSettings;
+    protected EditorBehaviorSettingsDataObject|null $editorBehaviorSettings = null;
 
     protected $packageStructure;
     private $css = [];
@@ -69,9 +67,9 @@ trait H5PBehaviorSettings
             return;
         }
         $this->alterRetryButton();
-        $this->addCss(sprintf('.h5p-flashcards-results.show .h5p-results-retry-button, 
-        .h5p-image-sequencing .h5p-image-sequencing-retry 
-        { 
+        $this->addCss(sprintf('.h5p-flashcards-results.show .h5p-results-retry-button,
+        .h5p-image-sequencing .h5p-image-sequencing-retry
+        {
             display: %s;
         }', $this->behaviorSettings->enableRetry === true ? 'inline-block' : 'none'));
     }

--- a/sourcecode/apis/contentauthor/composer.json
+++ b/sourcecode/apis/contentauthor/composer.json
@@ -16,7 +16,6 @@
         "ext-pdo": "*",
         "ext-zip": "*",
         "cerpus/cerpushelper": "^2.1",
-        "cerpus/coreclient": "^1.4.0",
         "cerpus/edlib-resource-kit-laravel": "^0.6.0",
         "cerpus/imageservice-client": "^2.1",
         "cerpus/laravel-rabbitmq-pubsub": "^2.1",

--- a/sourcecode/apis/contentauthor/composer.lock
+++ b/sourcecode/apis/contentauthor/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "211f9a624c6cce708322275ff71cb579",
+    "content-hash": "1fd674e156313954899ecd7a6d284612",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -393,70 +393,6 @@
                 "source": "https://github.com/cerpus/php-cerpushelper/tree/v2.2.0"
             },
             "time": "2023-03-15T09:34:04+00:00"
-        },
-        {
-            "name": "cerpus/coreclient",
-            "version": "v1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/cerpus/php-coreclient.git",
-                "reference": "a19d2d2b9fd95e19514adbb6ea2b753623af3697"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/cerpus/php-coreclient/zipball/a19d2d2b9fd95e19514adbb6ea2b753623af3697",
-                "reference": "a19d2d2b9fd95e19514adbb6ea2b753623af3697",
-                "shasum": ""
-            },
-            "require": {
-                "cerpus/cerpushelper": "^1.0|^2.0",
-                "ext-json": "*",
-                "illuminate/http": "*",
-                "php": "^7.4 || ^8.0"
-            },
-            "require-dev": {
-                "fakerphp/faker": "^1.16",
-                "illuminate/validation": "^6.0",
-                "mockery/mockery": "^1.0",
-                "phpunit/phpunit": "^9.5"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "Cerpus\\CoreClient\\Providers\\CoreClientServiceProvider"
-                    ],
-                    "aliases": {
-                        "CoreClient": "Cerpus\\CoreClient\\CoreClient"
-                    }
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Cerpus\\CoreClient\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-3.0-only"
-            ],
-            "authors": [
-                {
-                    "name": "Thomas Horn Sivertsen",
-                    "email": "thomass@cerpus.com"
-                }
-            ],
-            "description": "Client for communication with Core",
-            "keywords": [
-                "Cerpus Core API Client",
-                "laravel",
-                "lumen"
-            ],
-            "support": {
-                "issues": "https://github.com/cerpus/php-coreclient/issues",
-                "source": "https://github.com/cerpus/php-coreclient/tree/v1.5.0"
-            },
-            "time": "2022-01-21T14:54:46+00:00"
         },
         {
             "name": "cerpus/edlib-resource-kit",
@@ -3204,6 +3140,7 @@
                 "issues": "https://github.com/LaravelCollective/html/issues",
                 "source": "https://github.com/LaravelCollective/html"
             },
+            "abandoned": "spatie/laravel-html",
             "time": "2023-02-13T18:15:35+00:00"
         },
         {
@@ -4879,6 +4816,7 @@
                 "issues": "https://github.com/php-http/message-factory/issues",
                 "source": "https://github.com/php-http/message-factory/tree/master"
             },
+            "abandoned": "psr/http-factory",
             "time": "2015-12-19T14:08:53+00:00"
         },
         {

--- a/sourcecode/apis/contentauthor/phpstan-baseline.neon
+++ b/sourcecode/apis/contentauthor/phpstan-baseline.neon
@@ -1092,11 +1092,6 @@ parameters:
 			path: app/Libraries/H5P/ViewConfig.php
 
 		-
-			message: "#^Call to function is_null\\(\\) with Cerpus\\\\CoreClient\\\\DataObjects\\\\BehaviorSettingsDataObject will always evaluate to false\\.$#"
-			count: 2
-			path: app/Libraries/H5P/ViewConfig.php
-
-		-
 			message: "#^Else branch is unreachable because ternary operator condition is always true\\.$#"
 			count: 1
 			path: app/Libraries/H5P/ViewConfig.php

--- a/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/API/Handler/ContentTypeHandlerTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/API/Handler/ContentTypeHandlerTest.php
@@ -3,11 +3,11 @@
 namespace Tests\Integration\Http\Controllers\API\Handler;
 
 use App\Http\Controllers\API\Handler\ContentTypeHandler;
+use App\Libraries\DataObjects\Answer;
+use App\Libraries\DataObjects\MultiChoiceQuestion;
+use App\Libraries\DataObjects\Questionset;
 use App\Libraries\H5P\Interfaces\H5PAdapterInterface;
 use App\Libraries\H5P\Packages\MultiChoice;
-use Cerpus\CoreClient\DataObjects\Answer;
-use Cerpus\CoreClient\DataObjects\MultiChoiceQuestion;
-use Cerpus\CoreClient\DataObjects\Questionset;
 use Cerpus\VersionClient\VersionData;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;

--- a/sourcecode/apis/contentauthor/tests/Integration/Traits/ImagePairTraitTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Traits/ImagePairTraitTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Integration\Traits;
 
+use App\Libraries\DataObjects\BehaviorSettingsDataObject;
 use App\Libraries\H5P\Packages\ImagePair;
-use Cerpus\CoreClient\DataObjects\BehaviorSettingsDataObject;
 use Tests\TestCase;
 
 class ImagePairTraitTest extends TestCase

--- a/sourcecode/apis/contentauthor/tests/Unit/Traits/H5PBehaviorSettingsTest.php
+++ b/sourcecode/apis/contentauthor/tests/Unit/Traits/H5PBehaviorSettingsTest.php
@@ -2,10 +2,10 @@
 
 namespace Tests\Unit\Traits;
 
+use App\Libraries\DataObjects\BehaviorSettingsDataObject;
 use App\Libraries\H5P\Packages\CoursePresentation;
 use App\Libraries\H5P\Packages\MultiChoice;
 use App\Traits\H5PBehaviorSettings;
-use Cerpus\CoreClient\DataObjects\BehaviorSettingsDataObject;
 use PHPUnit\Framework\TestCase;
 
 class H5PBehaviorSettingsTest extends TestCase


### PR DESCRIPTION
Core is long gone, but we still used data objects from its client library. To ease the maintenance burden, these are copied to CA and the client library removed.