### PR TITLE
Fix exporting Brightcove videos

### DIFF
--- a/sourcecode/apis/contentauthor/app/Http/Controllers/H5PController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/H5PController.php
@@ -32,6 +32,7 @@ use App\Libraries\H5P\Interfaces\H5PAudioInterface;
 use App\Libraries\H5P\Interfaces\H5PImageAdapterInterface;
 use App\Libraries\H5P\Interfaces\H5PVideoInterface;
 use App\Libraries\H5P\LtiToH5PLanguage;
+use App\Libraries\H5P\Storage\H5PCerpusStorage;
 use App\Libraries\H5P\ViewConfig;
 use App\SessionKeys;
 use App\Traits\ReturnToCore;
@@ -784,23 +785,21 @@ class H5PController extends Controller
         return [$oldContent, $content, $newH5pContent];
     }
 
-    public function downloadContent(H5PContent $h5p)
+    public function downloadContent(H5PContent $h5p, H5PExport $export, H5PCore $core, H5PCerpusStorage $storage)
     {
-        /** @var H5PCore $core */
-        $core = resolve(H5PCore::class);
-        $displayOptions = $core->getDisplayOptionsForView($h5p->disable, $h5p->id);
-        if (!array_key_exists('export', $displayOptions) || $displayOptions['export'] !== true) {
-            return trans('h5p-editor.download-not-available');
+        $options = $core->getDisplayOptionsForView($h5p->disable, $h5p->id);
+        $canExport = $options[H5PCore::DISPLAY_OPTION_DOWNLOAD] ?? false;
+
+        if (!$canExport) {
+            return response(trans('h5p-editor.download-not-available'), 403);
         }
 
         $fileName = sprintf("%s-%d.h5p", $h5p->slug, $h5p->id);
-        /** @var H5PExport $export */
-        $export = resolve(H5PExport::class, ['content' => $h5p]);
-        if ($core->fs->hasExport($fileName) || $export->generateExport(config('feature.export_h5p_with_local_files'))) {
-            return $core->fs->downloadContent($fileName, $h5p->title);
+        if ($storage->hasExport($fileName) || $export->generateExport($h5p)) {
+            return $storage->downloadContent($fileName, $h5p->title);
         }
 
-        return response(trans('h5p-editor.could-not-find-content'));
+        return response(trans('h5p-editor.could-not-find-content'), 404);
     }
 
     public function browseImages(Request $request)

--- a/sourcecode/apis/contentauthor/app/Jobs/ExportH5P.php
+++ b/sourcecode/apis/contentauthor/app/Jobs/ExportH5P.php
@@ -17,27 +17,12 @@ class ExportH5P implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    public $content;
-    public $adapter;
-    public $fileStorage;
-    public $localStorage;
-
-    /**
-     * ExportH5P constructor.
-     */
-    public function __construct(H5PContent $content)
+    public function __construct(private readonly H5PContent $content)
     {
-        $this->content = $content;
     }
 
-    /**
-     * Execute the job.
-     *
-     * @return bool
-     */
-    public function handle()
+    public function handle(H5PExport $export): void
     {
-        $export = resolve(H5PExport::class, ['content' => $this->content]);
-        return $export->generateExport(config('feature.export_h5p_with_local_files'));
+        $export->generateExport($this->content);
     }
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Adapters/CerpusH5PAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Adapters/CerpusH5PAdapter.php
@@ -6,18 +6,12 @@ use App\Libraries\H5P\Dataobjects\H5PAlterParametersSettingsDataObject;
 use App\Libraries\H5P\Interfaces\H5PAdapterInterface;
 use App\Libraries\H5P\Traits\H5PCommonAdapterTrait;
 use Cerpus\QuestionBankClient\QuestionBankClient;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 
 class CerpusH5PAdapter implements H5PAdapterInterface
 {
     use H5PCommonAdapterTrait;
-
-    public function __construct()
-    {
-        $this->adapterName = "cerpus";
-    }
 
     /**
      * Alter parameters before added to the H5PIntegrationObject
@@ -153,9 +147,9 @@ class CerpusH5PAdapter implements H5PAdapterInterface
         return is_null($isEnabled) || filter_var($isEnabled, FILTER_VALIDATE_BOOLEAN);
     }
 
-    public function getExternalProviders(): Collection
+    public function getExternalProviders(): array
     {
-        return collect();
+        return [];
     }
 
     public function useMaxScore(): bool
@@ -186,5 +180,10 @@ class CerpusH5PAdapter implements H5PAdapterInterface
     public function getCustomEditorStyles(): array
     {
         return [];
+    }
+
+    public function getAdapterName(): string
+    {
+        return 'cerpus';
     }
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Adapters/NDLAH5PAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Adapters/NDLAH5PAdapter.php
@@ -9,8 +9,8 @@ use App\Libraries\H5P\File\NDLATextTrack;
 use App\Libraries\H5P\Image\NDLAContentBrowser;
 use App\Libraries\H5P\Interfaces\H5PAdapterInterface;
 use App\Libraries\H5P\Interfaces\H5PImageAdapterInterface;
-use App\Libraries\H5P\Interfaces\H5PVideoInterface;
 use App\Libraries\H5P\Traits\H5PCommonAdapterTrait;
+use App\Libraries\H5P\Video\NDLAVideoAdapter;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
 
@@ -27,11 +27,6 @@ class NDLAH5PAdapter implements H5PAdapterInterface
 
     /** @var H5PAlterParametersSettingsDataObject */
     private $parameterSettings;
-
-    public function __construct()
-    {
-        $this->adapterName = "ndla";
-    }
 
     /**
      * Alter parameters before added to the H5PIntegrationObject
@@ -320,14 +315,14 @@ class NDLAH5PAdapter implements H5PAdapterInterface
         return filter_var(config("feature.enableUserPublish"), FILTER_VALIDATE_BOOLEAN);
     }
 
-    public function getExternalProviders(): Collection
+    public function getExternalProviders(): array
     {
-        return collect([
+        return [
             resolve(NDLAContentBrowser::class),
-            resolve(H5PVideoInterface::class),
+            resolve(NDLAVideoAdapter::class),
             resolve(NDLAAudioBrowser::class),
             resolve(NDLATextTrack::class),
-        ]);
+        ];
     }
 
     public function useMaxScore(): bool
@@ -378,5 +373,10 @@ class NDLAH5PAdapter implements H5PAdapterInterface
         return [
             (string) mix('js/react-contentbrowser.js')
         ];
+    }
+
+    public function getAdapterName(): string
+    {
+        return 'ndla';
     }
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Audio/NDLAAudioBrowser.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Audio/NDLAAudioBrowser.php
@@ -12,18 +12,14 @@ use Illuminate\Http\File;
 
 class NDLAAudioBrowser implements H5PAudioInterface, H5PExternalProviderInterface
 {
-    private $client;
-    /** @var CerpusStorageInterface */
-    private $storage;
-
     public const FIND_AUDIOS_URL = '/audio-api/v1/audio';
     public const GET_AUDIO_URL = '/audio-api/v1/audio/%s';
 
-    public function __construct(Client $client)
-    {
-        $this->client = $client;
+    public function __construct(
+        private readonly Client $client,
+        private readonly CerpusStorageInterface $storage
+    ) {
     }
-
 
     public function findAudio($filterParameters)
     {
@@ -119,10 +115,5 @@ class NDLAAudioBrowser implements H5PAudioInterface, H5PExternalProviderInterfac
     public function getType(): string
     {
         return "audio";
-    }
-
-    public function setStorage(CerpusStorageInterface $storage)
-    {
-        $this->storage = $storage;
     }
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/File/NDLATextTrack.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/File/NDLATextTrack.php
@@ -41,7 +41,7 @@ class NDLATextTrack implements H5PExternalProviderInterface
             parse_str(parse_url($source, PHP_URL_QUERY), $result);
             ['id' => $id, 'track' => $track] = $result;
             $source = collect($this->video->getVideoDetails($id)->text_tracks ?? [])
-                ->firstOrFail(fn($item) => $item->id === $track)
+                ->firstOrFail(fn ($item) => $item->id === $track)
                 ->sources[0]
                 ->src;
         }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PExport.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PExport.php
@@ -11,8 +11,10 @@ use H5PExport as H5PDefaultExport;
 use Illuminate\Support\Collection;
 use JsonException;
 use UnexpectedValueException;
+
 use function json_decode;
 use function property_exists;
+
 use const JSON_THROW_ON_ERROR;
 
 readonly class H5PExport

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Image/NDLAContentBrowser.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Image/NDLAContentBrowser.php
@@ -12,10 +12,6 @@ use Illuminate\Http\File;
 
 class NDLAContentBrowser implements H5PImageAdapterInterface, H5PExternalProviderInterface
 {
-    private $client;
-    /** @var CerpusStorageInterface */
-    private $storage;
-
     private $mappings = [
         'startX' => 'cropStartX',
         'startY' => 'cropStartY',
@@ -30,14 +26,10 @@ class NDLAContentBrowser implements H5PImageAdapterInterface, H5PExternalProvide
     public const GET_IMAGE_ID = '/image-api/raw/id/%s';
     public const GET_IMAGE_NAME = '/image-api/raw/%s';
 
-    public function __construct(Client $client)
-    {
-        $this->client = $client;
-    }
-
-    public function setStorage(CerpusStorageInterface $storage)
-    {
-        $this->storage = $storage;
+    public function __construct(
+        private readonly Client $client,
+        private readonly CerpusStorageInterface $storage,
+    ) {
     }
 
     public function findImages($filterParameters)

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Interfaces/H5PAdapterInterface.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Interfaces/H5PAdapterInterface.php
@@ -40,10 +40,7 @@ interface H5PAdapterInterface
      */
     public function alterLibrarySemantics(&$semantics, $machineName, $majorVersion, $minorVersion);
 
-    /**
-     * @return string|null
-     */
-    public function getAdapterName();
+    public function getAdapterName(): string;
 
     /**
      * @return void
@@ -89,7 +86,10 @@ interface H5PAdapterInterface
 
     public function enableEverybodyIsCollaborators(): bool;
 
-    public function getExternalProviders(): Collection;
+    /**
+     * @return array<H5PExternalProviderInterface>
+     */
+    public function getExternalProviders(): array;
 
     public function useMaxScore(): bool;
 

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Interfaces/H5PAdapterInterface.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Interfaces/H5PAdapterInterface.php
@@ -3,7 +3,6 @@
 namespace App\Libraries\H5P\Interfaces;
 
 use App\Libraries\H5P\Dataobjects\H5PAlterParametersSettingsDataObject;
-use Illuminate\Support\Collection;
 
 interface H5PAdapterInterface
 {

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Interfaces/H5PExternalProviderInterface.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Interfaces/H5PExternalProviderInterface.php
@@ -9,6 +9,4 @@ interface H5PExternalProviderInterface
     public function storeContent($source, $content);
 
     public function getType(): string;
-
-    public function setStorage(CerpusStorageInterface $storage);
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Traits/H5PCommonAdapterTrait.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Traits/H5PCommonAdapterTrait.php
@@ -10,8 +10,6 @@ use App\Libraries\HTMLPurify\Config\MathMLConfig;
 
 trait H5PCommonAdapterTrait
 {
-    protected $adapterName;
-
     protected $config;
 
     public function hasVideoLibrary(array $scripts, int $minimumMajorVersion = 1, int $minimumMinorVersion = 1)
@@ -50,11 +48,6 @@ trait H5PCommonAdapterTrait
         }
     }
 
-    public function getAdapterName()
-    {
-        return $this->adapterName;
-    }
-
     public static function getAllAdapters()
     {
         return [
@@ -71,7 +64,7 @@ trait H5PCommonAdapterTrait
 
     public function adapterIs($adapter)
     {
-        return strtolower($this->adapterName) === strtolower($adapter);
+        return strtolower($this->getAdapterName()) === strtolower($adapter);
     }
 
     public function setConfig(ConfigInterface $config)

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Video/NDLAVideoAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Video/NDLAVideoAdapter.php
@@ -9,7 +9,6 @@ use App\Libraries\H5P\Interfaces\H5PVideoInterface;
 use BadMethodCallException;
 use Exception;
 use GuzzleHttp\Client;
-use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Utils as GuzzleUtils;
 use Illuminate\Http\File;
 use InvalidArgumentException;
@@ -24,18 +23,13 @@ class NDLAVideoAdapter implements H5PVideoInterface, H5PExternalProviderInterfac
 
     public const VIDEO_URL = 'https://bc/%s';
 
-    private ClientInterface $client;
-    private string $accountId;
-    private CerpusStorageInterface $storage;
-
-    public function __construct(Client $client, string $accountId)
-    {
+    public function __construct(
+        private readonly Client $client,
+        private readonly string $accountId,
+    ) {
         if ($accountId === '') {
             throw new InvalidArgumentException('$accountId cannot be an empty string');
         }
-
-        $this->client = $client;
-        $this->accountId = $accountId;
     }
 
     public function upload($file, $fileHash)
@@ -150,9 +144,9 @@ class NDLAVideoAdapter implements H5PVideoInterface, H5PExternalProviderInterfac
         return !is_null($this->getVideoIdFromPath($path));
     }
 
-    public function getVideoIdFromPath($path)
+    public function getVideoIdFromPath($path): ?string
     {
-        !preg_match('/https:\/\/bc\/(ref:[a-z0-9]+|\d+)/', $path, $matches);
+        preg_match('!^https://bc/(?:0/|360/|ref:|)([a-z0-9]+)$!', $path, $matches);
         return $matches[1] ?? null;
     }
 
@@ -162,17 +156,17 @@ class NDLAVideoAdapter implements H5PVideoInterface, H5PExternalProviderInterfac
      */
     public function storeContent($source, $content, $setVideo = null)
     {
-        if (!preg_match('/https:\/\/bc\/(ref:[a-z0-9]+|\d+)/', $source['path'], $matches)) {
-            throw new Exception("No video id found");
-        }
-        $localFile = $this->downloadVideo($matches[1]);
+        $videoId = $this->getVideoIdFromPath($source['path'])
+            ?? throw new Exception("No video id found");
+        $localFile = $this->downloadVideo($videoId);
         $file = new File($localFile);
         $extension = $file->guessExtension();
         $mimeType = $file->getMimeType();
         $fileName = md5($source['path']);
         $filePath = sprintf(ContentStorageSettings::CONTENT_FULL_PATH, $content['id'], $this->getType(), $fileName, $extension);
 
-        if (!$this->storage->storeContentOnDisk($filePath, fopen($localFile, "r"))) {
+        $storage = app()->make(CerpusStorageInterface::class);
+        if (!$storage->storeContentOnDisk($filePath, fopen($localFile, "r"))) {
             throw new Exception("Could not store file on disk");
         }
         unlink($localFile);
@@ -186,10 +180,5 @@ class NDLAVideoAdapter implements H5PVideoInterface, H5PExternalProviderInterfac
     public function getType(): string
     {
         return "video";
-    }
-
-    public function setStorage(CerpusStorageInterface $storage)
-    {
-        $this->storage = $storage;
     }
 }

--- a/sourcecode/apis/contentauthor/phpstan-baseline.neon
+++ b/sourcecode/apis/contentauthor/phpstan-baseline.neon
@@ -892,21 +892,6 @@ parameters:
 			path: app/Libraries/H5P/H5PCopyright.php
 
 		-
-			message: "#^Access to an undefined property object\\:\\:\\$path\\.$#"
-			count: 1
-			path: app/Libraries/H5P/H5PExport.php
-
-		-
-			message: "#^Call to function is_null\\(\\) with App\\\\Libraries\\\\H5P\\\\Interfaces\\\\H5PExternalProviderInterface will always evaluate to false\\.$#"
-			count: 1
-			path: app/Libraries/H5P/H5PExport.php
-
-		-
-			message: "#^Property App\\\\Libraries\\\\H5P\\\\H5PExport\\:\\:\\$adapter is never read, only written\\.$#"
-			count: 1
-			path: app/Libraries/H5P/H5PExport.php
-
-		-
 			message: "#^Method Illuminate\\\\Support\\\\Collection\\<\\(int\\|string\\),mixed\\>\\:\\:put\\(\\) invoked with 1 parameter, 2 required\\.$#"
 			count: 1
 			path: app/Libraries/H5P/H5PImport.php
@@ -1065,11 +1050,6 @@ parameters:
 			message: "#^Variable \\$filePath might not be defined\\.$#"
 			count: 1
 			path: app/Libraries/H5P/Storage/H5PCerpusStorage.php
-
-		-
-			message: "#^Call to an undefined method GuzzleHttp\\\\ClientInterface\\:\\:get\\(\\)\\.$#"
-			count: 3
-			path: app/Libraries/H5P/Video/NDLAVideoAdapter.php
 
 		-
 			message: "#^Access to an undefined property object\\:\\:\\$path\\.$#"
@@ -1243,16 +1223,6 @@ parameters:
 
 		-
 			message: "#^Class App\\\\Libraries\\\\H5P\\\\EditorStorage constructor invoked with 2 parameters, 1 required\\.$#"
-			count: 1
-			path: app/Providers/H5PServiceProvider.php
-
-		-
-			message: "#^Variable \\$instance in empty\\(\\) always exists and is not falsy\\.$#"
-			count: 1
-			path: app/Providers/H5PServiceProvider.php
-
-		-
-			message: "#^Variable \\$instance on left side of \\?\\? always exists and is not nullable\\.$#"
 			count: 1
 			path: app/Providers/H5PServiceProvider.php
 

--- a/sourcecode/apis/contentauthor/phpstan.neon.dist
+++ b/sourcecode/apis/contentauthor/phpstan.neon.dist
@@ -13,3 +13,5 @@ parameters:
         - resources/lang
         - routes
         - tests
+    stubFiles:
+        - stubs/h5p-core/H5PExport.stub

--- a/sourcecode/apis/contentauthor/public/js/h5p/ndla-contentbrowser.js
+++ b/sourcecode/apis/contentauthor/public/js/h5p/ndla-contentbrowser.js
@@ -514,10 +514,10 @@ class VideoBrowser extends ContentBrowserBase {
 
     setCopyright(values) {
         this.copyrightHandler.set(this.buildCopyright(values));
-        this.setTextTracks(values.text_tracks);
+        this.setTextTracks(values);
     }
 
-    setTextTracks(tracks) {
+    setTextTracks(values) {
         const field = H5PEditor.findField('textTracks', this.parent) || H5PEditor.findField('a11y', this.parent);
         if (field) {
             const trackField = field.children[0];
@@ -525,14 +525,14 @@ class VideoBrowser extends ContentBrowserBase {
                 .forEach(() => {
                     trackField.removeItem(0)
                 });
-            for (let track of tracks) {
+            for (let track of values.text_tracks) {
                 const trackData = {
                     kind: track.kind,
                     label: track.label,
                     srcLang: track.srclang.split('-')[0],
                     track: {
                         externalId: track.id,
-                        path: track.sources[0].src,
+                        path: `https://bc?id=${encodeURIComponent(values.id)}&track=${encodeURIComponent(track.id)}`,
                         mime: track.mime_type,
                     }
                 };

--- a/sourcecode/apis/contentauthor/stubs/h5p-core/H5PExport.stub
+++ b/sourcecode/apis/contentauthor/stubs/h5p-core/H5PExport.stub
@@ -1,0 +1,11 @@
+<?php
+
+class H5PExport
+{
+    /**
+     * @param array<mixed> $content
+     */
+    public function createExportFile(array $content): bool
+    {
+    }
+}

--- a/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PExportTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PExportTest.php
@@ -5,10 +5,8 @@ namespace Tests\Integration\Libraries\H5P;
 use App\H5PContent;
 use App\Libraries\DataObjects\ContentStorageSettings;
 use App\Libraries\H5P\H5PExport;
-use App\Libraries\H5P\Interfaces\H5PAdapterInterface;
 use App\Libraries\H5P\Interfaces\H5PExternalProviderInterface;
 use Exception;
-use H5PExport as H5PDefaultExport;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -50,9 +48,8 @@ class H5PExportTest extends TestCase
     {
         $this->setupH5PAdapter([
             'alterLibrarySemantics' => null,
-            'getExternalProviders' => collect(),
+            'getExternalProviders' => [],
         ]);
-        $adapter = resolve(H5PAdapterInterface::class);
 
         $this->linkLibrariesFolder();
         $this->seed(TestH5PSeeder::class);
@@ -62,9 +59,9 @@ class H5PExportTest extends TestCase
             'library_id' => 284,
         ]);
 
-        $h5pExport = resolve(H5PDefaultExport::class);
-        $export = new H5PExport($h5p, $h5pExport, $adapter);
-        $this->assertTrue($export->generateExport(false));
+        config('feature.export_h5p_with_local_files', false);
+        $export = resolve(H5PExport::class);
+        $this->assertTrue($export->generateExport($h5p));
         $exportName = sprintf("%s-%s.", $h5p->slug, $h5p->id);
         $exportPath = sprintf(ContentStorageSettings::EXPORT_PATH, $exportName . "h5p");
         $archivePath = sprintf(ContentStorageSettings::EXPORT_PATH, $exportName . "zip");
@@ -85,9 +82,8 @@ class H5PExportTest extends TestCase
     {
         $this->setupH5PAdapter([
             'alterLibrarySemantics' => null,
-            'getExternalProviders' => collect(),
+            'getExternalProviders' => [],
         ]);
-        $adapter = resolve(H5PAdapterInterface::class);
 
         $this->linkLibrariesFolder();
         $this->seed(TestH5PSeeder::class);
@@ -97,9 +93,9 @@ class H5PExportTest extends TestCase
             'library_id' => 284,
         ]);
 
-        $h5pExport = resolve(H5PDefaultExport::class);
-        $export = new H5PExport($h5p, $h5pExport, $adapter);
-        $this->assertTrue($export->generateExport(false));
+        config('feature.export_h5p_with_local_files', false);
+        $export = resolve(H5PExport::class);
+        $this->assertTrue($export->generateExport($h5p));
         $exportName = sprintf("%s-%s.", $h5p->slug, $h5p->id);
         $exportPath = sprintf(ContentStorageSettings::EXPORT_PATH, $exportName . "h5p");
         $archivePath = sprintf(ContentStorageSettings::EXPORT_PATH, $exportName . "zip");
@@ -124,9 +120,8 @@ class H5PExportTest extends TestCase
     {
         $this->setupH5PAdapter([
             'alterLibrarySemantics' => null,
-            'getExternalProviders' => collect(),
+            'getExternalProviders' => [],
         ]);
-        $adapter = resolve(H5PAdapterInterface::class);
 
         $imageUrl = $this->faker->imageUrl();
 
@@ -138,9 +133,9 @@ class H5PExportTest extends TestCase
             'library_id' => 284,
         ]);
 
-        $h5pExport = resolve(H5PDefaultExport::class);
-        $export = new H5PExport($h5p, $h5pExport, $adapter);
-        $this->assertTrue($export->generateExport(false));
+        config('feature.export_h5p_with_local_files', false);
+        $export = resolve(H5PExport::class);
+        $this->assertTrue($export->generateExport($h5p));
         $exportName = sprintf("%s-%s.", $h5p->slug, $h5p->id);
         $exportPath = sprintf(ContentStorageSettings::EXPORT_PATH, $exportName . "h5p");
         $archivePath = sprintf(ContentStorageSettings::EXPORT_PATH, $exportName . "zip");
@@ -193,14 +188,13 @@ class H5PExportTest extends TestCase
                     ];
                 });
 
-                return collect([$imageProvider1, $imageProvider2]);
+                return [$imageProvider1, $imageProvider2];
             },
         ]);
-        $adapter = resolve(H5PAdapterInterface::class);
 
-        $h5pExport = resolve(H5PDefaultExport::class);
-        $export = new H5PExport($h5p, $h5pExport, $adapter);
-        $this->assertTrue($export->generateExport(true));
+        config('feature.export_h5p_with_local_files', true);
+        $export = resolve(H5PExport::class);
+        $this->assertTrue($export->generateExport($h5p));
         $exportName = sprintf("%s-%s.", $h5p->slug, $h5p->id);
         $exportPath = sprintf(ContentStorageSettings::EXPORT_PATH, $exportName . "h5p");
         $archivePath = sprintf(ContentStorageSettings::EXPORT_PATH, $exportName . "zip");
@@ -252,14 +246,13 @@ class H5PExportTest extends TestCase
                     ];
                 });
 
-                return collect([$imageProvider, $videoProvider]);
+                return [$imageProvider, $videoProvider];
             },
         ]);
-        $adapter = resolve(H5PAdapterInterface::class);
 
-        $h5pExport = resolve(H5PDefaultExport::class);
-        $export = new H5PExport($h5p, $h5pExport, $adapter);
-        $this->assertTrue($export->generateExport(true));
+        config('feature.export_h5p_with_local_files', false);
+        $export = resolve(H5PExport::class);
+        $this->assertTrue($export->generateExport($h5p));
         $exportName = sprintf("%s-%s.", $h5p->slug, $h5p->id);
         $exportPath = sprintf(ContentStorageSettings::EXPORT_PATH, $exportName . "h5p");
         $archivePath = sprintf(ContentStorageSettings::EXPORT_PATH, $exportName . "zip");
@@ -328,14 +321,12 @@ class H5PExportTest extends TestCase
                     ];
                 });
 
