### PR TITLE
GH #2589: CA Admin: Allow updating library translations in database

### DIFF
--- a/sourcecode/apis/contentauthor/app/H5PLibraryLanguage.php
+++ b/sourcecode/apis/contentauthor/app/H5PLibraryLanguage.php
@@ -7,6 +7,11 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @property int $library_id
+ * @property string $language_code
+ * @property string $translation JSON string
+ */
 class H5PLibraryLanguage extends Model
 {
     use HasFactory;

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/AdminH5PDetailsController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/AdminH5PDetailsController.php
@@ -197,6 +197,7 @@ class AdminH5PDetailsController extends Controller
         return view('admin.library-upgrade.translation', [
             'library' => $library,
             'languageCode' => $locale,
+            'haveTranslation' => $libLang !== null,
             'translationDb' => $libLang?->translation,
             'translationFile' => Storage::disk()->get(
                 sprintf('libraries/%s/language/%s.json', $library->getFolderName(), $locale)
@@ -208,7 +209,6 @@ class AdminH5PDetailsController extends Controller
     {
         $errorMsg = '';
         $success = -1;
-        $translation = '';
         $input = $request->validated();
 
         try {
@@ -241,7 +241,8 @@ class AdminH5PDetailsController extends Controller
         return view('admin.library-upgrade.translation', [
             'library' => $library,
             'languageCode' => $locale,
-            'translationDb' => $success === 0 ? $translation : $libLang?->translation,
+            'haveTranslation' => $libLang !== null,
+            'translationDb' => $libLang?->translation,
             'translationFile' => Storage::disk()->get(
                 sprintf('libraries/%s/language/%s.json', $library->getFolderName(), $locale)
             ),

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/AdminH5PDetailsController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/AdminH5PDetailsController.php
@@ -21,7 +21,6 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
-use Symfony\Component\HttpFoundation\Exception\JsonException;
 
 class AdminH5PDetailsController extends Controller
 {

--- a/sourcecode/apis/contentauthor/app/Http/Requests/AdminTranslationUpdateRequest.php
+++ b/sourcecode/apis/contentauthor/app/Http/Requests/AdminTranslationUpdateRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Support\Facades\Gate;
+
+class AdminTranslationUpdateRequest extends Request
+{
+    public function authorize(): bool
+    {
+        return Gate::allows('superadmin');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'translationFile' => [
+                'required_without:translation',
+                'filled',
+                'file',
+                'max:50',
+            ],
+            'translation' => [
+                'required_without:translationFile',
+                'filled',
+                'json',
+                'max:51200',
+            ],
+        ];
+    }
+}

--- a/sourcecode/apis/contentauthor/phpstan-baseline.neon
+++ b/sourcecode/apis/contentauthor/phpstan-baseline.neon
@@ -626,11 +626,6 @@ parameters:
 			path: app/Libraries/H5P/EditorStorage.php
 
 		-
-			message: "#^Called 'pluck' on Laravel collection, but could have been retrieved as a query\\.$#"
-			count: 1
-			path: app/Libraries/H5P/EditorStorage.php
-
-		-
 			message: "#^Property App\\\\H5PLibrary\\:\\:\\$restricted \\(int\\) does not accept false\\.$#"
 			count: 1
 			path: app/Libraries/H5P/EditorStorage.php

--- a/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/index.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/index.blade.php
@@ -32,6 +32,7 @@
                         <form action="{{ route('admin.check-for-updates') }}" method="post">
                             @csrf
                             <h4>Content types from h5p.org</h4>
+                            <p>Last updated: {{ \Carbon\Carbon::createFromTimestamp($contentTypeCacheUpdatedAt)->format('Y-m-d H:i:s e') }}</p>
                             <button type="submit" class="btn btn-success">Check for updates</button>
                         </form>
                     </div>

--- a/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/library-check.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/library-check.blade.php
@@ -155,6 +155,20 @@
                                     @endisset
                                 </td>
                             </tr>
+                            <tr>
+                                <th>Translations</th>
+                                <td colspan="2">
+                                    @foreach($languages as $lang)
+                                        <a
+                                            href="{{ route('admin.library-translation', [$library->id, $lang]) }}"
+                                            class="btn btn-default"
+                                        >
+                                            {{ $lang }}
+                                        </a>
+                                    @endforeach
+                                </td>
+                                <td></td>
+                            </tr>
                         </table>
                     </div>
                 </div>
@@ -171,14 +185,22 @@
                                 <th>semantics.json</th>
                             </tr>
                             <tr>
-                                <td>
+                                <td style="width:50%">
                                     @if(!empty($library->semantics))
-                                        <textarea wrap="off" readonly style="width:400px;height:300px;">{!!$library->semantics!!}</textarea>
+                                        <textarea
+                                            readonly
+                                            rows="15"
+                                            style="width:100%;white-space:pre"
+                                        >{!!$library->semantics!!}</textarea>
                                     @endif
                                 </td>
                                 <td>
                                     @if(!empty($libData['semantics']))
-                                        <textarea wrap="off" readonly style="width:400px;height:300px;">{!! $libData['semantics'] !!}</textarea>
+                                        <textarea
+                                            readonly
+                                            rows="15"
+                                            style="width:100%;white-space:pre"
+                                        >{!! $libData['semantics'] !!}</textarea>
                                     @endif
                                 </td>
                             </tr>

--- a/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/translation.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/translation.blade.php
@@ -19,25 +19,19 @@
                             </ul>
                         </div>
                     </div>
-                    @isset($success)
-                        @if($success)
-                            <div class="alert alert-success">
-                                Database updated
-                            </div>
-                        @endif
-                        @empty(!$errorMessage)
-                            <div class="alert alert-danger">
-                                Update failed
-                                <pre style="margin-top:1em;">{{ $errorMessage }}</pre>
-                            </div>
-                        @endif
-                    @endisset
-                    @if($errors->isNotEmpty())
+                    @if($errors->isNotEmpty() || $messages->isNotEmpty())
                         <div class="alert alert-danger">
                             Update failed
                             @foreach($errors->all() as $error)
                                 <pre style="margin-top:1em;">{{ $error }}</pre>
                             @endforeach
+                            @foreach($messages->all() as $msg)
+                                <pre style="margin-top:1em;">{{ $msg }}</pre>
+                            @endforeach
+                        </div>
+                    @else
+                        <div class="alert alert-success">
+                            Database updated
                         </div>
                     @endif
                     <div class="panel-body row">

--- a/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/translation.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/translation.blade.php
@@ -14,7 +14,7 @@
                     <div class="panel-body row">
                         <div class="alert alert-warning">
                             <ul>
-                                <li>This will be a local change only, for exported content the original file is included
+                                <li>Changes done here will not be included when the library is exported
                                 <li>If a new patch version of this library is installed, changes done may be lost
                             </ul>
                         </div>
@@ -43,21 +43,25 @@
                     <div class="panel-body row">
                         <div class="panel panel-default">
                             <div class="panel-heading">
-                                <h5>Upload language file</h5>
+                                <h5>Upload new translation</h5>
                             </div>
                             <div class="panel-body row">
-                                <form method="post" accept-charset="utf-8" enctype="multipart/form-data" >
-                                    @csrf
-                                    <input
-                                        type="file"
-                                        name="translationFile"
-                                        accept=".json"
-                                    >
-                                    <br>
-                                    <button type="submit" class="btn btn-primary btn-lg">
-                                        Upload
-                                    </button>
-                                </form>
+                                @if($haveTranslation)
+                                    <form method="post" accept-charset="utf-8" enctype="multipart/form-data" >
+                                        @csrf
+                                        <input
+                                            type="file"
+                                            name="translationFile"
+                                            accept=".json"
+                                        >
+                                        <br>
+                                        <button type="submit" class="btn btn-primary btn-lg">
+                                            Upload
+                                        </button>
+                                    </form>
+                                @else
+                                    Upload not available
+                                @endif
                             </div>
                         </div>
                     </div>
@@ -69,9 +73,7 @@
                             </tr>
                             <tr>
                                 <td style="width: 50%;">
-                                    @empty($translationDb)
-                                        No data found
-                                    @else
+                                    @if($haveTranslation)
                                         <form method="post" accept-charset="utf-8">
                                             @csrf
                                             <textarea
@@ -85,7 +87,9 @@
                                                 Save
                                             </button>
                                         </form>
-                                    @endempty
+                                    @else
+                                        No data found
+                                    @endif
                                 </td>
                                 <td style="width: 50%;">
                                     @empty($translationFile)

--- a/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/translation.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/translation.blade.php
@@ -1,0 +1,108 @@
+@extends ('layouts.admin')
+@section ('content')
+    <div class="container" style="width:80vw">
+        <a href="{{ route('admin.check-library', [$library->id]) }}">Back to library</a>
+        <div class="row">
+            <div class="col-md-12">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h3>
+                            "<b>{{ $languageCode }}</b>"
+                            translation for {{ $library->getLibraryString(true) }}
+                        </h3>
+                    </div>
+                    <div class="panel-body row">
+                        <div class="alert alert-warning">
+                            <ul>
+                                <li>This will be a local change only, for exported content the original file is included
+                                <li>If a new patch version of this library is installed, changes done may be lost
+                            </ul>
+                        </div>
+                    </div>
+                    @isset($success)
+                        @if($success)
+                            <div class="alert alert-success">
+                                Database updated
+                            </div>
+                        @endif
+                        @empty(!$errorMessage)
+                            <div class="alert alert-danger">
+                                Update failed
+                                <pre style="margin-top:1em;">{{ $errorMessage }}</pre>
+                            </div>
+                        @endif
+                    @endisset
+                    @if($errors->isNotEmpty())
+                        <div class="alert alert-danger">
+                            Update failed
+                            @foreach($errors->all() as $error)
+                                <pre style="margin-top:1em;">{{ $error }}</pre>
+                            @endforeach
+                        </div>
+                    @endif
+                    <div class="panel-body row">
+                        <div class="panel panel-default">
+                            <div class="panel-heading">
+                                <h5>Upload language file</h5>
+                            </div>
+                            <div class="panel-body row">
+                                <form method="post" accept-charset="utf-8" enctype="multipart/form-data" >
+                                    @csrf
+                                    <input
+                                        type="file"
+                                        name="translationFile"
+                                        accept=".json"
+                                    >
+                                    <br>
+                                    <button type="submit" class="btn btn-primary btn-lg">
+                                        Upload
+                                    </button>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="panel-body row">
+                        <table class="table table-striped">
+                            <tr>
+                                <th>Database</th>
+                                <th>File (read only)</th>
+                            </tr>
+                            <tr>
+                                <td style="width: 50%;">
+                                    @empty($translationDb)
+                                        No data found
+                                    @else
+                                        <form method="post" accept-charset="utf-8">
+                                            @csrf
+                                            <textarea
+                                                name="translation"
+                                                autocomplete="off"
+                                                required
+                                                style="width:100%;height:70vh;white-space:pre;"
+                                            >{{$translationDb}}</textarea>
+                                            <br>
+                                            <button type="submit" class="btn btn-primary btn-lg">
+                                                Save
+                                            </button>
+                                        </form>
+                                    @endempty
+                                </td>
+                                <td style="width: 50%;">
+                                    @empty($translationFile)
+                                        No data found
+                                    @else
+                                        <textarea
+                                            autocomplete="off"
+                                            readonly
+                                            style="width:100%;height:70vh;white-space:pre;"
+                                        >{{$translationFile}}</textarea>
+                                    @endempty
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/sourcecode/apis/contentauthor/routes/admin.php
+++ b/sourcecode/apis/contentauthor/routes/admin.php
@@ -48,6 +48,9 @@ Route::middleware(['auth:admin,sso', 'can:superadmin'])->prefix('admin')->group(
             ->name('admin.content-library');
         Route::get('content/{content}/details', [AdminH5PDetailsController::class, 'contentHistory'])
             ->name('admin.content-details');
+        Route::get('libraries/{library}/translation/{locale}', [AdminH5PDetailsController::class, 'libraryTranslation'])
+            ->name('admin.library-translation');
+        Route::post('libraries/{library}/translation/{locale}', [AdminH5PDetailsController::class, 'libraryTranslationUpdate']);
 
         Route::get('libraries/{library}', [ContentUpgradeController::class, 'upgrade'])->name('admin.library');
 

--- a/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/Admin/AdminH5PDetailsControllerTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/Admin/AdminH5PDetailsControllerTest.php
@@ -5,18 +5,23 @@ namespace Tests\Integration\Http\Controllers\Admin;
 use App\ApiModels\Resource;
 use App\H5PContent;
 use App\H5PLibrary;
+use App\H5PLibraryLanguage;
 use App\H5PLibraryLibrary;
 use App\Http\Controllers\Admin\AdminH5PDetailsController;
 use App\Libraries\ContentAuthorStorage;
 use App\Libraries\H5P\Framework;
 use Cerpus\VersionClient\VersionData;
+use Illuminate\Auth\GenericUser;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\View\View;
 use Tests\TestCase;
 
 class AdminH5PDetailsControllerTest extends TestCase
@@ -27,6 +32,9 @@ class AdminH5PDetailsControllerTest extends TestCase
     public function test_checkLibrary(): void
     {
         $library = H5PLibrary::factory()->create();
+        $libLang = H5PLibraryLanguage::factory(3)->create([
+            'library_id' => $library->id,
+        ]);
         $libraryDep = H5PLibrary::factory()->create([
             'name' => 'H5P.EditorDep',
             'major_version' => 2,
@@ -140,6 +148,7 @@ class AdminH5PDetailsControllerTest extends TestCase
         $this->assertArrayHasKey('usedBy', $data);
         $this->assertArrayHasKey('info', $data);
         $this->assertArrayHasKey('error', $data);
+        $this->assertArrayHasKey('languages', $data);
 
         $this->assertCount(2, $data['libData']['editorDependencies']);
         $this->assertCount(2, $data['libData']['preloadedDependencies']);
@@ -158,6 +167,11 @@ class AdminH5PDetailsControllerTest extends TestCase
 
         $this->assertEquals('H5P.PreDepX', $data['preloadDeps']->first()->requiredLibrary->name);
         $this->assertEquals('H5P.EditorDepX', $data['editorDeps']->first()->requiredLibrary->name);
+
+        $this->assertCount(3, $data['languages']);
+        $libLang->pluck('language_code')->each(
+            fn($langCode) => $this->assertContains($langCode, $data['languages'])
+        );
     }
 
     public function test_contentForLibrary(): void
@@ -273,5 +287,213 @@ class AdminH5PDetailsControllerTest extends TestCase
         $this->assertEquals('Testing', $history['versionPurpose']);
         $this->assertEquals($content->title, $history['content']['title']);
         $this->assertEquals($library->id, $history['content']['library_id']);
+    }
+
+    public function test_libraryTranslation(): void
+    {
+        Storage::fake();
+        $user = new GenericUser([
+            'roles' => ['superadmin'],
+            'name' => 'Super Tester',
+        ]);
+        $library = H5PLibrary::factory()->create();
+        H5PLibraryLanguage::factory()->create(['library_id' => $library->id]);
+        $translation = H5PLibraryLanguage::factory()->create([
+            'library_id' => $library->id,
+            'translation' => '{"data":"DB translation"}',
+        ]);
+
+        Storage::put(
+            sprintf('libraries/%s/language/%s.json', $library->getFolderName(), $translation->language_code),
+            '{"data":"File translation"}'
+        );
+
+        $response = $this->withSession(['user' => $user])
+            ->get(route('admin.library-translation', [$library, $translation->language_code]))
+            ->assertOk()
+            ->original;
+
+        $this->assertInstanceOf(View::class, $response);
+
+        $data = $response->getData();
+        $this->assertSame($library->id, $data['library']->id);
+        $this->assertSame($translation->language_code, $data['languageCode']);
+        $this->assertSame($translation->translation, $data['translationDb']);
+        $this->assertSame('{"data":"File translation"}', $data['translationFile']);
+    }
+
+    public function test_libraryTranslation_UnknownCode(): void
+    {
+        Storage::fake();
+        $user = new GenericUser([
+            'roles' => ['superadmin'],
+            'name' => 'Super Tester',
+        ]);
+        $library = H5PLibrary::factory()->create();
+        $translation = H5PLibraryLanguage::factory()->create([
+            'library_id' => $library->id,
+            'language_code' => 'nb',
+            'translation' => '{"data":"DB translation"}',
+        ]);
+
+        Storage::put(
+            sprintf('libraries/%s/language/%s.json', $library->getFolderName(), $translation->language_code),
+            '{"data":"File translation"}'
+        );
+
+        $response = $this->withSession(['user' => $user])
+            ->get(route('admin.library-translation', [$library, 'nn']))
+            ->assertOk()
+            ->original;
+
+        $this->assertInstanceOf(View::class, $response);
+
+        $data = $response->getData();
+        $this->assertSame($library->id, $data['library']->id);
+        $this->assertSame('nn', $data['languageCode']);
+        $this->assertNull($data['translationDb']);
+        $this->assertNull($data['translationFile']);
+    }
+
+    public function test_libraryTranslationUpdate_Text(): void
+    {
+        Storage::fake();
+        $user = new GenericUser([
+            'roles' => ['superadmin'],
+            'name' => 'Super Tester',
+        ]);
+        $library = H5PLibrary::factory()->create();
+        $unchangedTranslation = H5PLibraryLanguage::factory()->create(['library_id' => $library->id]);
+        $translation = H5PLibraryLanguage::factory()->create([
+            'library_id' => $library->id,
+            'translation' => '{"data":"DB translation"}',
+        ]);
+        $this->assertDatabaseCount('h5p_libraries_languages', 2);
+
+        Storage::put(
+            sprintf('libraries/%s/language/%s.json', $library->getFolderName(), $translation->language_code),
+            '{"data":"File translation"}'
+        );
+
+        $response = $this->withSession(['user' => $user])
+            ->post(
+                route('admin.library-translation', [$library, $translation->language_code]),
+                ['translation' => '{"data":"Updated DB translation"}']
+            )
+            ->assertOk()
+            ->original;
+
+        $this->assertInstanceOf(View::class, $response);
+        $this->assertDatabaseHas('h5p_libraries_languages', [
+            'library_id' => $library->id,
+            'language_code' => $translation->language_code,
+            'translation' => '{"data":"Updated DB translation"}',
+        ]);
+        $this->assertDatabaseHas('h5p_libraries_languages', [
+            'library_id' => $library->id,
+            'language_code' => $unchangedTranslation->language_code,
+            'translation' => $unchangedTranslation->translation,
+        ]);
+
+        $data = $response->getData();
+        $this->assertTrue($data['success']);
+        $this->assertSame($library->id, $data['library']->id);
+        $this->assertSame($translation->language_code, $data['languageCode']);
+        $this->assertSame('{"data":"Updated DB translation"}', $data['translationDb']);
+        $this->assertSame('{"data":"File translation"}', $data['translationFile']);
+    }
+
+    public function test_libraryTranslationUpdate_FileUpload(): void
+    {
+        Storage::fake();
+        $user = new GenericUser([
+            'roles' => ['superadmin'],
+            'name' => 'Super Tester',
+        ]);
+        $library = H5PLibrary::factory()->create();
+        $unchangedTranslation = H5PLibraryLanguage::factory()->create(['library_id' => $library->id]);
+        $translation = H5PLibraryLanguage::factory()->create([
+            'library_id' => $library->id,
+            'translation' => '{"data":"DB translation"}',
+        ]);
+
+        Storage::put(
+            sprintf('libraries/%s/language/%s.json', $library->getFolderName(), $translation->language_code),
+            '{"data":"File translation"}'
+        );
+
+        $file = UploadedFile::fake()->createWithContent(
+            $translation->language_code . '.json',
+            json_encode(['data' => 'Upload translation'])
+        );
+
+        $response = $this->withSession(['user' => $user])
+            ->post(
+                route('admin.library-translation', [$library, $translation->language_code]),
+                ['translationFile' => $file]
+            )
+            ->assertOk()
+            ->original;
+
+        $this->assertInstanceOf(View::class, $response);
+        $this->assertDatabaseHas('h5p_libraries_languages', [
+            'library_id' => $library->id,
+            'language_code' => $translation->language_code,
+            'translation' => '{"data":"Upload translation"}',
+        ]);
+
+        $this->assertDatabaseHas('h5p_libraries_languages', [
+            'library_id' => $library->id,
+            'language_code' => $unchangedTranslation->language_code,
+            'translation' => $unchangedTranslation->translation,
+        ]);
+
+        $data = $response->getData();
+        $this->assertTrue($data['success']);
+        $this->assertSame($library->id, $data['library']->id);
+        $this->assertSame($translation->language_code, $data['languageCode']);
+        $this->assertSame('{"data":"Upload translation"}', $data['translationDb']);
+        $this->assertSame('{"data":"File translation"}', $data['translationFile']);
+    }
+
+    public function test_libraryTranslationUpdate_UnkownCode(): void
+    {
+        Storage::fake();
+        $user = new GenericUser([
+            'roles' => ['superadmin'],
+            'name' => 'Super Tester',
+        ]);
+        $library = H5PLibrary::factory()->create();
+        $translation = H5PLibraryLanguage::factory()->create([
+            'library_id' => $library->id,
+            'language_code' => 'nb',
+            'translation' => '{"data":"DB translation"}',
+        ]);
+
+        Storage::put(
+            sprintf('libraries/%s/language/%s.json', $library->getFolderName(), $translation->language_code),
+            '{"data":"File translation"}'
+        );
+
+        $response = $this->withSession(['user' => $user])
+            ->post(
+                route('admin.library-translation', [$library, 'nn']),
+                ['translation' => json_encode(['data' => 'Updated DB translation'])]
+            )
+            ->assertOk()
+            ->original;
+
+        $this->assertInstanceOf(View::class, $response);
+        $this->assertDatabaseMissing('h5p_libraries_languages', [
+            'library_id' => $library->id,
+            'language_code' => 'nn',
+        ]);
+
+        $data = $response->getData();
+        $this->assertFalse($data['success']);
+        $this->assertSame($library->id, $data['library']->id);
+        $this->assertSame('nn', $data['languageCode']);
+        $this->assertSame('{"data":"Updated DB translation"}', $data['translationDb']);
+        $this->assertNull($data['translationFile']);
     }
 }

--- a/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/Admin/AdminH5PDetailsControllerTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/Admin/AdminH5PDetailsControllerTest.php
@@ -493,7 +493,7 @@ class AdminH5PDetailsControllerTest extends TestCase
         $this->assertFalse($data['success']);
         $this->assertSame($library->id, $data['library']->id);
         $this->assertSame('nn', $data['languageCode']);
-        $this->assertSame('{"data":"Updated DB translation"}', $data['translationDb']);
+        $this->assertNull($data['translationDb']);
         $this->assertNull($data['translationFile']);
     }
 }

--- a/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/Admin/AdminH5PDetailsControllerTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/Admin/AdminH5PDetailsControllerTest.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Admin\AdminH5PDetailsController;
 use App\Libraries\ContentAuthorStorage;
 use App\Libraries\H5P\Framework;
 use Cerpus\VersionClient\VersionData;
+use Generator;
 use Illuminate\Auth\GenericUser;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -320,6 +321,7 @@ class AdminH5PDetailsControllerTest extends TestCase
         $this->assertSame($translation->language_code, $data['languageCode']);
         $this->assertSame($translation->translation, $data['translationDb']);
         $this->assertSame('{"data":"File translation"}', $data['translationFile']);
+        $this->assertTrue($data['messages']->isEmpty());
     }
 
     public function test_libraryTranslation_UnknownCode(): void
@@ -353,6 +355,7 @@ class AdminH5PDetailsControllerTest extends TestCase
         $this->assertSame('nn', $data['languageCode']);
         $this->assertNull($data['translationDb']);
         $this->assertNull($data['translationFile']);
+        $this->assertTrue($data['messages']->isEmpty());
     }
 
     public function test_libraryTranslationUpdate_Text(): void
@@ -396,64 +399,11 @@ class AdminH5PDetailsControllerTest extends TestCase
         ]);
 
         $data = $response->getData();
-        $this->assertTrue($data['success']);
         $this->assertSame($library->id, $data['library']->id);
         $this->assertSame($translation->language_code, $data['languageCode']);
         $this->assertSame('{"data":"Updated DB translation"}', $data['translationDb']);
         $this->assertSame('{"data":"File translation"}', $data['translationFile']);
-    }
-
-    public function test_libraryTranslationUpdate_FileUpload(): void
-    {
-        Storage::fake();
-        $user = new GenericUser([
-            'roles' => ['superadmin'],
-            'name' => 'Super Tester',
-        ]);
-        $library = H5PLibrary::factory()->create();
-        $unchangedTranslation = H5PLibraryLanguage::factory()->create(['library_id' => $library->id]);
-        $translation = H5PLibraryLanguage::factory()->create([
-            'library_id' => $library->id,
-            'translation' => '{"data":"DB translation"}',
-        ]);
-
-        Storage::put(
-            sprintf('libraries/%s/language/%s.json', $library->getFolderName(), $translation->language_code),
-            '{"data":"File translation"}'
-        );
-
-        $file = UploadedFile::fake()->createWithContent(
-            $translation->language_code . '.json',
-            json_encode(['data' => 'Upload translation'])
-        );
-
-        $response = $this->withSession(['user' => $user])
-            ->post(
-                route('admin.library-translation', [$library, $translation->language_code]),
-                ['translationFile' => $file]
-            )
-            ->assertOk()
-            ->original;
-
-        $this->assertInstanceOf(View::class, $response);
-        $this->assertDatabaseHas('h5p_libraries_languages', [
-            'library_id' => $library->id,
-            'language_code' => $translation->language_code,
-            'translation' => '{"data":"Upload translation"}',
-        ]);
-
-        $this->assertDatabaseHas('h5p_libraries_languages', [
-            'library_id' => $library->id,
-            'language_code' => $unchangedTranslation->language_code,
-            'translation' => $unchangedTranslation->translation,
-        ]);
-
-        $data = $response->getData();
-        $this->assertTrue($data['success']);
-        $this->assertSame($library->id, $data['library']->id);
-        $this->assertSame($translation->language_code, $data['languageCode']);
-        $this->assertSame('{"data":"Upload translation"}', $data['translationDb']);
-        $this->assertSame('{"data":"File translation"}', $data['translationFile']);
+        $this->assertTrue($data['messages']->isEmpty());
     }
 
     public function test_libraryTranslationUpdate_UnkownCode(): void
@@ -478,7 +428,7 @@ class AdminH5PDetailsControllerTest extends TestCase
         $response = $this->withSession(['user' => $user])
             ->post(
                 route('admin.library-translation', [$library, 'nn']),
-                ['translation' => json_encode(['data' => 'Updated DB translation'])]
+                ['translation' => '{"data":"Updated DB translation"}']
             )
             ->assertOk()
             ->original;
@@ -490,10 +440,78 @@ class AdminH5PDetailsControllerTest extends TestCase
         ]);
 
         $data = $response->getData();
