### PR TITLE
GH #2385: Missing Wiris config caused CKEditor crash in create/edit NDLA mode

### DIFF
--- a/sourcecode/apis/contentauthor/app/Http/Controllers/H5PController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/H5PController.php
@@ -54,7 +54,6 @@ use Iso639p3;
 use MatthiasMullie\Minify\CSS;
 use stdClass;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
-
 use function Cerpus\Helper\Helpers\profile as config;
 
 class H5PController extends Controller
@@ -105,6 +104,7 @@ class H5PController extends Controller
             ->setContext($context)
             ->loadContent($id)
             ->setAlterParameterSettings(H5PAlterParametersSettingsDataObject::create(['useImageWidth' => $h5pContent->library->includeImageWidth()]));
+
         $h5pView = $this->h5p->createView($viewConfig);
         $content = $viewConfig->getContent();
         $settings = $h5pView->getSettings();
@@ -155,8 +155,8 @@ class H5PController extends Controller
             ->setUserName(Session::get('name', false))
             ->setDisplayHub(empty($contenttype))
             ->setRedirectToken($request->input('redirectToken'))
-            ->setDisplayHub(empty($contenttype))
             ->setLanguage(Iso639p3::code2letters($language));
+
         $h5pView = $this->h5p->createView($editorConfig);
 
         $jwtTokenInfo = Session::get('jwtToken', null);
@@ -252,6 +252,7 @@ class H5PController extends Controller
             ->setRedirectToken($request->input('redirectToken'))
             ->setLanguage(LtiToH5PLanguage::convert(Session::get('locale')))
             ->loadContent($id);
