### PR TITLE
H5P addons fails to load if having patch version in folder name

### DIFF
--- a/sourcecode/apis/contentauthor/app/H5PLibrary.php
+++ b/sourcecode/apis/contentauthor/app/H5PLibrary.php
@@ -328,6 +328,7 @@ class H5PLibrary extends Model
                 'l1.patch_version as patchVersion',
                 'l1.preloaded_js as preloadedJs',
                 'l1.preloaded_css as preloadedCss',
+                'l1.patch_version_in_folder_name as patchVersionInFolderName',
             ])
             ->whereNull('l2.name')
             ->whereNotNull('l1.add_to')


### PR DESCRIPTION
The addons are loaded in the H5P Editor for content types that are hardcoded in H5P Editor,`h5peditor.class.php`, as having WYSIWYG editor, currently these are 'H5P.CoursePresentation', 'H5P.InteractiveVideo' and 'H5P.DragQuestion'. They are loaded for all libraries when viewing H5P.
Addons can be identified by checking if there is a `addTo` property in the H5P librarys `library.json` file. In the database this value is stored in the column `h5p_libraries.add_to`.
An example of an addon is the 'H5P.MathDisplay' library.
No documentation was found on the H5P.org site