### PR TITLE
Fix CA build

### DIFF
--- a/sourcecode/apis/contentauthor/Dockerfile
+++ b/sourcecode/apis/contentauthor/Dockerfile
@@ -49,7 +49,7 @@ FROM node:16-alpine AS frontend
 
 WORKDIR /app
 
-RUN npm i -g npm node-gyp
+RUN npm i -g node-gyp
 
 COPY package.json package-lock.json ./
 RUN npm i --legacy-peer-deps


### PR DESCRIPTION
Building CA test image fails with the error
```
#20 [frontend  3/11] RUN npm i -g npm node-gyp
#20 0.893 npm ERR! code EBADENGINE
#20 0.895 npm ERR! engine Unsupported engine
#20 0.896 npm ERR! engine Not compatible with your version of node/npm: npm@10.0.0
#20 0.897 npm ERR! notsup Not compatible with your version of node/npm: npm@10.0.0
#20 0.898 npm ERR! notsup Required: {"node":"^18.17.0 || >=20.5.0"}
#20 0.898 npm ERR! notsup Actual:   {"npm":"8.19.4","node":"v16.20.2"}
```
Attempt to fix by not installing/updating npm