### PR TITLE
Fix 'Failed prop type' error loading editor

### DIFF
--- a/sourcecode/apis/contentauthor/resources/assets/react/theme/cerpusUI.js
+++ b/sourcecode/apis/contentauthor/resources/assets/react/theme/cerpusUI.js
@@ -82,7 +82,7 @@ const CerpusUI = ({ children }) => {
                     props: {
                         MuiAccordion: {
                             variant: 'elevation',
-                            elevation: '0',
+                            elevation: 0,
                         },
                     },
                 })}


### PR DESCRIPTION
Fixes `Failed prop type: Invalid prop 'elevation' of type 'string' supplied to 'ForwardRef(Paper)', expected 'number'` logged when loading editor