-        $this->assertFalse($data['success']);
         $this->assertSame($library->id, $data['library']->id);
         $this->assertSame('nn', $data['languageCode']);
         $this->assertNull($data['translationDb']);
         $this->assertNull($data['translationFile']);
+        $this->assertContains('No rows was updated', $data['messages']);
+    }
+
+    /**
+     * @dataProvider provider_libraryTranslationUpdate_File
+     */
+    public function test_libraryTranslationUpdate_FileError(string $fileContents, ?string $expectedMessage): void
+    {
+        Storage::fake();
+        $user = new GenericUser([
+            'roles' => ['superadmin'],
+            'name' => 'Super Tester',
+        ]);
+        $library = H5PLibrary::factory()->create();
+        $unchangedTranslation = H5PLibraryLanguage::factory()->create(['library_id' => $library->id]);
+        $translation = H5PLibraryLanguage::factory()->create([
+            'library_id' => $library->id,
+            'translation' => '{"data":"DB translation"}',
+        ]);
+
+        Storage::put(
+            sprintf('libraries/%s/language/%s.json', $library->getFolderName(), $translation->language_code),
+            '{"data":"File translation"}'
+        );
+
+        $file = UploadedFile::fake()->createWithContent(
+            $translation->language_code . '.json',
+            $fileContents
+        );
+
+        $response = $this->withSession(['user' => $user])
+            ->post(
+                route('admin.library-translation', [$library, $translation->language_code]),
+                ['translationFile' => $file]
+            )
+            ->assertOk()
+            ->original;
+
+        $storedTranslation = $expectedMessage === null ? $fileContents : $translation->translation;
+        $this->assertInstanceOf(View::class, $response);
+        $this->assertDatabaseHas('h5p_libraries_languages', [
+            'library_id' => $library->id,
+            'language_code' => $translation->language_code,
+            'translation' => $storedTranslation,
+        ]);
+
+        $this->assertDatabaseHas('h5p_libraries_languages', [
+            'library_id' => $library->id,
+            'language_code' => $unchangedTranslation->language_code,
+            'translation' => $unchangedTranslation->translation,
+        ]);
+
+        $data = $response->getData();
+        $this->assertSame($library->id, $data['library']->id);
+        $this->assertSame($translation->language_code, $data['languageCode']);
+        $this->assertSame($storedTranslation, $data['translationDb']);
+        $this->assertSame('{"data":"File translation"}', $data['translationFile']);
+        if ($expectedMessage !== null) {
+            $this->assertContains($expectedMessage, $data['messages']);
+        } else {
+            $this->assertTrue($data['messages']->isEmpty());
+        }
+    }
+
+    public function provider_libraryTranslationUpdate_File(): Generator
+    {
+        yield 'valid file' => ['{"data":"Upload translation"}', null];
+        yield 'empty file' => ['', 'Content was empty'];
+        yield 'invalid file' => ['Not JSON', 'Syntax error'];
     }
 }


### PR DESCRIPTION
Allow editing the existing translations stored in the database for H5P content types and libraries