### PR TITLE
CA Admin: Fix error on content history if content deleted from CA, incorrect error on content type semantics diff, other adjustments

### DIFF
--- a/sourcecode/apis/contentauthor/app/H5PContent.php
+++ b/sourcecode/apis/contentauthor/app/H5PContent.php
@@ -9,7 +9,6 @@ use App\Libraries\H5P\H5PLibraryAdmin;
 use App\Libraries\H5P\Packages\QuestionSet;
 use App\Libraries\Versioning\VersionableObject;
 use H5PCore;
-use H5PFrameworkInterface;
 use H5PMetadata;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -20,7 +19,6 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Iso639p3;
-
 use function route;
 
 /**
@@ -336,23 +334,7 @@ class H5PContent extends Content implements VersionableObject
             return null;
         }
 
-        $icon = null;
-
-        if ($library->has_icon) {
-            $h5pFramework = app(H5PFrameworkInterface::class);
-            $library_folder = $library->getFolderName();
-            $icon_path = $h5pFramework->getLibraryFileUrl($library_folder, 'icon.svg');
-
-            if (!empty($icon_path)) {
-                $icon = $icon_path;
-            }
-        }
-
-        if ($icon === null) {
-            $icon = url('/graphical/h5p_logo.svg');
-        }
-
-        return new ContentTypeDataObject("H5P", $contentType, $library->title, $icon);
+        return new ContentTypeDataObject("H5P", $contentType, $library->title, $library->getIconUrl());
     }
 
     public function getUrl(): string

--- a/sourcecode/apis/contentauthor/app/H5PContent.php
+++ b/sourcecode/apis/contentauthor/app/H5PContent.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Iso639p3;
+
 use function route;
 
 /**

--- a/sourcecode/apis/contentauthor/app/H5PLibrary.php
+++ b/sourcecode/apis/contentauthor/app/H5PLibrary.php
@@ -2,6 +2,7 @@
 
 namespace App;
 
+use H5PFrameworkInterface;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -349,5 +350,22 @@ class H5PLibrary extends Model
     public function includeImageWidth(): bool
     {
         return !in_array($this->name, ['H5P.ThreeImage', 'H5P.NDLAThreeImage']);
+    }
+
+    public function getIconUrl(): string
+    {
+        $icon = null;
+
+        if ($this->has_icon) {
+            $h5pFramework = app(H5PFrameworkInterface::class);
+            $library_folder = $this->getFolderName();
+            $icon_path = $h5pFramework->getLibraryFileUrl($library_folder, 'icon.svg');
+
+            if (!empty($icon_path)) {
+                $icon = $icon_path;
+            }
+        }
+
+        return $icon ?? url('/graphical/h5p_logo.svg');
     }
 }

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/AdminH5PDetailsController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/AdminH5PDetailsController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Content;
+use App\ContentLock;
 use App\H5PContent;
 use App\H5PLibrary;
 use App\H5PLibraryLanguage;
@@ -166,10 +167,10 @@ class AdminH5PDetailsController extends Controller
         $history = [];
 
         try {
-            $foliumId = $resourceService->getResourceFromExternalReference('contentauthor', $content->id)->id;
+            $resource = $resourceService->getResourceFromExternalReference('contentauthor', $content->id);
         } catch (Exception $e) {
             Log::warning($e);
-            $foliumId = '';
+            $resource = null;
         }
 
         if ($content->version_id) {
@@ -183,8 +184,9 @@ class AdminH5PDetailsController extends Controller
         return view('admin.library-upgrade.content-details', [
             'content' => $content,
             'latestVersion' => !isset($history[$content->id]['children']),
-            'foliumId' => $foliumId,
+            'resource' => $resource,
             'history' => $history,
+            'hasLock' => ContentLock::notExpiredById($content->id)?->updated_at,
         ]);
     }
 

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/LibraryUpgradeController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/LibraryUpgradeController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Exceptions\InvalidH5pPackageException;
 use App\H5PLibrariesHubCache;
 use App\H5PLibrary;
+use App\H5POption;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\H5pUpgradeRequest;
 use App\Libraries\H5P\AdminConfig;
@@ -41,7 +42,6 @@ class LibraryUpgradeController extends Controller
         $hubCacheLibraries = H5PLibrariesHubCache::all();
 
         $isPatchUpdate = function ($library) {
-            /** @noinspection PhpParamsInspection */
             if ($this->h5pFramework->isPatchedLibrary([
                 'machineName' => $library->name,
                 'majorVersion' => $library->major_version,
@@ -108,7 +108,7 @@ class LibraryUpgradeController extends Controller
                         'machineName' => $hubCache->name,
                         'majorVersion' => $hubCache->major_version,
                         'minorVersion' => $hubCache->minor_version,
-                        'title' => $hubCache->title,
+                        'title' => sprintf('%s (%d.%d.%d)', $hubCache->title, $hubCache->major_version, $hubCache->minor_version, $hubCache->patch_version),
                         'summary' => $hubCache->summary,
                         'external_link' => $hubCache->example,
                         'numContent' => 0,
@@ -123,6 +123,7 @@ class LibraryUpgradeController extends Controller
             'installedLibraries' => $libraries->sortBy('machineName', SORT_STRING | SORT_FLAG_CASE)->toArray(),
             'installedContentTypes' => $contentTypes->sortBy('machineName', SORT_STRING | SORT_FLAG_CASE)->toArray(),
             'available' => $available->sortBy('machineName', SORT_STRING | SORT_FLAG_CASE)->toArray(),
+            'contentTypeCacheUpdateAt' => H5POption::select('option_value')->where('option_name', 'content_type_cache_updated_at')->first(),
         ]);
     }
 

