### PR TITLE
CA: get embed details from LTI params

### DIFF
--- a/sourcecode/apis/contentauthor/app/Http/Controllers/H5PController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/H5PController.php
@@ -87,8 +87,9 @@ class H5PController extends Controller
 
     public function doShow($id, $context, $preview = false): View
     {
+        $ltiRequest = $this->lti->getRequest(request());
         $styles = [];
-        $style = $this->lti->getRequest(request())?->getLaunchPresentationCssUrl();
+        $style = $ltiRequest?->getLaunchPresentationCssUrl();
         if ($style) {
             $styles[] = $style;
             Session::flash(SessionKeys::EXT_CSS_URL, $style);
@@ -105,6 +106,8 @@ class H5PController extends Controller
             ->setUserName(Session::get('name', false))
             ->setPreview($preview)
             ->setContext($context)
+            ->setEmbedId($ltiRequest?->getExtEmbedId())
+            ->setResourceLinkTitle($ltiRequest?->getResourceLinkTitle())
             ->loadContent($id)
             ->setAlterParameterSettings(H5PAlterParametersSettingsDataObject::create(['useImageWidth' => $h5pContent->library->includeImageWidth()]));
 

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PViewConfig.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PViewConfig.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace App\Libraries\H5P;
 
-use App\ApiModels\Resource;
-use App\Apis\ResourceApiService;
-use App\Exceptions\NotFoundException;
 use App\Exceptions\UnknownH5PPackageException;
 use App\Libraries\H5P\Dataobjects\H5PAlterParametersSettingsDataObject;
 use App\Libraries\H5P\Helper\H5PPackageProvider;

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PViewConfig.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PViewConfig.php
@@ -15,8 +15,13 @@ use App\Libraries\H5P\Interfaces\ContentTypeInterface;
 use App\Libraries\H5P\Interfaces\H5PAdapterInterface;
 use App\SessionKeys;
 use App\Traits\H5PBehaviorSettings;
+use H5PCore;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+
+use function htmlspecialchars;
+use function sprintf;
+use function url;
 
 class H5PViewConfig extends H5PConfigAbstract
 {
@@ -24,11 +29,12 @@ class H5PViewConfig extends H5PConfigAbstract
 
     private bool $preview = false;
     private ?string $context = null;
-    private ?Resource $resource = null;
     private ?H5PAlterParametersSettingsDataObject $alterParametersSettings = null;
     private ?string $filterParams = null;
+    private ?string $embedId = null;
+    private ?string $resourceLinkTitle = null;
 
-    public function __construct(H5PAdapterInterface $adapter, \H5PCore $h5pCore)
+    public function __construct(H5PAdapterInterface $adapter, H5PCore $h5pCore)
     {
         parent::__construct($adapter, $h5pCore);
 
@@ -66,7 +72,6 @@ class H5PViewConfig extends H5PConfigAbstract
     {
         parent::loadContent($id);
 
-        $this->loadResource();
         $this->setDependentFiles();
 
         $displayOptions = config('h5p.overrideDisableSetting') === false ? $this->content['disable'] : config('h5p.overrideDisableSetting');
@@ -81,20 +86,18 @@ class H5PViewConfig extends H5PConfigAbstract
         $this->contentConfig['title'] = $this->content['title'];
         $this->contentConfig['metadata'] = $this->content['metadata'];
 
-        if ($this->resource) {
-            $edlibEmbedPath = config('edlib.embedPath');
-            if ($edlibEmbedPath !== null) {
-                $this->config['documentUrl'] = str_replace('<resourceId>', $this->resource->id, $edlibEmbedPath);
-                $this->contentConfig['embedCode'] = sprintf(
-                    self::EMBED_TEMPLATE,
-                    htmlspecialchars($this->config['documentUrl'], ENT_QUOTES),
-                    htmlspecialchars($this->resource->title ?? '', ENT_QUOTES)
-                );
-                $this->contentConfig['resizeCode'] = sprintf(
-                    '<script src="%s"></script>',
-                    htmlspecialchars(url('/h5p-php-library/js/h5p-resizer.js'))
-                );
-            }
+        $embedPathTemplate = config('edlib.embedPath');
+        if ($embedPathTemplate && $this->embedId !== null) {
+            $this->config['documentUrl'] = str_replace('<resourceId>', $this->embedId, $embedPathTemplate);
+            $this->contentConfig['embedCode'] = sprintf(
+                self::EMBED_TEMPLATE,
+                htmlspecialchars($this->config['documentUrl'], ENT_QUOTES),
+                htmlspecialchars($this->resourceLinkTitle ?? $this->content['title'] ?? '', ENT_QUOTES)
+            );
+            $this->contentConfig['resizeCode'] = sprintf(
+                '<script src="%s"></script>',
+                htmlspecialchars(url('/h5p-php-library/js/h5p-resizer.js'))
+            );
         }
 
         $this->config['saveFreq'] = $this->getSaveFrequency();
@@ -106,6 +109,18 @@ class H5PViewConfig extends H5PConfigAbstract
     public function setAlterParameterSettings(H5PAlterParametersSettingsDataObject $settings): static
     {
         $this->alterParametersSettings = $settings;
+        return $this;
+    }
+
+    public function setEmbedId(string|null $embedId): static
+    {
+        $this->embedId = $embedId;
+        return $this;
+    }
+
+    public function setResourceLinkTitle(string|null $resourceLinkTitle): static
+    {
+        $this->resourceLinkTitle = $resourceLinkTitle;
         return $this;
     }
 
@@ -131,15 +146,6 @@ class H5PViewConfig extends H5PConfigAbstract
             $this->config['contents'] = (object) [
                 'cid-' . $this->content['id'] => (object) $this->contentConfig,
             ];
-        }
-    }
-
-    private function loadResource(): void
-    {
-        try {
-            $this->resource = app(ResourceApiService::class)->getResourceFromExternalReference('contentauthor', (string) $this->content['id']);
-        } catch (NotFoundException|\JsonException) {
-            $this->resource = null;
         }
     }
 

--- a/sourcecode/apis/contentauthor/app/Lti/LtiRequest.php
+++ b/sourcecode/apis/contentauthor/app/Lti/LtiRequest.php
@@ -149,4 +149,14 @@ class LtiRequest extends \Cerpus\EdlibResourceKit\Oauth1\Request
     {
         return $this->param('ext_translation_language');
     }
+
+    public function getExtEmbedId(): string|null
+    {
+        return $this->param('ext_embed_id');
+    }
+
+    public function getResourceLinkTitle(): string|null
+    {
+        return $this->param('resource_link_title');
+    }
 }

--- a/sourcecode/apis/contentauthor/phpunit.xml
+++ b/sourcecode/apis/contentauthor/phpunit.xml
@@ -46,6 +46,7 @@
         <server name="LICENSE_SITE" value="ContentAuthorTest"/>
         <server name="H5P_CONSUMER_KEY" value="h5p"/>
         <server name="H5P_CONSUMER_SECRET" value="secret2"/>
+        <server name="H5P_VIDEO_ACCOUNT_ID" value="1234567890"/>
         <server name="TEST_FS_ROOT" value="/tmp"/>
         <server name="MAIL_PRETEND" value="true"/>
         <server name="MAIL_DRIVER" value="log"/>

--- a/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/H5PControllerTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/H5PControllerTest.php
@@ -2,9 +2,7 @@
 
 namespace Tests\Integration\Http\Controllers;
 
-use App\ApiModels\Resource;
 use App\ApiModels\User;
-use App\Apis\ResourceApiService;
 use App\H5PContent;
 use App\H5PContentLibrary;
 use App\H5PContentsMetadata;
@@ -13,15 +11,23 @@ use App\H5PLibrary;
 use App\H5PLibraryLibrary;
 use App\Http\Controllers\H5PController;
 use App\Http\Libraries\License;
+use App\Libraries\H5P\Adapters\CerpusH5PAdapter;
+use App\Libraries\H5P\Adapters\NDLAH5PAdapter;
 use App\Libraries\H5P\H5PConfigAbstract;
+use App\Libraries\H5P\Interfaces\H5PAdapterInterface;
+use Cerpus\EdlibResourceKit\Oauth1\CredentialStoreInterface;
+use Cerpus\EdlibResourceKit\Oauth1\Request as Oauth1Request;
+use Cerpus\EdlibResourceKit\Oauth1\SignerInterface;
 use Faker\Factory;
 use H5PCore;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
+use LogicException;
 use Tests\Helpers\MockAuthApi;
 use Tests\TestCase;
 
@@ -29,13 +35,13 @@ class H5PControllerTest extends TestCase
 {
     use RefreshDatabase;
     use MockAuthApi;
+    use WithFaker;
 
     /** @dataProvider provider_testCreate */
     public function testCreate(string $adapterMode, ?string $contentType): void
     {
-        $faker = Factory::create();
         $this->session([
-            'authId' => $faker->uuid(),
+            'authId' => $this->faker->uuid(),
             'name' => 'Emily Quackfaster',
             'userName' => 'QuackMaster',
             'email' => 'emily.quackfaster@duckburg.quack',
@@ -43,7 +49,7 @@ class H5PControllerTest extends TestCase
             'adapterMode' => $adapterMode,
         ]);
         $request = Request::create('lti-content/create', 'POST', [
-            'redirectToken' => $faker->uuid,
+            'redirectToken' => $this->faker->uuid,
         ]);
 
         H5PLibrary::factory()->create();
@@ -277,12 +283,14 @@ class H5PControllerTest extends TestCase
     /** @dataProvider provider_adapterMode */
     public function testDoShow(string $adapterMode): void
     {
-        Session::put('adapterMode', $adapterMode);
-        $faker = Factory::create();
+        $this->app->singleton(H5PAdapterInterface::class, match ($adapterMode) {
+            'cerpus' => CerpusH5PAdapter::class,
+            'ndla' => NDLAH5PAdapter::class,
+            default => throw new LogicException('Invalid adapter'),
+        });
+
         Storage::fake('test');
-        $resourceId = $faker->uuid;
-        $resourceApi = $this->createMock(ResourceApiService::class);
-        $this->instance(ResourceApiService::class, $resourceApi);
+        $resourceId = $this->faker->uuid;
 
         $depH5PVideo = H5PLibrary::factory()->create(['name' => 'H5P.Video', 'major_version' => 2, 'minor_version' => 9]);
         $depCerpusVideo = H5PLibrary::factory()->create(['name' => 'H5P.CerpusVideo', 'major_version' => 3, 'minor_version' => 8]);
@@ -343,14 +351,19 @@ class H5PControllerTest extends TestCase
             'drop_css' => 0,
         ]);
 
-        $resourceApi
-            ->expects($this->atLeastOnce())
-            ->method('getResourceFromExternalReference')
-            ->willReturn(new Resource($resourceId, '', '', '', '', '', $content->title));
+        $request = new Oauth1Request('POST', 'http://localhost/h5p/' . $content->id, [
+            'lti_message_type' => 'basic-lti-launch-request',
+            'ext_embed_id' => $resourceId,
+            'resource_link_title' => 'Some resource title',
+        ]);
+        $request = $this->app->make(SignerInterface::class)->sign(
+            $request,
+            $this->app->make(CredentialStoreInterface::class),
+        );
 
-        $controller = app(H5PController::class);
-        $result = $controller->doShow($content->id, $faker->sha1, false)->getData();
+        $result = $this->post('/h5p/' . $content->id, $request->toArray())->original;
 
+        $this->assertInstanceOf(View::class, $result);
         $this->assertEquals($content->id, $result['id']);
         $this->assertFalse($result['preview']);
         $this->assertStringContainsString('data-content-id="'.$content->id.'"', $result['embed']);
@@ -392,6 +405,7 @@ class H5PControllerTest extends TestCase
         $this->assertObjectHasAttribute('displayOptions', $contents);
         $this->assertObjectHasAttribute('contentUserData', $contents);
         $this->assertStringContainsString("/s/resources/$resourceId", $contents->embedCode);
+        $this->assertStringContainsString('Some resource title', $contents->embedCode);
 
         // Adapter specific
         $this->assertContains('//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-AMS-MML_SVG', $result['jsScripts']);

--- a/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PViewConfigTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PViewConfigTest.php
@@ -125,16 +125,11 @@ class H5PViewConfigTest extends TestCase
             'license_version' => '4.0',
             'default_language' => 'nb',
         ]);
-        $resourceApi = $this->createMock(ResourceApiService::class);
-        $this->instance(ResourceApiService::class, $resourceApi);
-        $resourceApi
-            ->expects($this->atLeastOnce())
-            ->method('getResourceFromExternalReference')
-            ->willReturn(new Resource($resourceId, '', '', '', '', '', $content->title));
 
         $data = app(H5PViewConfig::class)
             ->setUserId($userId)
             ->setContext($context)
+            ->setEmbedId('my-embed-id')
             ->loadContent($content->id)
             ->getConfig();
 
@@ -147,14 +142,14 @@ class H5PViewConfigTest extends TestCase
             "/api/progress?action=h5p_contents_user_data&content_id=:contentId&data_type=:dataType&sub_content_id=:subContentId&context=$context",
             $data->ajax['contentUserData']
         );
-        $this->assertStringEndsWith("/s/resources/$resourceId", $data->documentUrl);
+        $this->assertSame("https://www.edlib.test/s/resources/my-embed-id", $data->documentUrl);
 
         $contentData = $data->contents->{'cid-' . $content->id};
 
         $this->assertSame('H5P.Foobar 1.2', $contentData->library);
         $this->assertSame(1, $contentData->fullScreen);
         $this->assertStringEndsWith("/h5p/$content->id/download", $contentData->exportUrl);
-        $this->assertStringContainsString("/s/resources/$resourceId", $contentData->embedCode);
+        $this->assertStringContainsString("/s/resources/my-embed-id", $contentData->embedCode);
         $this->assertNotEmpty($data->url);
         $this->assertSame($content->title, $contentData->title);
         $this->assertSame(config('h5p.saveFrequency'), $data->saveFreq);
@@ -182,21 +177,12 @@ class H5PViewConfigTest extends TestCase
 
     public function test_setAlterParameterSettings(): void
     {
-        $faker = Factory::create();
-
-        $resourceId = $faker->uuid;
         $library = H5PLibrary::factory()->create();
         $content = H5PContent::factory()->create([
             'library_id' => $library->id,
             'disable' => 2,
             'filtered' => 'here be filtered data',
         ]);
-        $resourceApi = $this->createMock(ResourceApiService::class);
-        $this->instance(ResourceApiService::class, $resourceApi);
-        $resourceApi
-            ->expects($this->atLeastOnce())
-            ->method('getResourceFromExternalReference')
-            ->willReturn(new Resource($resourceId, '', '', '', '', '', $content->title));
 
         $data = app(H5PViewConfig::class)
             ->loadContent($content->id)
@@ -208,21 +194,12 @@ class H5PViewConfigTest extends TestCase
 
     public function test_behaviorSettings(): void
     {
-        $faker = Factory::create();
-
-        $resourceId = $faker->uuid;
         $library = H5PLibrary::factory()->create();
         $content = H5PContent::factory()->create([
             'library_id' => $library->id,
             'disable' => 8,
             'filtered' => '{"title":"something"}',
         ]);
-        $resourceApi = $this->createMock(ResourceApiService::class);
-        $this->instance(ResourceApiService::class, $resourceApi);
-        $resourceApi
-            ->expects($this->atLeastOnce())
-            ->method('getResourceFromExternalReference')
-            ->willReturn(new Resource($resourceId, '', '', '', '', '', $content->title));
 
         Session::put(SessionKeys::EXT_BEHAVIOR_SETTINGS, BehaviorSettingsDataObject::create([
             'presetmode' => 'exam',

--- a/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PViewConfigTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Libraries/H5P/H5PViewConfigTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\Integration\Libraries\H5P;
 
-use App\ApiModels\Resource;
-use App\Apis\ResourceApiService;
 use App\H5PContent;
 use App\H5PContentsMetadata;
 use App\H5PLibrary;

--- a/sourcecode/proxies/lti/src/services/lti.js
+++ b/sourcecode/proxies/lti/src/services/lti.js
@@ -16,6 +16,7 @@ const allowedParameters = [
     'ext_content_intended_use',
     'launch_presentation_document_target',
     'resource_link_id',
+    'resource_link_title',
     'ext_jwt_token',
     'ext_h5p_only',
     'context_id',
@@ -36,6 +37,7 @@ const allowedParameters = [
     'ext_create_content_default_license',
     'ext_behavior_settings',
     'ext_preview',
+    'ext_embed_id',
 ];
 
 const buildLtiRequest = (
@@ -132,14 +134,23 @@ const viewResourceRequest = async (
         resourceVersionId
     );
 
+    const { version } = await context.services.resource.getResourceWithVersion(
+        resourceId,
+        resourceVersionId
+    );
+
     return {
         resourceVersion,
-        launchRequest: await buildLtiRequest(
+        launchRequest: buildLtiRequest(
             ltiResourceUrl,
             consumerKey,
             consumerSecret,
             authorization,
-            extras
+            {
+                ...extras,
+                ext_embed_id: resourceId,
+                resource_link_title: version.title,
+            },
         ),
     };
 };


### PR DESCRIPTION
Removes an HTTP request to resourceapi that is done before showing content. This is part of making CA independent of old Edlib and making it compatible with Edlib 3.