### PR TITLE
Fix some migrations

### DIFF
--- a/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/AdminUserController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/AdminUserController.php
@@ -18,7 +18,7 @@ class AdminUserController extends Controller
      */
     public function index()
     {
-        $adminUsers = Administrator::select('id', 'username', 'name')->where('id', '<>', 1)->get();
+        $adminUsers = Administrator::select('id', 'username', 'name')->get();
 
         return view('admin.admin-users.index')->with(compact('adminUsers'));
     }

--- a/sourcecode/apis/contentauthor/database/migrations/2014_10_12_104748_create_administrators_table.php
+++ b/sourcecode/apis/contentauthor/database/migrations/2014_10_12_104748_create_administrators_table.php
@@ -20,14 +20,6 @@ class CreateAdministratorsTable extends Migration
             $table->string('remember_token', 100)->nullable();
             $table->timestamps();
         });
-
-        Schema::table('administrators', function (Blueprint $table) {
-            $admin = new \App\Administrator();
-            $admin->username = 'admin';
-            $admin->password = md5(time());
-            $admin->name = 'SleepingOwl Administrator';
-            $admin->save();
-        });
     }
 
 

--- a/sourcecode/apis/contentauthor/database/migrations/2019_11_05_112216_add_ndla_css_timestamp.php
+++ b/sourcecode/apis/contentauthor/database/migrations/2019_11_05_112216_add_ndla_css_timestamp.php
@@ -9,13 +9,13 @@ use Illuminate\Support\Facades\DB;
 return new class () extends Migration {
     public function up(): void
     {
-        DB::table('h5p_options')->upsert([
+        DB::table('h5p_options')->insert([
             [
                 'option_name' => 'NDLA_CUSTOM_CSS_TIMESTAMP',
                 'option_value' => Carbon::now()->toAtomString(),
                 'autoload' => 0,
             ],
-        ], uniqueBy: ['option_name']);
+        ]);
     }
 
     public function down(): void

--- a/sourcecode/apis/contentauthor/database/migrations/2019_11_05_112216_add_ndla_css_timestamp.php
+++ b/sourcecode/apis/contentauthor/database/migrations/2019_11_05_112216_add_ndla_css_timestamp.php
@@ -1,35 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
+use Carbon\Carbon;
 use Illuminate\Database\Migrations\Migration;
-use App\H5POption;
+use Illuminate\Support\Facades\DB;
 
-class AddNdlaCssTimestamp extends Migration
-{
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
-    public function up()
+return new class () extends Migration {
+    public function up(): void
     {
-        H5POption::updateOrCreate([
-            'option_name' => H5POption::NDLA_CUSTOM_CSS_TIMESTAMP
-        ], [
-            'option_value' => \Carbon\Carbon::now()->toAtomString(),
-            'autoload' => 0,
-        ]);
+        DB::table('h5p_options')->upsert([
+            [
+                'option_name' => 'NDLA_CUSTOM_CSS_TIMESTAMP',
+                'option_value' => Carbon::now()->toAtomString(),
+                'autoload' => 0,
+            ],
+        ], uniqueBy: ['option_name']);
     }
 
-    /**
-     * Reverse the migrations.
-     *
-     * @return void
-     */
-    public function down()
+    public function down(): void
     {
-        $ndlaCustomCssTimestamp = H5POption::where('option_name', H5POption::NDLA_CUSTOM_CSS_TIMESTAMP)->first();
-        if ($ndlaCustomCssTimestamp) {
-            $ndlaCustomCssTimestamp->delete();
-        }
+        DB::table('h5p_options')
+            ->where('option_name', 'NDLA_CUSTOM_CSS_TIMESTAMP')
+            ->delete();
     }
-}
+};

--- a/sourcecode/apis/contentauthor/phpstan-baseline.neon
+++ b/sourcecode/apis/contentauthor/phpstan-baseline.neon
@@ -922,11 +922,6 @@ parameters:
 			path: app/User.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function md5 expects string, int\\<1, max\\> given\\.$#"
-			count: 1
-			path: database/migrations/2014_10_12_104748_create_administrators_table.php
-
-		-
 			message: "#^Method Illuminate\\\\Database\\\\Schema\\\\Blueprint\\:\\:text\\(\\) invoked with 2 parameters, 1 required\\.$#"
 			count: 2
 			path: database/migrations/2015_09_25_092958_create_h5p_contents_table.php


### PR DESCRIPTION
1. Remove creation of useless default user

   This creates a predictable password which would essentially function like a backdoor, except CA does not match passwords stored as MD5 hashes. Since the hash is not usable, creating this account has no purpose anyway.

2. Don't invoke application code when inserting H5P option

   This invokes `H5POptionObserver` which then tries interacting with the cache, which might not be available at the time of running migrations. Additionally, migrations have to take the DB state up until the point it's ran into consideration, therefore it should not rely on application code which could change at any point.