--- a/sourcecode/apis/contentauthor/resources/views/admin/fragments/dependency-table.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/fragments/dependency-table.blade.php
@@ -5,7 +5,7 @@
             <th>Machine name</th>
             <th>Type</th>
             <th>Required version</th>
-            <th>DB version</th>
+            <th>Installed version</th>
             <th>Set in DB</th>
         </tr>
         @foreach($dependencies as $dep)

--- a/sourcecode/apis/contentauthor/resources/views/admin/fragments/library-table.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/fragments/library-table.blade.php
@@ -83,6 +83,8 @@
                     >
                         <span class="fa fa-trash"></span>
                     </button>
+                @elseif(isset($showCount))
+                    <div class="h5p-action-button"></div>
                 @endif
                 @if(!empty($library['external_link']))
                     <a

--- a/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/index.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/index.blade.php
@@ -32,6 +32,11 @@
                         <form action="{{ route('admin.check-for-updates') }}" method="post">
                             @csrf
                             <h4>Content types from h5p.org</h4>
+                            <div style="margin: 1em 0;">Last updated:
+                                @isset($contentTypeCacheUpdateAt)
+                                    {{ \Carbon\Carbon::createFromTimestamp($contentTypeCacheUpdateAt)->format('Y-m-d H:i:s e') }}
+                                @endempty
+                            </div>
                             <button type="submit" class="btn btn-success">Check for updates</button>
                         </form>
                     </div>

--- a/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/library-check.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/library-check.blade.php
@@ -1,12 +1,15 @@
 @extends ('layouts.admin')
 @section ('content')
     <div class="container">
-        <a href="{{ route('admin.update-libraries') }}">Back to library list</a>
+        <a href="{{ route('admin.update-libraries') }}">Library list</a>
         <div class="row">
             <div class="col-md-12">
                 <div class="panel panel-default">
                     <div class="panel-heading">
-                        <h3>Details for {{ $library->runnable ? 'content type' : 'library' }} "<strong>{{ $library->name }}</strong>"</h3>
+                        <h3>
+                            <img style="height:3em;" src="{{ $library->getIconUrl() }}" alt="Content type icon">
+                            Details for {{ $library->runnable ? 'content type' : 'library' }} <strong>{{ $library->getLibraryString(true) }}</strong>
+                        </h3>
                     </div>
 
                     <div class="panel-body row">
@@ -28,20 +31,10 @@
                                 library failed validation
                             </div>
                         @else
-                            @if (array_key_exists('semantics', $libData) && $libData['semantics'] !== $library->semantics)
+                            @if (array_key_exists('semantics', $libData) && trim($libData['semantics']) !== trim($library->semantics))
                                 <div class="alert alert-danger">
                                     Semantics data in database does not match the 'semantics.json' file.
                                     Rebuild the library to update the database
-                                </div>
-                            @endif
-                            @if ($library && $libData && (
-                                    $library->major_version !== $libData['majorVersion'] ||
-                                    $library->minor_version !== $libData['minorVersion'] ||
-                                    $library->patch_version !== $libData['patchVersion']
-                                )
-                            )
-                                <div class="alert alert-danger">
-                                    Library version in database does not match version in 'library.json'
                                 </div>
                             @endif
                         @endif
@@ -81,7 +74,7 @@
                                 <td>{{ $library->minor_version }}</td>
                                 <td>{{ $libData['minorVersion'] ?? '' }}</td>
                             </tr>
