### PR TITLE
Detect debug function calls and other undesirable statements

### DIFF
--- a/sourcecode/apis/contentauthor/composer.json
+++ b/sourcecode/apis/contentauthor/composer.json
@@ -48,6 +48,7 @@
     },
     "require-dev": {
         "barryvdh/laravel-ide-helper": "^2.10",
+        "ekino/phpstan-banned-code": "^1.0",
         "fakerphp/faker": "^1.16",
         "mockery/mockery": "^1.0",
         "nunomaduro/larastan": "^2.0",

--- a/sourcecode/apis/contentauthor/composer.lock
+++ b/sourcecode/apis/contentauthor/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5bad76ecae7092883dc8eda732e02555",
+    "content-hash": "f8f90b383667fa459cb93c1d1c6f8360",
     "packages": [
         {
             "name": "auth0/auth0-php",
@@ -9507,6 +9507,71 @@
                 }
             ],
             "time": "2022-12-30T00:23:10+00:00"
+        },
+        {
+            "name": "ekino/phpstan-banned-code",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ekino/phpstan-banned-code.git",
+                "reference": "4f0d7c8a0c9f5d222ffc24234aa6c5b3b71bf4c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ekino/phpstan-banned-code/zipball/4f0d7c8a0c9f5d222ffc24234aa6c5b3b71bf4c3",
+                "reference": "4f0d7c8a0c9f5d222ffc24234aa6c5b3b71bf4c3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0",
+                "phpstan/phpstan": "^1.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.6",
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "nikic/php-parser": "^4.3",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/var-dumper": "^5.0"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ekino\\PHPStanBannedCode\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rémi Marseille",
+                    "email": "remi.marseille@ekino.com",
+                    "homepage": "https://www.ekino.com"
+                }
+            ],
+            "description": "Detected banned code using PHPStan",
+            "homepage": "https://github.com/ekino/phpstan-banned-code",
+            "keywords": [
+                "PHPStan",
+                "code quality"
+            ],
+            "support": {
+                "issues": "https://github.com/ekino/phpstan-banned-code/issues",
+                "source": "https://github.com/ekino/phpstan-banned-code/tree/v1.0.0"
+            },
+            "time": "2021-11-02T08:37:34+00:00"
         },
         {
             "name": "fakerphp/faker",

--- a/sourcecode/apis/contentauthor/phpstan-baseline.neon
+++ b/sourcecode/apis/contentauthor/phpstan-baseline.neon
@@ -36,6 +36,11 @@ parameters:
 			path: app/Console/Commands/VersionAllUnversionedContent.php
 
 		-
+			message: "#^Should not use node with type \"Stmt_Echo\", please change the code\\.$#"
+			count: 2
+			path: app/Console/Commands/VersionAllUnversionedContent.php
+
+		-
 			message: "#^Access to an undefined property App\\\\ContentLanguageLink\\:\\:\\$link_content_id\\.$#"
 			count: 1
 			path: app/Content.php
@@ -616,6 +621,11 @@ parameters:
 			path: app/Libraries/H5P/AjaxRequest.php
 
 		-
+			message: "#^Should not use node with type \"Expr_Exit\", please change the code\\.$#"
+			count: 3
+			path: app/Libraries/H5P/AjaxRequest.php
+
+		-
 			message: "#^Ternary operator condition is always true\\.$#"
 			count: 1
 			path: app/Libraries/H5P/ContentType/BaseH5PContent.php
@@ -844,6 +854,11 @@ parameters:
 		-
 			message: "#^Property App\\\\Libraries\\\\H5P\\\\H5PProgress\\:\\:\\$request is never read, only written\\.$#"
 			count: 1
+			path: app/Libraries/H5P/H5PProgress.php
+
+		-
+			message: "#^Should not use node with type \"Expr_Exit\", please change the code\\.$#"
+			count: 2
 			path: app/Libraries/H5P/H5PProgress.php
 
 		-

--- a/sourcecode/apis/contentauthor/phpstan.neon.dist
+++ b/sourcecode/apis/contentauthor/phpstan.neon.dist
@@ -1,4 +1,5 @@
 includes:
+    - vendor/ekino/phpstan-banned-code/extension.neon
     - vendor/nunomaduro/larastan/extension.neon
     - phpstan-baseline.neon
 
@@ -16,3 +17,18 @@ parameters:
     stubFiles:
         - stubs/h5p-core/H5PCore.stub
         - stubs/h5p-core/H5PExport.stub
+    banned_code:
+        nodes:
+            -
+                type: Expr_FuncCall
+                functions:
+                    - dd
+                    - dump
+                    - phpinfo
+                    - print_r
+                    - printf
+                    - var_dump
+            - { type: Expr_ShellExec, functions: null }
+            - { type: Stmt_Echo, functions: null }
+            - { type: Stmt_Exit, functions: null }
+            - { type: Stmt_Print, functions: null }

--- a/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PConfigAbstractTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PConfigAbstractTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Libraries\H5P;
+namespace Tests\Integration\Libraries\H5P;
 
 use App\Libraries\H5P\H5PCreateConfig;
 use Illuminate\Foundation\Testing\RefreshDatabase;


### PR DESCRIPTION
Adds the [phpstan-banned-code extension](https://packagist.org/packages/ekino/phpstan-banned-code) to prevent use of debug statements (`dd()`, `dump()`, `phpinfo()`, `var_dump()`), stuff that bypasses Laravel's output (`die`/`exit`, `echo`/`print`, `printf()`, `print_r()`), nasty surprises ([backtick operator](https://www.php.net/manual/en/language.operators.execution.php)), and use of test code outside of tests.

This is primarily intended to make sure we don't commit code containing `dd()` or such, as this is easy to do by accident if you don't use a debugger, and can leak details that should not be seen.

One test class was misnamed and triggered the test-code-outside-tests detection, so has been renamed. The other discovered issues are baselined.