-                return collect([$imageProvider, $videoProvider]);
+                return [$imageProvider, $videoProvider];
             },
         ]);
-        $adapter = resolve(H5PAdapterInterface::class);
 
-        $h5pExport = resolve(H5PDefaultExport::class);
-        $export = new H5PExport($h5p, $h5pExport, $adapter);
-        $this->assertTrue($export->generateExport(true));
+        $export = resolve(H5PExport::class);
+        $this->assertTrue($export->generateExport($h5p));
         $exportName = sprintf("%s-%s.", $h5p->slug, $h5p->id);
         $exportPath = sprintf(ContentStorageSettings::EXPORT_PATH, $exportName . "h5p");
         $archivePath = sprintf(ContentStorageSettings::EXPORT_PATH, $exportName . "zip");
@@ -404,14 +395,12 @@ class H5PExportTest extends TestCase
                     ];
                 });
 
-                return collect([$textTrackProvider, $videoProvider]);
+                return [$textTrackProvider, $videoProvider];
             },
         ]);
-        $adapter = resolve(H5PAdapterInterface::class);
 
-        $h5pExport = resolve(H5PDefaultExport::class);
-        $export = new H5PExport($h5p, $h5pExport, $adapter);
-        $this->assertTrue($export->generateExport(true));
+        $export = resolve(H5PExport::class);
+        $this->assertTrue($export->generateExport($h5p));
         $exportName = sprintf("%s-%s.", $h5p->slug, $h5p->id);
         $exportPath = sprintf(ContentStorageSettings::EXPORT_PATH, $exportName . "h5p");
         $archivePath = sprintf(ContentStorageSettings::EXPORT_PATH, $exportName . "zip");


### PR DESCRIPTION
This fixes exporting Brightcove videos. It is now possible to export such a video, and it will reference the video source and text tracks located in the .h5p file. You can then upload the .h5p again and the video will work in any H5P system (theoretically).

Some additional improvements were included:

* Unwanted HTML escaping in the exported H5P JSON data has been fixed. We use the so-called H5PValidator to resolve dependencies, and nothing else.

* The `H5PExport::generateExport()` method now uses config taken in constructor and the `H5PContent` object as a parameter, instead of the other way round. The method is also rewritten to be less of a roundabout to read.

* General improvements to method naming.

* Some improvements that aren't strictly related, but would have been included in a big push leading up to this fix (I landed this way earlier than expected.)