### PR TITLE
Fix missing H5P authorship

### DIFF
--- a/sourcecode/proxies/lti/src/controllers/launch.js
+++ b/sourcecode/proxies/lti/src/controllers/launch.js
@@ -25,6 +25,11 @@ export default {
             {
                 jwt: req.authorizationJwt,
                 userId: req.user && req.user.id,
+                user: {
+                    firstName: req?.user?.firstName,
+                    lastName: req?.user?.lastName,
+                    email: req?.user?.email,
+                },
             },
             resourceId,
             resourceVersionId
@@ -78,6 +83,11 @@ export default {
             {
                 jwt: req.authorizationJwt,
                 userId: req.user && req.user.id,
+                user: {
+                    firstName: req?.user?.firstName,
+                    lastName: req?.user?.lastName,
+                    email: req?.user?.email,
+                },
             },
             params
         );

--- a/sourcecode/proxies/lti/src/controllers/launchEditor.js
+++ b/sourcecode/proxies/lti/src/controllers/launchEditor.js
@@ -17,6 +17,11 @@ export default {
             {
                 jwt: req.authorizationJwt,
                 userId: req.user.id,
+                user: {
+                    firstName: req?.user?.firstName,
+                    lastName: req?.user?.lastName,
+                    email: req?.user?.email,
+                },
             },
             {
                 launch_presentation_return_url:

--- a/sourcecode/proxies/lti/src/controllers/lti.js
+++ b/sourcecode/proxies/lti/src/controllers/lti.js
@@ -19,6 +19,11 @@ export default {
             {
                 jwt: req.authorizationJwt,
                 userId: req.user.id,
+                user: {
+                    firstName: req?.user?.firstName,
+                    lastName: req?.user?.lastName,
+                    email: req?.user?.email,
+                },
             },
             extras
         );
@@ -39,6 +44,11 @@ export default {
                 req.authorizationJwt && {
                     jwt: req.authorizationJwt,
                     userId: req.user.id,
+                    user: {
+                        firstName: req?.user?.firstName,
+                        lastName: req?.user?.lastName,
+                        email: req?.user?.email,
+                    },
                 },
                 extras
             );

--- a/sourcecode/proxies/lti/src/services/lti.js
+++ b/sourcecode/proxies/lti/src/services/lti.js
@@ -80,6 +80,18 @@ const buildLtiRequest = (
         fields.ext_user_id = authorization.userId;
     }
 
+    if (authorization?.user?.firstName) {
+        fields.lis_person_name_given = authorization.user.firstName;
+    }
+    
+    if (authorization?.user?.lastName) {
+        fields.lis_person_name_family = authorization.user.lastName;
+    }
+
+    if (authorization?.user?.email) {
+        fields.lis_person_contact_email_primary = authorization.user.email;
+    }
+
     if (fields.ext_preview === '1' || fields.ext_preview === true) {
         fields.ext_preview = 'true';
     }
@@ -167,10 +179,6 @@ const editResourceRequest = async (
             launch_presentation_return_url:
                 reqProtoHost +
                 `/lti/v2/editors/${resourceVersion.externalSystemName.toLowerCase()}/return`,
-            ext_user_id: authorization.userId,
-            lis_person_name_given: authorization.user.firstName,
-            lis_person_name_family: authorization.user.lastName,
-            lis_person_contact_email_primary: authorization.user.email,
         }
     );
 };


### PR DESCRIPTION
Caused by JWT handling being removed from CA, but user details not being sent as regular LTI params.