### PR TITLE
Upgrade Postgres from 11 -> 16 in dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ volumes:
   mysql:
   npm_cache:
   npm-components-storybook_nodemodules:
+  postgres_data:
   proxy-admin_nodemodules:
   proxy-auth_nodemodules:
   proxy-lti_nodemodules:
@@ -31,22 +32,15 @@ services:
       - "6379:6379"
 
   postgres:
-    image: postgres:11-alpine
+    image: postgres:16-alpine
     healthcheck:
-      test:
-        [
-          CMD,
-          psql,
-          -d,
-          "postgres://postgres:thepgpassword@localhost:5432",
-          -c,
-          "select 1",
-        ]
+      test: [CMD, pg_isready]
     volumes:
-      - ./data/postgresql:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql/data
       - ./localSetup/projects/postgres/postgresinit.d:/docker-entrypoint-initdb.d
     environment:
       POSTGRES_PASSWORD: thepgpassword
+      PGUSER: postgres
     ports:
       - 5432:5432
 


### PR DESCRIPTION
Since the upgrade requires a clean data directory anyway, the bind mount is changed to be a volume, which performs better on Windows/macOS due to not requiring file sharing.