### PR TITLE
Add CDN URL to s3 config

### DIFF
--- a/sourcecode/apis/contentauthor/config/filesystems.php
+++ b/sourcecode/apis/contentauthor/config/filesystems.php
@@ -47,6 +47,7 @@ return [
             'secret' => env('AWS_SECRET_ACCESS_KEY'),
             'region' => env('AWS_DEFAULT_REGION'),
             'bucket' => env('AWS_BUCKET'),
+            'url' => env('CDN_WITH_PREFIX'),
         ],
         // temporary directory for test files
         // this has to be its own directory, or your files will go missing!


### PR DESCRIPTION
Fixes the URLs generated in #2441. Additionally, this requires a change to the CloudFront configuration.