### PR TITLE
fix OAuth 1 null params

### DIFF
--- a/sourcecode/apis/contentauthor/app/Http/Middleware/SignedOauth10Request.php
+++ b/sourcecode/apis/contentauthor/app/Http/Middleware/SignedOauth10Request.php
@@ -35,7 +35,7 @@ final readonly class SignedOauth10Request
             $request->getMethod(),
             $request->url(),
             // undo empty string => null conversion
-            array_map(fn($v) => $v === null ? '' : $v, $params),
+            array_map(fn ($v) => $v === null ? '' : $v, $params),
         );
 
         try {

--- a/sourcecode/apis/contentauthor/app/Http/Middleware/SignedOauth10Request.php
+++ b/sourcecode/apis/contentauthor/app/Http/Middleware/SignedOauth10Request.php
@@ -34,7 +34,8 @@ final readonly class SignedOauth10Request
         $oauth1Request = new Oauth10Request(
             $request->getMethod(),
             $request->url(),
-            $params,
+            // undo empty string => null conversion
+            array_map(fn($v) => $v === null ? '' : $v, $params),
         );
 
         try {

--- a/sourcecode/apis/contentauthor/app/Http/Requests/LTIRequest.php
+++ b/sourcecode/apis/contentauthor/app/Http/Requests/LTIRequest.php
@@ -14,7 +14,7 @@ class LTIRequest extends \Cerpus\EdlibResourceKit\Oauth1\Request
                     $request->method(),
                     $request->url(),
                     // undo empty string => null conversion
-                    array_map(fn($v) => $v === null ? '' : $v, $request->all()),
+                    array_map(fn ($v) => $v === null ? '' : $v, $request->all()),
                 )
                 : null;
 

--- a/sourcecode/apis/contentauthor/app/Http/Requests/LTIRequest.php
+++ b/sourcecode/apis/contentauthor/app/Http/Requests/LTIRequest.php
@@ -10,7 +10,12 @@ class LTIRequest extends \Cerpus\EdlibResourceKit\Oauth1\Request
     {
         if (!$request->attributes->has('lti_request')) {
             $ltiRequest = $request->has('lti_message_type')
-                ? new self($request->method(), $request->url(), $request->all())
+                ? new self(
+                    $request->method(),
+                    $request->url(),
+                    // undo empty string => null conversion
+                    array_map(fn($v) => $v === null ? '' : $v, $request->all()),
+                )
                 : null;
 
             $request->attributes->set('lti_request', $ltiRequest);


### PR DESCRIPTION
The OAuth library expects parameters to be strings, but Laravel converts empty strings to null. This causes a type check to fail.

In the future, this should probably be handled by the Laravel package for edlib-resource-kit.