### PR TITLE
CA Config: Fix issue where 'h5p.saveFrequency' is false, don't add user by default

### DIFF
--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PConfigAbstract.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PConfigAbstract.php
@@ -43,10 +43,6 @@ abstract class H5PConfigAbstract implements ConfigInterface
             'url' => $this->h5pCore->fs->getDisplayPath(false),
             'postUserStatistics' => false,
             'ajaxPath' => '/ajax?action=',
-            'user' => [
-                'name' => trans('h5p-editor.anonymous'),
-                'mail' => false,
-            ],
             'canGiveScore' => false,
             'hubIsEnabled' => false,
             'ajax' => [
@@ -90,7 +86,7 @@ abstract class H5PConfigAbstract implements ConfigInterface
 
             $this->config['user'] = (object) [
                 'name' => $name,
-                'mail' => $this->userEmail,
+                'mail' => $this->userEmail ?? false,
             ];
         }
 

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PViewConfig.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PViewConfig.php
@@ -142,7 +142,7 @@ class H5PViewConfig extends H5PConfigAbstract
         }
     }
 
-    private function getSaveFrequency(): int
+    private function getSaveFrequency(): int|false
     {
         if (array_key_exists("library", $this->content) &&
             array_key_exists("name", $this->content["library"]) &&

--- a/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PViewConfigTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PViewConfigTest.php
@@ -83,9 +83,11 @@ class H5PViewConfigTest extends TestCase
         ];
     }
 
-    public function test_loadContent(): void
+    /** @dataProvider provider_saveFrequency */
+    public function test_loadContent(int|false $frequency): void
     {
         $faker = Factory::create();
+        config()->set('h5p.saveFrequency', $frequency);
 
         $resourceId = $faker->uuid;
         $context = $faker->uuid;
@@ -131,6 +133,13 @@ class H5PViewConfigTest extends TestCase
         $this->assertStringContainsString("/s/resources/$resourceId", $contentData->embedCode);
         $this->assertNotEmpty($data->url);
         $this->assertSame($content->title, $contentData->title);
+        $this->assertSame($frequency, $data->saveFreq);
+
+        if ($frequency === false) {
+            $this->assertObjectNotHasAttribute('user', $data);
+        } else {
+            $this->assertObjectHasAttribute('user', $data);
+        }
 
         $this->assertSame('Emily Quackfaster', $contentData->metadata['authors'][0]->name);
         $this->assertSame('CC BY-NC-ND', $contentData->metadata['license']);
@@ -145,6 +154,12 @@ class H5PViewConfigTest extends TestCase
         $this->assertNull($contentData->displayOptions->copy);
 
         $this->assertFalse($contentData->contentUserData['state']);
+    }
+
+    public function provider_saveFrequency()
+    {
+        yield [15];
+        yield [false];
     }
 
     public function test_setAlterParameterSettings(): void


### PR DESCRIPTION
In the view/edit/create config: 
 - The value `false` for environment setting `h5p.saveFrequency` was not handled correctly
 - `user` was always added