### PR TITLE
refactor H5PExternalProviderInterface::setStorage away

### DIFF
--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Audio/NDLAAudioBrowser.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Audio/NDLAAudioBrowser.php
@@ -12,18 +12,14 @@ use Illuminate\Http\File;
 
 class NDLAAudioBrowser implements H5PAudioInterface, H5PExternalProviderInterface
 {
-    private $client;
-    /** @var CerpusStorageInterface */
-    private $storage;
-
     public const FIND_AUDIOS_URL = '/audio-api/v1/audio';
     public const GET_AUDIO_URL = '/audio-api/v1/audio/%s';
 
-    public function __construct(Client $client)
-    {
-        $this->client = $client;
+    public function __construct(
+        private readonly Client $client,
+        private readonly CerpusStorageInterface $storage
+    ) {
     }
-
 
     public function findAudio($filterParameters)
     {
@@ -119,10 +115,5 @@ class NDLAAudioBrowser implements H5PAudioInterface, H5PExternalProviderInterfac
     public function getType(): string
     {
         return "audio";
-    }
-
-    public function setStorage(CerpusStorageInterface $storage)
-    {
-        $this->storage = $storage;
     }
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/File/NDLATextTrack.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/File/NDLATextTrack.php
@@ -10,13 +10,10 @@ use GuzzleHttp\Client;
 
 class NDLATextTrack implements H5PExternalProviderInterface
 {
-    private $client;
-    /** @var CerpusStorageInterface */
-    private $storage;
-
-    public function __construct(Client $client)
-    {
-        $this->client = $client;
+    public function __construct(
+        private readonly Client $client,
+        private readonly CerpusStorageInterface $storage,
+    ) {
     }
 
     public function isTargetType($mimeType, $pathToFile): bool
@@ -59,10 +56,5 @@ class NDLATextTrack implements H5PExternalProviderInterface
     public function getType(): string
     {
         return 'file';
-    }
-
-    public function setStorage(CerpusStorageInterface $storage)
-    {
-        $this->storage = $storage;
     }
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PExport.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PExport.php
@@ -96,7 +96,6 @@ class H5PExport
         });
 
         if (!is_null($externalProvider)) {
-            $externalProvider->setStorage($this->export->h5pC->fs);
             $fileDetails = $externalProvider->storeContent($values, $content);
             $values = array_merge($values, $fileDetails);
         }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Image/NDLAContentBrowser.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Image/NDLAContentBrowser.php
@@ -12,10 +12,6 @@ use Illuminate\Http\File;
 
 class NDLAContentBrowser implements H5PImageAdapterInterface, H5PExternalProviderInterface
 {
-    private $client;
-    /** @var CerpusStorageInterface */
-    private $storage;
-
     private $mappings = [
         'startX' => 'cropStartX',
         'startY' => 'cropStartY',
@@ -30,14 +26,10 @@ class NDLAContentBrowser implements H5PImageAdapterInterface, H5PExternalProvide
     public const GET_IMAGE_ID = '/image-api/raw/id/%s';
     public const GET_IMAGE_NAME = '/image-api/raw/%s';
 
-    public function __construct(Client $client)
-    {
-        $this->client = $client;
-    }
-
-    public function setStorage(CerpusStorageInterface $storage)
-    {
-        $this->storage = $storage;
+    public function __construct(
+        private readonly Client $client,
+        private readonly CerpusStorageInterface $storage,
+    ) {
     }
 
     public function findImages($filterParameters)

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Interfaces/H5PExternalProviderInterface.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Interfaces/H5PExternalProviderInterface.php
@@ -9,6 +9,4 @@ interface H5PExternalProviderInterface
     public function storeContent($source, $content);
 
     public function getType(): string;
-
-    public function setStorage(CerpusStorageInterface $storage);
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Video/NDLAVideoAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Video/NDLAVideoAdapter.php
@@ -3,7 +3,6 @@
 namespace App\Libraries\H5P\Video;
 
 use App\Libraries\DataObjects\ContentStorageSettings;
-use App\Libraries\H5P\Interfaces\CerpusStorageInterface;
 use App\Libraries\H5P\Interfaces\H5PExternalProviderInterface;
 use App\Libraries\H5P\Interfaces\H5PVideoInterface;
 use BadMethodCallException;
@@ -25,7 +24,6 @@ class NDLAVideoAdapter implements H5PVideoInterface, H5PExternalProviderInterfac
 
     public function __construct(
         private readonly Client $client,
-        private readonly CerpusStorageInterface $storage,
         private readonly string $accountId,
     ) {
         if ($accountId === '') {
@@ -167,7 +165,8 @@ class NDLAVideoAdapter implements H5PVideoInterface, H5PExternalProviderInterfac
         $fileName = md5($source['path']);
         $filePath = sprintf(ContentStorageSettings::CONTENT_FULL_PATH, $content['id'], $this->getType(), $fileName, $extension);
 
-        if (!$this->storage->storeContentOnDisk($filePath, fopen($localFile, "r"))) {
+        $storage = app()->make(H5PVideoInterface::class);
+        if (!$storage->storeContentOnDisk($filePath, fopen($localFile, "r"))) {
             throw new Exception("Could not store file on disk");
         }
         unlink($localFile);

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Video/NDLAVideoAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Video/NDLAVideoAdapter.php
@@ -9,7 +9,6 @@ use App\Libraries\H5P\Interfaces\H5PVideoInterface;
 use BadMethodCallException;
 use Exception;
 use GuzzleHttp\Client;
-use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Utils as GuzzleUtils;
 use Illuminate\Http\File;
 use InvalidArgumentException;
@@ -24,18 +23,14 @@ class NDLAVideoAdapter implements H5PVideoInterface, H5PExternalProviderInterfac
 
     public const VIDEO_URL = 'https://bc/%s';
 
-    private ClientInterface $client;
-    private string $accountId;
-    private CerpusStorageInterface $storage;
-
-    public function __construct(Client $client, string $accountId)
-    {
+    public function __construct(
+        private readonly Client $client,
+        private readonly CerpusStorageInterface $storage,
+        private readonly string $accountId,
+    ) {
         if ($accountId === '') {
             throw new InvalidArgumentException('$accountId cannot be an empty string');
         }
-
-        $this->client = $client;
-        $this->accountId = $accountId;
     }
 
     public function upload($file, $fileHash)
@@ -186,10 +181,5 @@ class NDLAVideoAdapter implements H5PVideoInterface, H5PExternalProviderInterfac
     public function getType(): string
     {
         return "video";
-    }
-
-    public function setStorage(CerpusStorageInterface $storage)
-    {
-        $this->storage = $storage;
     }
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Video/NDLAVideoAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Video/NDLAVideoAdapter.php
@@ -3,6 +3,7 @@
 namespace App\Libraries\H5P\Video;
 
 use App\Libraries\DataObjects\ContentStorageSettings;
+use App\Libraries\H5P\Interfaces\CerpusStorageInterface;
 use App\Libraries\H5P\Interfaces\H5PExternalProviderInterface;
 use App\Libraries\H5P\Interfaces\H5PVideoInterface;
 use BadMethodCallException;
@@ -165,7 +166,7 @@ class NDLAVideoAdapter implements H5PVideoInterface, H5PExternalProviderInterfac
         $fileName = md5($source['path']);
         $filePath = sprintf(ContentStorageSettings::CONTENT_FULL_PATH, $content['id'], $this->getType(), $fileName, $extension);
 
-        $storage = app()->make(H5PVideoInterface::class);
+        $storage = app()->make(CerpusStorageInterface::class);
         if (!$storage->storeContentOnDisk($filePath, fopen($localFile, "r"))) {
             throw new Exception("Could not store file on disk");
         }

--- a/sourcecode/apis/contentauthor/app/Providers/H5PServiceProvider.php
+++ b/sourcecode/apis/contentauthor/app/Providers/H5PServiceProvider.php
@@ -103,7 +103,7 @@ class H5PServiceProvider extends ServiceProvider
 
         $this->app->when(NDLAContentBrowser::class)
             ->needs(Client::class)
-            ->give(fn() => Auth0Client::getClient(OauthSetup::create([
+            ->give(fn () => Auth0Client::getClient(OauthSetup::create([
                 'key' => config('h5p.image.key'),
                 'secret' => config('h5p.image.secret'),
                 'authUrl' => config('h5p.image.authDomain'),

--- a/sourcecode/apis/contentauthor/phpstan-baseline.neon
+++ b/sourcecode/apis/contentauthor/phpstan-baseline.neon
@@ -1077,11 +1077,6 @@ parameters:
 			path: app/Libraries/H5P/Storage/H5PCerpusStorage.php
 
 		-
-			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:get\\(\\)\\.$#"
-			count: 3
-			path: app/Libraries/H5P/Video/NDLAVideoAdapter.php
-
-		-
 			message: "#^Access to an undefined property object\\:\\:\\$path\\.$#"
 			count: 1
 			path: app/Libraries/H5P/ViewConfig.php


### PR DESCRIPTION
This simplifies the code related to external providers in H5P a bit. 

Interfaces shouldn't be aware of implementation details like what dependencies are needed, and objects should be usable at all times. Having a `setStorage` method on an interface and requiring it be called prior to making other calls violates both principles.

We also make use of the service container to inject dependencies automatically when we can.