-                            <tr>
+                            <tr @if(isset($libData['patchVersion']) && $library->patch_version !== $libData['patchVersion']) class="alert-danger"@endif>
                                 <th>Patch version</th>
                                 <td>{{ $library->patch_version }}</td>
                                 <td>{{ $libData['patchVersion'] ?? '' }}</td>
@@ -156,18 +149,27 @@
                                 </td>
                             </tr>
                             <tr>
-                                <th>Translations</th>
+                                <th>Translations in database ({{$languages->count()}})</th>
                                 <td colspan="2">
                                     @foreach($languages as $lang)
                                         <a
                                             href="{{ route('admin.library-translation', [$library->id, $lang]) }}"
                                             class="btn btn-default"
+                                            title="{{Iso639p3::englishName($lang)}}"
                                         >
                                             {{ $lang }}
                                         </a>
                                     @endforeach
                                 </td>
                                 <td></td>
+                            </tr>
+                            <tr>
+                                <th>Number of contents</th>
+                                <td colspan="2">
+                                    <a href="{{ route('admin.content-library', [$library->id]) }}">
+                                        {{ $library->contents()->count() }}
+                                    </a>
+                                </td>
                             </tr>
                         </table>
                     </div>

--- a/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/library-content.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/library-content.blade.php
@@ -1,7 +1,9 @@
 @extends ('layouts.admin')
 @section ('content')
     <div class="container">
-        <a href="{{ route('admin.update-libraries') }}">Back to library list</a>
+        <a href="{{ route('admin.update-libraries') }}">Library list</a>
+        <br>
+        <a href="{{ route('admin.check-library', [$library->id]) }}">Library details</a>
         <div class="row">
             <div class="col-md-12">
                 <div class="panel panel-default">

--- a/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/translation.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/translation.blade.php
@@ -1,13 +1,16 @@
 @extends ('layouts.admin')
 @section ('content')
     <div class="container" style="width:80vw">
-        <a href="{{ route('admin.check-library', [$library->id]) }}">Back to library</a>
+        <a href="{{ route('admin.update-libraries') }}">Library list</a>
+        <br>
+        <a href="{{ route('admin.check-library', [$library->id]) }}">Library details</a>
         <div class="row">
             <div class="col-md-12">
                 <div class="panel panel-default">
                     <div class="panel-heading">
                         <h3>
-                            "<b>{{ $languageCode }}</b>"
+                            {{Iso639p3::englishName($languageCode)}}
+                            <abbr>(<b>{{ $languageCode }}</b>)</abbr>
                             translation for {{ $library->getLibraryString(true) }}
                         </h3>
                     </div>

--- a/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/Admin/AdminH5PDetailsControllerTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/Admin/AdminH5PDetailsControllerTest.php
@@ -239,6 +239,10 @@ class AdminH5PDetailsControllerTest extends TestCase
 
     public function test_contentHistory(): void
     {
+        $user = new GenericUser([
+            'roles' => ['superadmin'],
+            'name' => 'Super Tester',
+        ]);
         $f4mId = $this->faker->uuid;
         $library = H5PLibrary::factory()->create();
         $content = H5PContent::factory()->create([
@@ -270,17 +274,19 @@ class AdminH5PDetailsControllerTest extends TestCase
             ->with($versionId)
             ->willReturn($version);
 
-        $controller = app(AdminH5PDetailsController::class);
-        $res = $controller->contentHistory($content);
+        $response = $this->withSession(['user' => $user])
+            ->get(route('admin.content-details', $content))
+            ->assertOk()
+            ->original;
 
-        $data = $res->getData();
+        $data = $response->getData();
         $this->assertArrayHasKey('content', $data);
         $this->assertArrayHasKey('latestVersion', $data);
-        $this->assertArrayHasKey('foliumId', $data);
+        $this->assertArrayHasKey('resource', $data);
         $this->assertArrayHasKey('history', $data);
 
-        $this->assertEquals(true, $data['latestVersion']);
-        $this->assertEquals($f4mId, $data['foliumId']);
+        $this->assertTrue($data['latestVersion']);
+        $this->assertEquals($f4mId, $data['resource']->id);
         $this->assertInstanceOf(Collection::class, $data['history']);
         $this->assertNotNull($data['history']->get($content->id));
 


### PR DESCRIPTION
- Fix error on content history if item in history was deleted from CA database
- Fix incorrect warning about semantics difference on content type check
- Show last updated for H5P Hub cache
- Show content type icon on content type details page
- Show content count on content type details page
- Highlight different patch-version in list instead of with error text on content type details page
- Show name of language on hover in content details page
- Show name of language on translation edit page
- Show version for libraries that can be installed from H5P.org hub
- Add link to content type from content details
- If resource is deleted display time of deletion
- Display status of content lock