### PR TITLE
make logging better suited for vapor

### DIFF
--- a/sourcecode/apis/contentauthor/.env.example
+++ b/sourcecode/apis/contentauthor/.env.example
@@ -4,6 +4,10 @@ APP_DEBUG=true
 APP_KEY=
 APP_URL=https://ca.edlib.test
 
+LOG_CHANNEL=stderr
+LOG_STDERR_FORMATTER=null
+LOG_LEVEL=debug
+
 DB_CONNECTION=mysql
 DB_HOST=mysql
 DB_PORT=3306

--- a/sourcecode/apis/contentauthor/config/logging.php
+++ b/sourcecode/apis/contentauthor/config/logging.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Logging\JsonFormatter;
 use Monolog\Handler\StreamHandler;
 
 return [
@@ -40,13 +41,15 @@ return [
         'single' => [
             'driver' => 'single',
             'path' => storage_path('logs/laravel.log'),
-            'level' => 'debug',
+            'level' => env('LOG_LEVEL', 'info'),
+            'replace_placeholders' => true,
         ],
         'daily' => [
             'driver' => 'daily',
             'path' => storage_path('logs/laravel.log'),
-            'level' => 'debug',
+            'level' => env('LOG_LEVEL', 'info'),
             'days' => 7,
+            'replace_placeholders' => true,
         ],
         'slack' => [
             'driver' => 'slack',
@@ -54,24 +57,27 @@ return [
             'username' => 'Laravel Log',
             'emoji' => ':boom:',
             'level' => 'critical',
+            'replace_placeholders' => true,
         ],
         'stderr' => [
             'driver' => 'monolog',
             'handler' => StreamHandler::class,
-            'formatter' => App\Logging\JsonFormatter::class,
+            'formatter' => env('LOG_STDERR_FORMATTER', JsonFormatter::class),
             'with' => [
                 'stream' => 'php://stderr',
             ],
-            'level' => 'info',
+            'level' => env('LOG_LEVEL', 'info'),
         ],
         'syslog' => [
             'driver' => 'syslog',
-            'level' => 'debug',
+            'level' => env('LOG_LEVEL', 'info'),
+            'replace_placeholders' => true,
         ],
         'errorlog' => [
             'driver' => 'errorlog',
-            'level' => 'debug',
-        ]
+            'level' => env('LOG_LEVEL', 'info'),
+            'replace_placeholders' => true,
+        ],
     ],
 
 ];


### PR DESCRIPTION
* Allow JSON formatter to be disabled by setting `LOG_STDERR_FORMATTER=null`
* Make log channels use `LOG_LEVEL=info` by default
* Use `LOG_LEVEL=debug` for development