+
         $h5pView = $this->h5p->createView($editorConfig);
         $content = $editorConfig->getContent();
 

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Adapters/CerpusH5PAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Adapters/CerpusH5PAdapter.php
@@ -44,7 +44,7 @@ class CerpusH5PAdapter implements H5PAdapterInterface
 
     public function getCustomEditorScripts(): array
     {
-        return ['/js/videos/streamps.js', asset('js/videos/brightcove.js')];
+        return ['/js/videos/streamps.js', '/js/videos/brightcove.js'];
     }
 
 

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Adapters/NDLAH5PAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Adapters/NDLAH5PAdapter.php
@@ -198,9 +198,10 @@ class NDLAH5PAdapter implements H5PAdapterInterface
     {
         $css = [];
         $ndlaCustomCssOption = H5POption::where('option_name', H5POption::NDLA_CUSTOM_CSS_TIMESTAMP)->first();
-        if ($ndlaCustomCssOption && !empty($this->config->content)) {
+        $content = $this->config->getContent();
+        if ($ndlaCustomCssOption && !empty($content)) {
             $customCssBreakpoint = Carbon::parse($ndlaCustomCssOption->option_value);
-            $updated = $this->config->content['updated_at'];
+            $updated = $content['updated_at'];
             if ($customCssBreakpoint > $updated) {
                 $css[] = (string) mix('css/ndlah5p-iframe-legacy.css');
             }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PConfigAbstract.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PConfigAbstract.php
@@ -14,11 +14,11 @@ use function Cerpus\Helper\Helpers\profile as config;
 
 abstract class H5PConfigAbstract implements ConfigInterface
 {
-    protected const CACHE_BUSTER_STRING = '2.0.3';
+    public const CACHE_BUSTER_STRING = '2.0.3';
     protected const EMBED_TEMPLATE = '<iframe src="%s" width=":w" height=":h" frameborder="0" allowfullscreen="allowfullscreen" allow="geolocation *; microphone *; camera *; midi *; encrypted-media *" title="%s"></iframe>';
 
     public function __construct(
-        protected H5PAdapterInterface $adapter,
+        public H5PAdapterInterface $adapter,
         public \H5PCore $h5pCore,
         public ?int $id = null,
         protected array $config = [],

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PConfigAbstract.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PConfigAbstract.php
@@ -18,7 +18,7 @@ abstract class H5PConfigAbstract implements ConfigInterface
     protected const EMBED_TEMPLATE = '<iframe src="%s" width=":w" height=":h" frameborder="0" allowfullscreen="allowfullscreen" allow="geolocation *; microphone *; camera *; midi *; encrypted-media *" title="%s"></iframe>';
 
     public function __construct(
-        public H5PAdapterInterface $adapter,
+        protected H5PAdapterInterface $adapter,
         public \H5PCore $h5pCore,
         public ?int $id = null,
         protected array $config = [],

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PCreateConfig.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PCreateConfig.php
@@ -33,6 +33,11 @@ class H5PCreateConfig extends H5PConfigAbstract
         $this->config['ajax']['contentUserData'] = '/api/progress?action=h5p_preview&c=1';
         $this->config['ajax']['setFinished'] = '/api/progress?action=h5p_preview&f=1';
 
+        $editorSettings = $this->adapter->getEditorSettings();
+        if (!empty($editorSettings)) {
+            $this->editorConfig = array_merge($this->editorConfig, $editorSettings);
+        }
+
         $this->addCoreAssets();
         $this->addDefaultEditorAssets();
         $this->addCustomEditorStyles();
@@ -48,6 +53,7 @@ class H5PCreateConfig extends H5PConfigAbstract
     {
         $this->editorConfig['language'] = $this->language ?? 'en';
         $this->editorConfig['ajaxPath'] = sprintf("/ajax?redirectToken=%s&h5p_id=&action=", $this->redirectToken);
+
         $this->config['editor'] = (object) $this->editorConfig;
     }
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PEditConfig.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PEditConfig.php
@@ -37,6 +37,11 @@ class H5PEditConfig extends H5PConfigAbstract
         $this->config['ajax']['contentUserData'] = '/api/progress?action=h5p_preview&c=1';
         $this->config['ajax']['setFinished'] = '/api/progress?action=h5p_preview&f=1';
 
+        $editorSettings = $this->adapter->getEditorSettings();
+        if (!empty($editorSettings)) {
+            $this->editorConfig = array_merge($this->editorConfig, $editorSettings);
+        }
+
         $this->addCoreAssets();
         $this->addDefaultEditorAssets();
         $this->addCustomEditorStyles();
@@ -58,6 +63,7 @@ class H5PEditConfig extends H5PConfigAbstract
         if ($this->content) {
             $this->editorConfig['ajaxPath'] = sprintf("/ajax?redirectToken=%s&h5p_id=%s&action=", $this->redirectToken, $this->content['id']);
         }
+
         $this->config['editor'] = (object) $this->editorConfig;
     }
 }

--- a/sourcecode/apis/contentauthor/phpunit.xml
+++ b/sourcecode/apis/contentauthor/phpunit.xml
@@ -53,5 +53,6 @@
         <server name="H5P_VIDEO_ADAPTER_DELETEVIDEO" value="true"/>
         <server name="FEATURE_ENABLE_USER_PUBLISH" value="false"/>
         <server name="FILESYSTEM_DRIVER" value="test"/>
+        <server name="H5P_VIDEO_ACCOUNT_ID" value="videoAccountId"/>
     </php>
 </phpunit>

--- a/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/H5PControllerTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/H5PControllerTest.php
@@ -33,7 +33,6 @@ class H5PControllerTest extends TestCase
     /** @dataProvider provider_adapterMode */
     public function testCreate(string $adapterMode): void
     {
-        Session::put('adapterMode', $adapterMode);
         $faker = Factory::create();
         $this->session([
             'authId' => $faker->uuid(),
@@ -44,6 +43,7 @@ class H5PControllerTest extends TestCase
             'jwtToken' => [
                 'raw' => 'a unique token',
             ],
+            'adapterMode' => $adapterMode,
         ]);
         $request = Request::create('lti-content/create', 'POST', [
             'redirectToken' => $faker->uuid,

--- a/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/H5PControllerTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/H5PControllerTest.php
@@ -10,12 +10,15 @@ use App\H5PContentLibrary;
 use App\H5PContentsMetadata;
 use App\H5PContentsUserData;
 use App\H5PLibrary;
+use App\H5PLibraryLibrary;
 use App\Http\Controllers\H5PController;
 use App\Http\Libraries\License;
+use App\Libraries\H5P\H5PConfigAbstract;
 use Faker\Factory;
 use H5PCore;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
@@ -27,8 +30,10 @@ class H5PControllerTest extends TestCase
     use RefreshDatabase;
     use MockAuthApi;
 
-    public function testCreate(): void
+    /** @dataProvider provider_adapterMode */
+    public function testCreate(string $adapterMode): void
     {
+        Session::put('adapterMode', $adapterMode);
         $faker = Factory::create();
         $this->session([
             'authId' => $faker->uuid(),
@@ -92,10 +97,21 @@ class H5PControllerTest extends TestCase
         $this->assertNull($state['libraryid']);
         $this->assertSame('nob', $state['language_iso_639_3']);
         $this->assertEquals(config('license.default-license'), $state['license']);
+
+        // Adapter specific
+        $this->assertSame($adapterMode, $editorSetup['adapterName']);
+
+        if ($adapterMode === 'ndla') {
+            $this->assertContains('/js/react-contentbrowser.js', $result['configJs']);
+        } elseif ($adapterMode === 'cerpus') {
+            $this->assertSame([], $data['configJs']);
+        }
     }
 
-    public function testEdit(): void
+    /** @dataProvider provider_adapterMode */
+    public function testEdit(string $adapterMode): void
     {
+        Session::put('adapterMode', $adapterMode);
         $faker = Factory::create();
         $user = new User(42, 'Emily', 'Quackfaster', 'emily.quackfaster@duckburg.quack');
         $this->setupAuthApi([
@@ -150,13 +166,13 @@ class H5PControllerTest extends TestCase
         /** @var H5PController $articleController */
         $articleController = app(H5PController::class);
         $result = $articleController->edit($request, $h5pContent->id);
-
         $this->assertNotEmpty($result);
         $this->assertInstanceOf(View::class, $result);
         $data = $result->getData();
 
         $this->assertSame('a unique token', $data['jwtToken']);
         $this->assertSame($h5pContent->id, $data['id']);
+        $this->assertInstanceOf(H5PContent::class, $data['h5p']);
         $this->assertSame($h5pContent->id, $data['h5p']->id);
 
         $this->assertNotEmpty($data['config']);
@@ -168,7 +184,6 @@ class H5PControllerTest extends TestCase
         $this->assertNotEmpty($data['hasUserProgress']);
         $this->assertNotEmpty($data['editorSetup']);
         $this->assertNotEmpty($data['state']);
-        $this->assertSame([], $data['configJs']);
 
         $config = json_decode(substr($result['config'], 25, -9), true, flags: JSON_THROW_ON_ERROR);
         $this->assertFalse($config['canGiveScore']);
@@ -199,6 +214,13 @@ class H5PControllerTest extends TestCase
         $this->assertNotEmpty($state['parameters']);
         $this->assertNotEmpty($state['redirectToken']);
         $this->assertNotEmpty($state['title']);
+
+        // Adapter specific
+        if ($adapterMode === 'ndla') {
+            $this->assertContains('/js/react-contentbrowser.js', $result['configJs']);
+        } elseif ($adapterMode === 'cerpus') {
+            $this->assertSame([], $data['configJs']);
+        }
     }
 
     /**
@@ -243,15 +265,18 @@ class H5PControllerTest extends TestCase
         yield [['language_iso_639_3' => 'eeee'], ['language_iso_639_3']];
     }
 
-    public function testDoShow(): void
+    /** @dataProvider provider_adapterMode */
+    public function testDoShow(string $adapterMode): void
     {
+        Session::put('adapterMode', $adapterMode);
         $faker = Factory::create();
         Storage::fake('test');
         $resourceId = $faker->uuid;
         $resourceApi = $this->createMock(ResourceApiService::class);
         $this->instance(ResourceApiService::class, $resourceApi);
 
-        H5PLibrary::factory()->create();
+        $depH5PVideo = H5PLibrary::factory()->create(['name' => 'H5P.Video', 'major_version' => 2, 'minor_version' => 9]);
+        $depCerpusVideo = H5PLibrary::factory()->create(['name' => 'H5P.CerpusVideo', 'major_version' => 3, 'minor_version' => 8]);
         /** @var H5PLibrary $library */
         $library = H5PLibrary::factory()->create([
             'minor_version' => 18,
@@ -264,6 +289,17 @@ class H5PControllerTest extends TestCase
             'preloaded_js' => 'deplib.js',
             'preloaded_css' => 'deplib.css',
         ]);
+        H5PLibraryLibrary::create([
+            'library_id' => $library->id,
+            'required_library_id' => $depH5PVideo->id,
+            'dependency_type' => 'preloaded',
+        ]);
+        H5PLibraryLibrary::create([
+            'library_id' => $library->id,
+            'required_library_id' => $depCerpusVideo->id,
+            'dependency_type' => 'preloaded',
+        ]);
+
         Storage::put('libraries/H5P.DepLib-2.19/deplib.js', 'Here be JS content');
         Storage::put('libraries/H5P.DepLib-2.19/deplib.css', 'Here be CSS content');
         H5PContent::factory()->create([
@@ -279,6 +315,20 @@ class H5PControllerTest extends TestCase
         H5PContentLibrary::create([
             'content_id' => $content->id,
             'library_id' => $dependency->id,
+            'dependency_type' => 'preloaded',
+            'weight' => 1,
+            'drop_css' => 0,
+        ]);
+        H5PContentLibrary::create([
+            'content_id' => $content->id,
+            'library_id' => $depH5PVideo->id,
+            'dependency_type' => 'preloaded',
+            'weight' => 1,
+            'drop_css' => 0,
+        ]);
+        H5PContentLibrary::create([
+            'content_id' => $content->id,
+            'library_id' => $depCerpusVideo->id,
             'dependency_type' => 'preloaded',
             'weight' => 1,
             'drop_css' => 0,
@@ -308,7 +358,11 @@ class H5PControllerTest extends TestCase
         $config = json_decode(substr($result['config'], 25, -9), flags: JSON_THROW_ON_ERROR);
         $this->assertObjectHasAttribute('baseUrl', $config);
         $this->assertObjectHasAttribute('url', $config);
-        $this->assertObjectHasAttribute('user', $config);
+        if (config('h5p.saveFrequency') === false) {
+            $this->assertObjectNotHasAttribute('user', $config);
+        } else {
+            $this->assertObjectHasAttribute('user', $config);
+        }
         $this->assertObjectHasAttribute('tokens', $config);
         $this->assertObjectHasAttribute('siteUrl', $config);
         $this->assertObjectHasAttribute('l10n', $config);
@@ -329,5 +383,25 @@ class H5PControllerTest extends TestCase
         $this->assertObjectHasAttribute('displayOptions', $contents);
         $this->assertObjectHasAttribute('contentUserData', $contents);
         $this->assertStringContainsString("/s/resources/$resourceId", $contents->embedCode);
+
+        // Adapter specific
+        $this->assertContains('//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-AMS-MML_SVG', $result['jsScripts']);
+        $this->assertContains('/js/videos/brightcove.js', $result['jsScripts']);
+
+        if ($adapterMode === "ndla") {
+            $this->assertContains('/js/h5p/wiris/view.js', $result['jsScripts']);
+            $this->assertContains('/js/h5peditor-custom.js', $result['jsScripts']);
+
+            $this->assertContains('/css/ndlah5p-iframe-legacy.css?ver=' . H5PConfigAbstract::CACHE_BUSTER_STRING, $result['styles']);
+            $this->assertContains('/css/ndlah5p-iframe.css?ver=' . H5PConfigAbstract::CACHE_BUSTER_STRING, $result['styles']);
+        } elseif ($adapterMode === "cerpus") {
+            $this->assertContains('/js/videos/streamps.js', $result['jsScripts']);
+        }
+    }
+
+    public function provider_adapterMode(): \Generator
+    {
+        yield 'cerpus' => ['cerpus'];
+        yield 'ndla' => ['ndla'];
     }
 }

--- a/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/H5PControllerTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/H5PControllerTest.php
@@ -99,8 +99,6 @@ class H5PControllerTest extends TestCase
         $this->assertEquals(config('license.default-license'), $state['license']);
 
         // Adapter specific
-        $this->assertSame($adapterMode, $editorSetup['adapterName']);
-
         if ($adapterMode === 'ndla') {
             $this->assertContains('/js/react-contentbrowser.js', $result['configJs']);
         } elseif ($adapterMode === 'cerpus') {

--- a/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PCreateConfigTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PCreateConfigTest.php
@@ -2,25 +2,34 @@
 
 namespace Tests\Integration\Libraries\H5P;
 
+use App\Libraries\H5P\H5PConfigAbstract;
 use App\Libraries\H5P\H5PCreateConfig;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Session;
 use Tests\TestCase;
 
 class H5PCreateConfigTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_getConfig(): void
+    /** @dataProvider provider_adapterMode */
+    public function test_getConfig(string $adapterMode): void
     {
-        $data = app(H5PCreateConfig::class)
-            ->getConfig();
+        Session::put('adapterMode', $adapterMode);
+
+        $config = app(H5PCreateConfig::class);
+        $data = $config->getConfig();
 
         // Check that the common attributes are present
         $this->assertObjectHasAttribute('baseUrl', $data);
         $this->assertObjectHasAttribute('url', $data);
         $this->assertObjectHasAttribute('postUserStatistics', $data);
         $this->assertObjectHasAttribute('ajaxPath', $data);
-        $this->assertObjectHasAttribute('user', $data);
+        if (config('h5p.saveFrequency') === false) {
+            $this->assertObjectNotHasAttribute('user', $data);
+        } else {
+            $this->assertObjectHasAttribute('user', $data);
+        }
         $this->assertObjectHasAttribute('canGiveScore', $data);
         $this->assertObjectHasAttribute('hubIsEnabled', $data);
         $this->assertObjectHasAttribute('ajax', $data);
@@ -60,6 +69,35 @@ class H5PCreateConfigTest extends TestCase
         $this->assertNotEmpty($data->editor->extraAllowedContent);
         $this->assertSame('en', $data->editor->language);
         $this->assertSame('en', $data->editor->defaultLanguage);
+
+        // Adapter specific
+        $adapter = $config->adapter;
+        $this->assertSame($adapterMode, $adapter->getAdapterName());
+
+        if ($adapterMode === 'ndla') {
+            $this->assertContains('/css/ndlah5p-editor.css', $data->editor->assets->css);
+            $this->assertContains('/js/cropperjs/cropper.min.css', $data->editor->assets->css);
+            $this->assertContains('/css/ndlah5p-youtube.css', $data->editor->assets->css);
+
+            $this->assertContains('/js/h5p/wiris/h5peditor-html-wiris-addon.js?ver=' . H5PConfigAbstract::CACHE_BUSTER_STRING, $data->editor->assets->js);
+            $this->assertContains('/js/ndla-contentbrowser.js?ver=' . H5PConfigAbstract::CACHE_BUSTER_STRING, $data->editor->assets->js);
+            $this->assertContains('/js/videos/brightcove.js?ver=' . H5PConfigAbstract::CACHE_BUSTER_STRING, $data->editor->assets->js);
+            $this->assertContains('/js/h5peditor-image-popup.js?ver=' . H5PConfigAbstract::CACHE_BUSTER_STRING, $data->editor->assets->js);
+            $this->assertContains('/js/h5peditor-custom.js?ver=' . H5PConfigAbstract::CACHE_BUSTER_STRING, $data->editor->assets->js);
+            $this->assertContains('/js/h5p/ndlah5p-youtube.js?ver=' . H5PConfigAbstract::CACHE_BUSTER_STRING, $data->editor->assets->js);
+
+            $this->assertSame('https://www.wiris.net/client/plugins/ckeditor/plugin.js', $data->editor->wirisPath);
+        } elseif ($adapterMode === 'cerpus') {
+            $this->assertContains('/js/videos/streamps.js?ver=' . H5PConfigAbstract::CACHE_BUSTER_STRING, $data->editor->assets->js);
+            $this->assertContains('/js/videos/brightcove.js?ver=' . H5PConfigAbstract::CACHE_BUSTER_STRING, $data->editor->assets->js);
+            $this->assertObjectNotHasAttribute('wirisPath', $data->editor);
+        }
+    }
+
+    public function provider_adapterMode(): \Generator
+    {
+        yield 'cerpusMode' => ['cerpus'];
+        yield 'ndlaMode' => ['ndla'];
     }
 
     public function test_setDisplayHub(): void

--- a/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PCreateConfigTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PCreateConfigTest.php
@@ -71,9 +71,6 @@ class H5PCreateConfigTest extends TestCase
         $this->assertSame('en', $data->editor->defaultLanguage);
 
         // Adapter specific
-        $adapter = $config->adapter;
-        $this->assertSame($adapterMode, $adapter->getAdapterName());
-
         if ($adapterMode === 'ndla') {
             $this->assertContains('/css/ndlah5p-editor.css', $data->editor->assets->css);
             $this->assertContains('/js/cropperjs/cropper.min.css', $data->editor->assets->css);

--- a/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PEditConfigTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PEditConfigTest.php
@@ -5,25 +5,34 @@ namespace Tests\Integration\Libraries\H5P;
 use App\H5PContent;
 use App\H5PContentsMetadata;
 use App\H5PLibrary;
+use App\Libraries\H5P\H5PConfigAbstract;
 use App\Libraries\H5P\H5PEditConfig;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Session;
 use Tests\TestCase;
 
 class H5PEditConfigTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_getConfig(): void
+    /** @dataProvider provider_adapterMode */
+    public function test_getConfig(string $adapterMode): void
     {
-        $data = app(H5PEditConfig::class)
-            ->getConfig();
+        Session::put('adapterMode', $adapterMode);
+
+        $config = app(H5PEditConfig::class);
+        $data = $config->getConfig();
 
         // Check that the common attributes are present
         $this->assertObjectHasAttribute('baseUrl', $data);
         $this->assertObjectHasAttribute('url', $data);
         $this->assertObjectHasAttribute('postUserStatistics', $data);
         $this->assertObjectHasAttribute('ajaxPath', $data);
-        $this->assertObjectHasAttribute('user', $data);
+        if (config('h5p.saveFrequency') === false) {
+            $this->assertObjectNotHasAttribute('user', $data);
+        } else {
+            $this->assertObjectHasAttribute('user', $data);
+        }
         $this->assertObjectHasAttribute('canGiveScore', $data);
         $this->assertObjectHasAttribute('hubIsEnabled', $data);
         $this->assertObjectHasAttribute('ajax', $data);
@@ -62,6 +71,35 @@ class H5PEditConfigTest extends TestCase
         $this->assertNotEmpty($data->editor->extraAllowedContent);
         $this->assertSame('en', $data->editor->language);
         $this->assertSame('en', $data->editor->defaultLanguage);
+
+        // Adapter specific
+        $adapter = $config->adapter;
+        $this->assertSame($adapterMode, $adapter->getAdapterName());
+
+        if ($adapterMode === 'ndla') {
+            $this->assertContains('/css/ndlah5p-editor.css', $data->editor->assets->css);
+            $this->assertContains('/js/cropperjs/cropper.min.css', $data->editor->assets->css);
+            $this->assertContains('/css/ndlah5p-youtube.css', $data->editor->assets->css);
+
+            $this->assertContains('/js/h5p/wiris/h5peditor-html-wiris-addon.js?ver=' . H5PConfigAbstract::CACHE_BUSTER_STRING, $data->editor->assets->js);
+            $this->assertContains('/js/ndla-contentbrowser.js?ver=' . H5PConfigAbstract::CACHE_BUSTER_STRING, $data->editor->assets->js);
+            $this->assertContains('/js/videos/brightcove.js?ver=' . H5PConfigAbstract::CACHE_BUSTER_STRING, $data->editor->assets->js);
+            $this->assertContains('/js/h5peditor-image-popup.js?ver=' . H5PConfigAbstract::CACHE_BUSTER_STRING, $data->editor->assets->js);
+            $this->assertContains('/js/h5peditor-custom.js?ver=' . H5PConfigAbstract::CACHE_BUSTER_STRING, $data->editor->assets->js);
+            $this->assertContains('/js/h5p/ndlah5p-youtube.js?ver=' . H5PConfigAbstract::CACHE_BUSTER_STRING, $data->editor->assets->js);
+
+            $this->assertSame('https://www.wiris.net/client/plugins/ckeditor/plugin.js', $data->editor->wirisPath);
+        } elseif ($adapterMode === 'cerpus') {
+            $this->assertContains('/js/videos/streamps.js?ver=' . H5PConfigAbstract::CACHE_BUSTER_STRING, $data->editor->assets->js);
+            $this->assertContains('/js/videos/brightcove.js?ver=' . H5PConfigAbstract::CACHE_BUSTER_STRING, $data->editor->assets->js);
+            $this->assertObjectNotHasAttribute('wirisPath', $data->editor);
+        }
+    }
+
+    public function provider_adapterMode(): \Generator
+    {
+        yield 'cerpus' => ['cerpus'];
+        yield 'ndla' => ['ndla'];
     }
 
     public function test_loadContent(): void

--- a/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PEditConfigTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PEditConfigTest.php
@@ -73,9 +73,6 @@ class H5PEditConfigTest extends TestCase
         $this->assertSame('en', $data->editor->defaultLanguage);
 
         // Adapter specific
-        $adapter = $config->adapter;
-        $this->assertSame($adapterMode, $adapter->getAdapterName());
-
         if ($adapterMode === 'ndla') {
             $this->assertContains('/css/ndlah5p-editor.css', $data->editor->assets->css);
             $this->assertContains('/js/cropperjs/cropper.min.css', $data->editor->assets->css);

--- a/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PViewConfigTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PViewConfigTest.php
@@ -58,9 +58,6 @@ class H5PViewConfigTest extends TestCase
         $this->assertObjectHasAttribute('pluginCacheBuster', $data);
         $this->assertObjectHasAttribute('libraryUrl', $data);
 
-        $adapter = $config->adapter;
-        $this->assertSame($adapterMode, $adapter->getAdapterName());
-
         // Attributes altered or set
         $this->assertSame('', $data->documentUrl);
         $this->assertSame([], $data->contents);

--- a/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PViewConfigTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PViewConfigTest.php
@@ -21,17 +21,24 @@ class H5PViewConfigTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_getConfig(): void
+    /** @dataProvider provider_adapterMode */
+    public function test_getConfig(string $adapterMode): void
     {
-        $data = app(H5PViewConfig::class)
-            ->getConfig();
+        Session::put('adapterMode', $adapterMode);
+
+        $config = app(H5PViewConfig::class);
+        $data = $config->getConfig();
 
         // Check that the common attributes are present
         $this->assertObjectHasAttribute('baseUrl', $data);
         $this->assertObjectHasAttribute('url', $data);
         $this->assertObjectHasAttribute('postUserStatistics', $data);
         $this->assertObjectHasAttribute('ajaxPath', $data);
-        $this->assertObjectHasAttribute('user', $data);
+        if (config('h5p.saveFrequency') === false) {
+            $this->assertObjectNotHasAttribute('user', $data);
+        } else {
+            $this->assertObjectHasAttribute('user', $data);
+        }
         $this->assertObjectHasAttribute('canGiveScore', $data);
         $this->assertObjectHasAttribute('hubIsEnabled', $data);
         $this->assertObjectHasAttribute('ajax', $data);
@@ -51,11 +58,20 @@ class H5PViewConfigTest extends TestCase
         $this->assertObjectHasAttribute('pluginCacheBuster', $data);
         $this->assertObjectHasAttribute('libraryUrl', $data);
 
+        $adapter = $config->adapter;
+        $this->assertSame($adapterMode, $adapter->getAdapterName());
+
         // Attributes altered or set
         $this->assertSame('', $data->documentUrl);
         $this->assertSame([], $data->contents);
         $this->assertSame('', $data->ajax['contentUserData']);
         $this->assertSame('/api/progress?action=h5p_setFinished', $data->ajax['setFinished']);
+    }
+
+    public function provider_adapterMode(): \Generator
+    {
+        yield 'cerpus' => ['cerpus'];
+        yield 'ndla' => ['ndla'];
     }
 
     /** @dataProvider provider_setPreview */
@@ -84,11 +100,11 @@ class H5PViewConfigTest extends TestCase
         ];
     }
 
-    /** @dataProvider provider_saveFrequency */
-    public function test_loadContent(int|false $frequency): void
+    /** @dataProvider provider_adapterMode */
+    public function test_loadContent(string $adapterMode): void
     {
+        Session::put('adapterMode', $adapterMode);
         $faker = Factory::create();
-        config()->set('h5p.saveFrequency', $frequency);
 
         $resourceId = $faker->uuid;
         $context = $faker->uuid;
@@ -144,9 +160,9 @@ class H5PViewConfigTest extends TestCase
         $this->assertStringContainsString("/s/resources/$resourceId", $contentData->embedCode);
         $this->assertNotEmpty($data->url);
         $this->assertSame($content->title, $contentData->title);
-        $this->assertSame($frequency, $data->saveFreq);
+        $this->assertSame(config('h5p.saveFrequency'), $data->saveFreq);
 
-        if ($frequency === false) {
+        if (config('h5p.saveFrequency') === false) {
             $this->assertObjectNotHasAttribute('user', $data);
         } else {
             $this->assertObjectHasAttribute('user', $data);
@@ -165,12 +181,6 @@ class H5PViewConfigTest extends TestCase
         $this->assertNull($contentData->displayOptions->copy);
 
         $this->assertFalse($contentData->contentUserData['state']);
-    }
-
-    public function provider_saveFrequency()
-    {
-        yield [15];
-        yield [false];
     }
 
     public function test_setAlterParameterSettings(): void


### PR DESCRIPTION
- Add missing settings from adapter in create/edit H5P config
- Fix NDLA adapter accessing protected variable in H5P config
- Update unittests