### PR TITLE
use less non-standard laravel config

### DIFF
--- a/sourcecode/apis/contentauthor/.env.example
+++ b/sourcecode/apis/contentauthor/.env.example
@@ -1,6 +1,19 @@
+APP_NAME="Content Author"
 APP_ENV=local
 APP_DEBUG=true
-APP_KEY=SomeRandomString
+APP_KEY=
+APP_URL=https://ca.edlib.test
+
+DB_CONNECTION=mysql
+DB_HOST=mysql
+DB_PORT=3306
+DB_DATABASE=edlibcontentauthor
+DB_USERNAME=root
+DB_PASSWORD=mysqlpassword
+
+REDIS_HOST=redis
+REDIS_PASSWORD=null
+REDIS_PORT=6379
 
 FILESYSTEM_DRIVER=local
 

--- a/sourcecode/apis/contentauthor/config/app.php
+++ b/sourcecode/apis/contentauthor/config/app.php
@@ -1,6 +1,9 @@
 <?php
 
 return [
+
+    'name' => env('APP_NAME', 'Content Author'),
+
     'env' => env('APP_ENV', 'production'),
     'enable_licensing' => env('ENABLE_LICENSING', false),
 
@@ -30,6 +33,8 @@ return [
     */
 
     'url' => env('APP_URL', 'http://localhost'),
+
+    'asset_url' => env('ASSET_URL'),
 
     /*
     |--------------------------------------------------------------------------

--- a/sourcecode/apis/contentauthor/config/cache.php
+++ b/sourcecode/apis/contentauthor/config/cache.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Str;
+
 return [
 
     /*
@@ -37,10 +39,12 @@ return [
             'driver' => 'database',
             'table'  => 'cache',
             'connection' => null,
+            'lock_connection' => null,
         ],
         'file' => [
             'driver' => 'file',
-            'path'   => storage_path('framework/cache'),
+            'path'   => storage_path('framework/cache/data'),
+            'lock_path' => storage_path('framework/cache/data'),
         ],
         'memcached' => [
             'driver'  => 'memcached',
@@ -52,7 +56,8 @@ return [
         ],
         'redis' => [
             'driver' => 'redis',
-            'connection' => 'default',
+            'connection' => 'cache',
+            'lock_connection' => 'default',
         ],
     ],
 
@@ -66,8 +71,6 @@ return [
     | value to get prefixed to all our keys so we can avoid collisions.
     |
     */
-    'prefix' => env(
-        'CACHE_PREFIX',
-        'api-contentauthor'
-    )
+    'prefix' => env('CACHE_PREFIX', Str::slug(env('APP_NAME', 'Content Author'), '_') . '_cache_'),
+
 ];

--- a/sourcecode/apis/contentauthor/config/database.php
+++ b/sourcecode/apis/contentauthor/config/database.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Str;
+
 return [
 
     /*
@@ -42,39 +44,43 @@ return [
     |
     */
     'connections' => [
-        'sqlite-test' => [
-            'driver'   => 'sqlite',
-            'database' => ':memory:',
-            'prefix'   => '',
-        ],
-        'mysql-test' => [
-            'driver'    => 'mysql',
-            'host'      => 'localhost',
-            'database'  => env('DB_DATABASE', 'forge').'-test',
-            'username'  => env('DB_USERNAME', 'forge'),
-            'password'  => env('DB_PASSWORD', ''),
-            'charset'   => 'utf8mb4',
-            'collation' => 'utf8mb4_unicode_ci',
-            'prefix'    => '',
-            'strict'    => false,
-        ],
+
         'sqlite' => [
-            'driver'   => 'sqlite',
-            'database' => storage_path('database.sqlite'),
-            'prefix'   => '',
+            'driver' => 'sqlite',
+            'url' => env('DATABASE_URL'),
+            'database' => env('DB_DATABASE', storage_path('database.sqlite')),
+            'prefix' => '',
+            'foreign_key_constraints' => true,
         ],
+
         'mysql' => [
-            'driver'    => 'mysql',
-            'host'      => env('EDLIBCOMMON_DB_HOST', 'localhost'),
-            'database'  => env('DB_DATABASE', env('EDLIBCOMMON_DB_PREFIX', '') . 'contentauthor'),
-            'username'  => env('EDLIBCOMMON_DB_USER', 'forge'),
-            'password'  => env('EDLIBCOMMON_DB_PASSWORD', ''),
-            'port'      => env('EDLIBCOMMON_DB_PORT', '3306'),
-            'charset'   => 'utf8mb4',
+            'driver' => 'mysql',
+            'host' => env('DB_HOST', env('EDLIBCOMMON_DB_HOST', '127.0.0.1')),
+            'database' => env('DB_DATABASE', env('EDLIBCOMMON_DB_PREFIX', '') . 'contentauthor'),
+            'username' => env('DB_USER', env('EDLIBCOMMON_DB_USER', 'forge')),
+            'password' => env('DB_PASSWORD', env('EDLIBCOMMON_DB_PASSWORD', '')),
+            'port' => env('DB_PORT', env('EDLIBCOMMON_DB_PORT', '3306')),
+            'charset' => 'utf8mb4',
             'collation' => 'utf8mb4_unicode_ci',
-            'prefix'    => '',
-            'strict'    => false,
+            'prefix' => '',
+            'strict' => false,
         ],
+
+        'pgsql' => [
+            'driver' => 'pgsql',
+            'url' => env('DATABASE_URL'),
+            'host' => env('DB_HOST', '127.0.0.1'),
+            'port' => env('DB_PORT', '5432'),
+            'database' => env('DB_DATABASE', 'forge'),
+            'username' => env('DB_USERNAME', 'forge'),
+            'password' => env('DB_PASSWORD', ''),
+            'charset' => 'utf8',
+            'prefix' => '',
+            'prefix_indexes' => true,
+            'search_path' => 'public',
+            'sslmode' => 'prefer',
+        ],
+
     ],
 
     /*
@@ -100,14 +106,28 @@ return [
     |
     */
     'redis' => [
-        'cluster' => false,
+
         'client' => env('REDIS_CLIENT', 'predis'),
+
+        'options' => [
+            'cluster' => env('REDIS_CLUSTER', 'redis'),
+            'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'Content Author'), '_') . '_database_'),
+        ],
+
         'default' => [
-            'host'     => env('EDLIBCOMMON_REDIS_HOST', 'redis'),
-            'port'     => env('EDLIBCOMMON_REDIS_PORT', 6379),
-            'password' => env('REDIS_PASSWORD', null),
-            'database' => env('REDIS_DATABASE', 0),
+            'host' => env('REDIS_HOST', env('EDLIBCOMMON_REDIS_HOST', 'redis')),
+            'port' => env('REDIS_PORT', env('EDLIBCOMMON_REDIS_PORT', '6379')),
+            'password' => env('REDIS_PASSWORD'),
+            'database' => env('REDIS_DB', '0'),
             'read_write_timeout' => 0
         ],
+
+        'cache' => [
+            'host' => env('REDIS_HOST', env('EDLIBCOMMON_REDIS_HOST', 'redis')),
+            'port' => env('REDIS_PORT', env('EDLIBCOMMON_REDIS_PORT', '6379')),
+            'password' => env('REDIS_PASSWORD'),
+            'database' => env('REDIS_CACHE_DB', '1'),
+        ],
+
     ],
 ];

--- a/sourcecode/apis/contentauthor/config/session.php
+++ b/sourcecode/apis/contentauthor/config/session.php
@@ -108,10 +108,7 @@ return [
     |
     */
 
-    'cookie' => env(
-        'SESSION_COOKIE',
-        Str::slug(env('APP_NAME', 'laravel'), '_').'_session'
-    ),
+    'cookie' => env('SESSION_COOKIE', Str::slug(env('APP_NAME', 'Content Author'), '_') . '_session'),
 
     /*
     |--------------------------------------------------------------------------

--- a/sourcecode/apis/contentauthor/database/factories/GameFactory.php
+++ b/sourcecode/apis/contentauthor/database/factories/GameFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Game;
+use App\Gametype;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -14,7 +15,7 @@ class GameFactory extends Factory
     {
         return [
             'id' => $this->faker->uuid,
-            'gametype' => $this->faker->uuid,
+            'gametype' => Gametype::factory(),
             'title' => $this->faker->sentence,
             'language_code' => $this->faker->languageCode,
             'owner' => $this->faker->uuid,

--- a/sourcecode/apis/contentauthor/phpunit.xml
+++ b/sourcecode/apis/contentauthor/phpunit.xml
@@ -38,7 +38,8 @@
         <server name="CACHE_DRIVER" value="array"/>
         <server name="SESSION_DRIVER" value="array"/>
         <server name="QUEUE_DRIVER" value="sync"/>
-        <server name="DB_CONNECTION" value="sqlite-test"/>
+        <server name="DB_CONNECTION" value="sqlite"/>
+        <server name="DB_DATABASE" value=":memory:"/>
         <server name="ENABLE_LICENSING" value="true"/>
         <server name="FEATURE_CONTENT_LOCKING" value="true"/>
         <server name="FEATURE_CONTEXT_COLLABORATION" value="true"/>


### PR DESCRIPTION
Vapor uses Laravel's naming convention for database variables, e.g. `DB_HOST`, so CA needs to recognise these. The `EDLIBCOMMON_` stuff was misguided and should be removed after we shut down k8s, but CA will keep supporting them for now.

While we're at it, we do some minor cleanup to bring the configuration closer to the Laravel skeleton application's defaults.