### PR TITLE
CA Admin: New find content page, minor improvements and fixes

### DIFF
--- a/sourcecode/apis/contentauthor/app/Apis/LtiApiService.php
+++ b/sourcecode/apis/contentauthor/app/Apis/LtiApiService.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Apis;
+
+use App\Util;
+use GuzzleHttp\Client;
+
+class LtiApiService
+{
+    private Client $client;
+
+    public function __construct()
+    {
+        $this->client = new Client([
+            'base_uri' => 'http://ltiapi',
+        ]);
+    }
+
+    public function getResourceFromUsageId(string $usageId): array
+    {
+        return Util::handleEdlibNodeApiRequest(
+            function () use ($usageId) {
+                return $this->client
+                    ->getAsync("/v1/usages/" . $usageId)
+                    ->wait();
+            }
+        );
+    }
+}

--- a/sourcecode/apis/contentauthor/app/Apis/ResourceApiService.php
+++ b/sourcecode/apis/contentauthor/app/Apis/ResourceApiService.php
@@ -7,6 +7,7 @@ use App\ApiModels\ResourceCollaborator;
 use App\Exceptions\NotFoundException;
 use App\Util;
 use GuzzleHttp\Client;
+use JsonException;
 
 class ResourceApiService
 {
@@ -22,7 +23,7 @@ class ResourceApiService
     /**
      * @return ResourceCollaborator[]
      * @throws NotFoundException
-     * @throws \JsonException
+     * @throws JsonException
      */
     public function getCollaborators(string $externalSystemName, string $externalSystemId): array
     {
@@ -41,7 +42,7 @@ class ResourceApiService
 
     /**
      * @throws NotFoundException
-     * @throws \JsonException
+     * @throws JsonException
      */
     public function getResourceFromExternalReference(string $externalSystemName, string $externalSystemId): Resource
     {
@@ -60,5 +61,43 @@ class ResourceApiService
             $data['createdAt'],
             $data['version']['title']
         );
+    }
+
+    /**
+     * @throws NotFoundException
+     * @throws JsonException
+     */
+    public function getResourceById(string $resourceId): array
+    {
+        $data = Util::handleEdlibNodeApiRequest(function () use ($resourceId) {
+            return $this->client
+                ->getAsync("/v1/resources/$resourceId/version")
+                ->wait();
+        });
+
+        if ($data['externalSystemName'] === 'contentauthor') {
+            return $data;
+        }
+
+        throw new NotFoundException('Resource');
+    }
+
+    /**
+     * @throws NotFoundException
+     * @throws JsonException
+     */
+    public function getResourceByIdAndVersion(string $resourceId, string $versionId): array
+    {
+        $data = Util::handleEdlibNodeApiRequest(function () use ($resourceId, $versionId) {
+            return $this->client
+                ->getAsync("/v1/resources/$resourceId/versions/$versionId")
+                ->wait();
+        });
+
+        if ($data['externalSystemName'] === 'contentauthor') {
+            return $data;
+        }
+
+        throw new NotFoundException('Resource');
     }
 }

--- a/sourcecode/apis/contentauthor/app/H5PContentLibrary.php
+++ b/sourcecode/apis/contentauthor/app/H5PContentLibrary.php
@@ -4,6 +4,7 @@ namespace App;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class H5PContentLibrary extends Model
 {
@@ -14,4 +15,12 @@ class H5PContentLibrary extends Model
     protected $guarded = [];
 
     public $timestamps = false;
+
+    /**
+     * @return BelongsTo<H5PLibrary, self>
+     */
+    public function library(): BelongsTo
+    {
+        return $this->belongsTo(H5PLibrary::class, 'library_id');
+    }
 }

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/LibraryUpgradeController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/LibraryUpgradeController.php
@@ -169,7 +169,7 @@ class LibraryUpgradeController extends Controller
         $usage = $this->h5pFramework->getLibraryUsage($library->id);
         $hasContentUsage = H5PContentLibrary::where('library_id', $library->id)->exists();
 
-        if ($usage['libraries'] > 0 || $usage['content'] > 0 || $hasContentUsage === true ) {
+        if ($usage['libraries'] > 0 || $usage['content'] > 0 || $hasContentUsage === true) {
             throw new BadRequestHttpException(
                 'Cannot delete libraries used by content or other libraries'
             );

--- a/sourcecode/apis/contentauthor/app/Libraries/DataObjects/ResourceUserDataObject.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/DataObjects/ResourceUserDataObject.php
@@ -12,7 +12,7 @@ class ResourceUserDataObject
     use CreateTrait;
 
     public const NAME_FORMAT = '%s %s';
-    public const NAME_AND_EMAIL_FORMAT = self::NAME_FORMAT . '(%s)';
+    public const NAME_AND_EMAIL_FORMAT = self::NAME_FORMAT . ' (%s)';
 
     public $firstname;
     public $lastname;

--- a/sourcecode/apis/contentauthor/resources/assets/entrypoints/admin-preview.scss
+++ b/sourcecode/apis/contentauthor/resources/assets/entrypoints/admin-preview.scss
@@ -1,0 +1,6 @@
+.h5p-admin-preview {
+    width: 50vw;
+    max-height: 70vh;
+    margin-left: auto;
+    margin-right: auto;
+}

--- a/sourcecode/apis/contentauthor/resources/views/admin/content-details.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/content-details.blade.php
@@ -1,0 +1,54 @@
+@extends('layouts.admin')
+
+@section('content')
+    <div class="container">
+        <div class="row">
+            <div class="col-md-10 col-md-offset-1">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h3>H5P content info</h3>
+                    </div>
+                    <div class="panel-body">
+                        <div>
+                            <h4>Value types</h4>
+                            <ul>
+                                <li><b>Content</b> - When editing this is displayed under Properties</li>
+                                <li><b>Resource/Folium</b> - Displayed in the preview popup and in embed links, gets the latest <i>published</i> version</li>
+                                <li><b>Usage</b> - The id in the LTI launch link</li>
+                                <li><b>Version</b> - Internal version id</li>
+                            </ul>
+                        </div>
+                        <form>
+                            <div class="form-group">
+                                <label for="value_type">Value type</label>
+                                <br>
+                                <select name="valueType" id="value_type">
+                                    <option value="content" {{$valueType === 'content' ? 'selected' : '' }}>Content Id (integer)</option>
+                                    <option value="resource" {{$valueType === 'resource' ? 'selected' : '' }}>Resource/Folium Id (uuid)</option>
+                                    <option value="usage" {{$valueType === 'usage' ? 'selected' : '' }}>Usage Id (uuid)</option>
+                                    <option value="version" {{$valueType === 'version' ? 'selected' : '' }}>Version Id (uuid)</option>
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label for="value">Value</label>
+                                <input
+                                    class="form-control"
+                                    type="text"
+                                    name="value"
+                                    id="value"
+                                    value="{{$value ?? ""}}"
+                                >
+                            </div>
+                            <button type="submit" class="btn btn-primary">Submit</button>
+                        </form>
+                        @isset($error)
+                            <div style="margin-top:2em;">
+                                {{ $error }}
+                            </div>
+                        @endisset
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/sourcecode/apis/contentauthor/resources/views/admin/fragments/library-table.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/fragments/library-table.blade.php
@@ -74,7 +74,7 @@
                         <span class="fa fa-history"></span>
                     </button>
                 @endif
-                @if(empty($library['numLibraryDependencies']) && !empty($library['libraryId']))
+                @if(array_key_exists('canDelete', $library) && $library['canDelete'] === true)
                     <button
                             type="button"
                             class="btn btn-danger btn-xs h5p-action-button delete-btn"

--- a/sourcecode/apis/contentauthor/resources/views/admin/games/index.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/games/index.blade.php
@@ -68,8 +68,8 @@
                                         <td>{{ $gameType->title }}</td>
                                         <td>{{ $gameType->getVersion() }}</td>
                                         <td>{{ $gameType->games()->count() }}</td>
-                                        <td>{{ $gameType->created_at->format('d.m.y H:i:s') }}</td>
-                                        <td>{{ $gameType->updated_at->format('d.m.y H:i:s') }}</td>
+                                        <td>{{ $gameType->created_at->format('Y-m-d H:i:s e') }}</td>
+                                        <td>{{ $gameType->updated_at->format('Y-m-d H:i:s e') }}</td>
 
                                     </tr>
                                 @empty

--- a/sourcecode/apis/contentauthor/resources/views/admin/h5p-preview.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/h5p-preview.blade.php
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="{{$language}}" class="h5p-admin-preview">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <title>{{ $title }}</title>
+    <link media="all" type="text/css" rel="stylesheet" href="{{ mix('css/h5p-core.css') }}">
+    <link media="all" type="text/css" rel="stylesheet" href="{{ mix('css/h5pcss.css') }}">
+    @if($inlineStyle)
+        <style>{!! $inlineStyle !!}</style>
+    @endif
+    @foreach( $styles as $css)
+        {!! HTML::style($css) !!}
+    @endforeach
+    {!! HTML::script('https://code.jquery.com/jquery-1.12.4.min.js') !!}
+    <script type="text/x-mathjax-config">
+        // When MathJax is done, check if a resize of the container is required
+        MathJax.Hub.Register.StartupHook("End", function () {
+            if (window.parent && document.documentElement.scrollHeight > document.documentElement.clientHeight) {
+                window.parent.postMessage({
+                  context: 'h5p',
+                  action: 'hello'
+                }, '*');
+            }
+        });
+    </script>
+</head>
+<body>
+    <div class="h5p-preview">
+        {!! $embed !!}
+    </div>
+    {!! $config !!}
+
+    <script src="{{ mix('js/h5p-core-bundle.js') }}"></script>
+    @foreach( $jsScripts as $js)
+        {!! HTML::script($js) !!}
+    @endforeach
+    <script>
+        H5P.jQuery.ajaxSetup({
+            headers: {
+                'X-CSRF-TOKEN': H5P.jQuery('meta[name="csrf-token"]').attr('content')
+            }
+        });
+    </script>
+</body>
+</html>

--- a/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/content-details.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/content-details.blade.php
@@ -3,7 +3,9 @@
     <div class="container">
         <a href="{{ route('admin.update-libraries') }}">Library list</a>
         <br>
-        <a href="{{ route('admin.content-library', $content->library->id) }}">Library content list</a>
+        @if($content->library)
+            <a href="{{ route('admin.content-library', $content->library->id) }}">Library content list</a>
+        @endif
         <div class="row">
             <div class="col-md-12">
                 <div class="panel panel-default">
@@ -16,10 +18,42 @@
                         <table class="table table-striped">
                             <tr>
                                 <th>Id</th>
-                                <td>{{ $content->id }}</td>
+                                <td>
+                                    {{ $content->id }}
+                                    <form
+                                        action="{{route('admin.content-preview', $content)}}"
+                                        method="POST"
+                                        target="_blank"
+                                        style="display:inline-block; margin-left:1em;"
+                                    >
+                                        @csrf
+                                        <button
+                                            type="submit"
+                                            title="Preview"
+                                            aria-label="Preview"
+                                        >
+                                            <i aria-hidden="true" class="glyphicon glyphicon-eye-open"></i>
+                                        </button>
+                                    </form>
+                                    <form
+                                        action="{{route('admin.content-export', $content)}}"
+                                        method="POST"
+                                        target="_blank"
+                                        style="display:inline-block; margin-left:1em;"
+                                    >
+                                        @csrf
+                                        <button
+                                            type="submit"
+                                            title="Export"
+                                            aria-label="Export"
+                                        >
+                                            <i aria-hidden="true" class="glyphicon glyphicon-export"></i>
+                                        </button>
+                                    </form>
+                                </td>
                             </tr>
                             <tr>
-                                <th>Folium id</th>
+                                <th>Resource/Folium id</th>
                                 <td>{{ $resource?->id ?? '' }}</td>
                             </tr>
                             <tr>
@@ -63,10 +97,18 @@
                                 <td>{{ $latestVersion ? 'Yes' : 'No' }}</td>
                             </tr>
                             <tr>
-                                <th>Language</th>
+                                <th>Edlib language</th>
                                 <td>
                                     @isset($content->language_iso_639_3)
                                         {{ $content->language_iso_639_3 }} ({{ Iso639p3::englishName($content->language_iso_639_3) }})
+                                    @endisset
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>H5P language</th>
+                                <td>
+                                    @isset($content->metadata->default_language)
+                                        {{ $content->metadata->default_language }} ({{{Iso639p3::englishName($content->metadata->default_language)}}})
                                     @endisset
                                 </td>
                             </tr>
@@ -94,9 +136,11 @@
                             <tr>
                                 <th>Library</th>
                                 <td>
-                                    <a href="{{ route('admin.check-library', [$content->library->id]) }}">
-                                        {{ sprintf('%s %d.%d.%d', $content->library->name, $content->library->major_version, $content->library->minor_version, $content->library->patch_version) }}
-                                    </a>
+                                    @if($content->library)
+                                        <a href="{{ route('admin.check-library', [$content->library->id]) }}">
+                                            {{ $content->library->getLibraryString(true) }}
+                                        </a>
+                                    @endif
                                 </td>
                             </tr>
                         </table>
@@ -114,37 +158,91 @@
                         <div class="panel-body">
                             <table class="table table-striped">
                                 <thead>
-                                    <tr>
-                                        <th>Id</th>
-                                        <th>Date (Version)</th>
-                                        <th>Title</th>
-                                        <th>License</th>
-                                        <th>Language</th>
-                                        <th>Reason</th>
-                                        <th>Library</th>
-                                    </tr>
+                                <tr>
+                                    <th>Id</th>
+                                    <th>Date (Version)</th>
+                                    <th>Title</th>
+                                    <th>License</th>
+                                    <th>Language</th>
+                                    <th>Reason</th>
+                                    <th>Library</th>
+                                </tr>
                                 </thead>
                                 <tbody>
-                                    @while(true)
-                                        @php
-                                            if (!isset($itemId)) {
-                                                $itemId = $content->id;
-                                            } else {
-                                                $itemId = !empty($history[$itemId]['parent']) && !empty($history[$history[$itemId]['parent']]) ? $history[$itemId]['parent'] : null;
-                                            }
-                                            if ($itemId === null) {
-                                                break;
-                                            }
-                                        @endphp
+                                @while(true)
+                                    @php
+                                        if (!isset($itemId)) {
+                                            $itemId = $content->id;
+                                        } else {
+                                            $itemId = !empty($history[$itemId]['parent']) && !empty($history[$history[$itemId]['parent']]) ? $history[$itemId]['parent'] : null;
+                                        }
+                                        if ($itemId === null) {
+                                            break;
+                                        }
+                                    @endphp
+                                    <tr>
+                                        <td>
+                                            @if ($itemId !== $content->id && isset($history[$itemId]['content']))
+                                                <a href="{{ route('admin.content-details', [$history[$itemId]['content_id']]) }}">
+                                                    {{ $history[$itemId]['content_id'] }}
+                                                </a>
+                                            @else
+                                                {{ $history[$itemId]['content_id'] }}
+                                            @endif
+                                        </td>
+                                        <td>{{ $history[$itemId]['versionDate']->format('Y-m-d H:i:s.u e') }}</td>
+                                        <td>{{ $history[$itemId]['content']['title'] ?? '' }}</td>
+                                        <td>{{ $history[$itemId]['content']['license'] ?? '' }}</td>
+                                        <td>{{ $history[$itemId]['content']['language'] ?? '' }}</td>
+                                        <td>{{ $history[$itemId]['version_purpose'] }}</td>
+                                        <td>
+                                            @if(isset($history[$itemId]['content']) && isset($history[$itemId]['content']['library_id']))
+                                                <a href="{{ route('admin.check-library', [$history[$itemId]['content']['library_id']]) }}">
+                                                    {{ $history[$itemId]['content']['library'] }}
+                                                </a>
+                                            @else
+                                                {{ $history[$itemId]['content']['library'] ?? '' }}
+                                            @endif
+                                        </td>
+                                    </tr>
+                                @endwhile
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="panel panel-default">
+                        <div class="panel-heading">
+                            <h4>Content from this version</h4>
+                        </div>
+                        <div class="panel-body">
+                            <table class="table table-striped">
+                                <thead>
+                                <tr>
+                                    <th>Id</th>
+                                    <th>Date (Version)</th>
+                                    <th>Title</th>
+                                    <th>License</th>
+                                    <th>Language</th>
+                                    <th>Reason</th>
+                                    <th>Library</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                @empty($history[$content->id]['children'])
+                                    <tr>
+                                        <td colspan="6">
+                                            {{ $latestVersion ? 'This is the latest version' : 'No content found' }}
+                                        </td>
+                                    </tr>
+                                @else
+                                    @foreach($history[$content->id]['children'] as $itemId)
                                         <tr>
                                             <td>
-                                                @if ($itemId !== $content->id && isset($history[$itemId]['content']))
-                                                    <a href="{{ route('admin.content-details', [$history[$itemId]['content_id']]) }}">
-                                                        {{ $history[$itemId]['content_id'] }}
-                                                    </a>
+                                                @isset($history[$itemId]['content'])
+                                                    <a href="{{ route('admin.content-details', [$history[$itemId]['content_id']]) }}">{{ $history[$itemId]['content_id'] }}</a>
                                                 @else
-                                                    {{ $history[$itemId]['content_id'] }}
-                                                @endif
+                                                    {{ $history[$itemId]['external_reference'] }}
+                                                @endisset
                                             </td>
                                             <td>{{ $history[$itemId]['versionDate']->format('Y-m-d H:i:s.u e') }}</td>
                                             <td>{{ $history[$itemId]['content']['title'] ?? '' }}</td>
@@ -161,67 +259,56 @@
                                                 @endif
                                             </td>
                                         </tr>
-                                    @endwhile
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                    <div class="panel panel-default">
-                        <div class="panel-heading">
-                            <h4>Content from this version</h4>
-                        </div>
-                        <div class="panel-body">
-                            <table class="table table-striped">
-                                <thead>
-                                    <tr>
-                                        <th>Id</th>
-                                        <th>Date (Version)</th>
-                                        <th>Title</th>
-                                        <th>License</th>
-                                        <th>Language</th>
-                                        <th>Reason</th>
-                                        <th>Library</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    @empty($history[$content->id]['children'])
-                                        <tr>
-                                            <td colspan="6">
-                                                {{ $latestVersion ? 'This is the latest version' : 'No content found' }}
-                                            </td>
-                                        </tr>
-                                    @else
-                                        @foreach($history[$content->id]['children'] as $itemId)
-                                            <tr>
-                                                <td>
-                                                    @isset($history[$itemId]['content'])
-                                                        <a href="{{ route('admin.content-details', [$history[$itemId]['content_id']]) }}">{{ $history[$itemId]['content_id'] }}</a>
-                                                    @else
-                                                        {{ $history[$itemId]['external_reference'] }}
-                                                    @endisset
-                                                </td>
-                                                <td>{{ $history[$itemId]['versionDate']->format('Y-m-d H:i:s.u e') }}</td>
-                                                <td>{{ $history[$itemId]['content']['title'] ?? '' }}</td>
-                                                <td>{{ $history[$itemId]['content']['license'] ?? '' }}</td>
-                                                <td>{{ $history[$itemId]['content']['language'] ?? '' }}</td>
-                                                <td>{{ $history[$itemId]['version_purpose'] }}</td>
-                                                <td>
-                                                    @if(isset($history[$itemId]['content']) && isset($history[$itemId]['content']['library_id']))
-                                                        <a href="{{ route('admin.check-library', [$history[$itemId]['content']['library_id']]) }}">
-                                                            {{ $history[$itemId]['content']['library'] }}
-                                                        </a>
-                                                    @else
-                                                        {{ $history[$itemId]['content']['library'] ?? '' }}
-                                                    @endif
-                                                </td>
-                                            </tr>
-                                        @endforeach
-                                    @endempty
+                                    @endforeach
+                                @endempty
                                 </tbody>
                             </table>
                         </div>
                     </div>
                 @endempty
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <h4>Libraries</h4>
+                    </div>
+                    <div class="panel-body">
+                        <table class="table table-striped">
+                            <thead>
+                            <tr>
+                                <th>Library</th>
+                                <th>Library type</th>
+                                <th>Dependency type</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            @foreach($content->contentLibraries()->orderBy('dependency_type')->orderBy('weight')->get() as $contentLib)
+                                <tr @class(['alert-danger' => !$contentLib->library])>
+                                    <td>
+                                        @if($contentLib->library)
+                                            <a href="{{ route('admin.check-library', [$contentLib->library_id]) }}">
+                                                {{ $contentLib->library->getLibraryString(true) }}
+                                            </a>
+                                        @else
+                                            - Library with id {{$contentLib->library_id}} was not found -
+                                        @endif
+                                    </td>
+                                    <td>
+                                        @if($contentLib->library)
+                                            @if($contentLib->library->runnable)
+                                                Content type
+                                            @else
+                                                Library
+                                            @endif
+                                        @endif
+                                    </td>
+                                    <td>
+                                        {{ $contentLib->dependency_type }}
+                                    </td>
+                                </tr>
+                            @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/library-check.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/library-check.blade.php
@@ -171,6 +171,12 @@
                                     </a>
                                 </td>
                             </tr>
+                            <tr>
+                                <th>Used as subcontent</th>
+                                <td colspan="2">
+                                    {{ $subContentCount ?? '' }}
+                                </td>
+                            </tr>
                         </table>
                     </div>
                 </div>

--- a/sourcecode/apis/contentauthor/resources/views/admin/maxscore-failed-overview.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/maxscore-failed-overview.blade.php
@@ -18,8 +18,8 @@
                             <tr>
                                 <td>{{$resource->id}}</td>
                                 <td>{{$resource->title}}</td>
-                                <td>{{sprintf('%s (%s %d.%d.%d)', $resource->library->title, $resource->library->name, $resource->library->major_version, $resource->library->minor_version, $resource->library->patch_version)}}</td>
-                                <td>{{$resource->created_at}}</td>
+                                <td>{{sprintf('%s (%s)', $resource->library->title, $resource->library->getLibraryString(true))}}</td>
+                                <td>{{$resource->created_at->format('Y-m-d H:i:s e')}}</td>
                                 <td>{{$resource->ownerName}}</td>
                             </tr>
                         @empty

--- a/sourcecode/apis/contentauthor/resources/views/admin/maxscore-overview.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/maxscore-overview.blade.php
@@ -24,7 +24,7 @@
                             <li class="list-group-item" id="library_{{$library->id}}">
                                 <label>
                                     <input value="{{$library->id}}" type="checkbox" name="calculateLibrary" class="maxScoreCheckbox" aria-checked="true" checked>
-                                    <span>{{sprintf('%s %d.%d (%s)', $library->name, $library->major_version, $library->minor_version, $library->title)}}</span>
+                                    <span>{{sprintf('%s (%s)', $library->getLibraryString(true), $library->title)}}</span>
                                 </label>
                                 <span class="badge">{{$library->contents_count}}</span>
                                 <div class="progress hidden" data-inprogress="0" data-success="0" data-failed="0">

--- a/sourcecode/apis/contentauthor/resources/views/layouts/admin.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/layouts/admin.blade.php
@@ -97,7 +97,10 @@
                                 <a href="{{ route('admin.capability') }}">Capabilities</a>
                             </li>
                             <li>
-                                <a href="{{ route('admin.update-libraries') }}">Update libraries</a>
+                                <a href="{{ route('admin.update-libraries') }}">Manage libraries</a>
+                            </li>
+                            <li>
+                                <a href="{{ route('admin.h5p-content-info') }}">Content info</a>
                             </li>
                             @if( resolve(\App\Libraries\H5P\Interfaces\H5PAdapterInterface::class)->useMaxscore() )
                                 <li>

--- a/sourcecode/apis/contentauthor/routes/admin.php
+++ b/sourcecode/apis/contentauthor/routes/admin.php
@@ -52,9 +52,15 @@ Route::middleware(['auth:admin,sso', 'can:superadmin'])->prefix('admin')->group(
             ->name('admin.content-library');
         Route::get('content/{content}/details', [AdminH5PDetailsController::class, 'contentHistory'])
             ->name('admin.content-details');
+        Route::post('content/{h5pContent}/preview', [AdminH5PDetailsController::class, 'contentPreview'])
+            ->name('admin.content-preview');
+        Route::post('content/{h5pContent}/export', [AdminH5PDetailsController::class, 'contentExport'])
+            ->name('admin.content-export');
         Route::get('libraries/{library}/translation/{locale}', [AdminH5PDetailsController::class, 'libraryTranslation'])
             ->name('admin.library-translation');
         Route::post('libraries/{library}/translation/{locale}', [AdminH5PDetailsController::class, 'libraryTranslationUpdate']);
+        Route::get('/h5p-content-info', [AdminH5PDetailsController::class, 'h5pContentInfo'])
+            ->name('admin.h5p-content-info');
 
         Route::get('libraries/{library}', [ContentUpgradeController::class, 'upgrade'])->name('admin.library');
 

--- a/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/Admin/AdminH5PDetailsControllerTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/Admin/AdminH5PDetailsControllerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Integration\Http\Controllers\Admin;
 
 use App\ApiModels\Resource;
+use App\Apis\ResourceApiService;
 use App\ContentVersion;
 use App\H5PContent;
 use App\H5PLibrary;
@@ -249,11 +250,11 @@ class AdminH5PDetailsControllerTest extends TestCase
             'library_id' => $library->id,
         ]);
 
-        $resourceAPI = $this->createMock('\App\Apis\ResourceApiService');
+        $resourceAPI = $this->createMock(ResourceApiService::class);
         $resourceAPI->expects($this->once())
             ->method('getResourceFromExternalReference')
             ->willReturn(new Resource($f4mId, '', '', '', '', '', ''));
-        $this->instance('\App\Apis\ResourceApiService', $resourceAPI);
+        $this->instance(ResourceApiService::class, $resourceAPI);
 
         $parentVersion = ContentVersion::factory()->create([
             'id' => $parent->version_id,
@@ -313,11 +314,11 @@ class AdminH5PDetailsControllerTest extends TestCase
             'library_id' => $library->id,
         ]);
 
-        $resourceAPI = $this->createMock('\App\Apis\ResourceApiService');
+        $resourceAPI = $this->createMock(ResourceApiService::class);
         $resourceAPI->expects($this->once())
             ->method('getResourceFromExternalReference')
             ->willThrowException(new \ErrorException('Just testing'));
-        $this->instance('\App\Apis\ResourceApiService', $resourceAPI);
+        $this->instance(ResourceApiService::class, $resourceAPI);
 
         $response = $this->withSession(['user' => $user])
             ->get(route('admin.content-details', $content))

--- a/sourcecode/apis/contentauthor/webpack.mix.js
+++ b/sourcecode/apis/contentauthor/webpack.mix.js
@@ -41,6 +41,7 @@ mix
     .js('resources/assets/entrypoints/react-contentbrowser.js', 'js/react-contentbrowser.js')
     .js('resources/assets/entrypoints/react-h5p.js', 'js/react-h5p.js')
     .js('resources/assets/entrypoints/react-questionset.js', 'js/react-questionset.js')
+    .sass('resources/assets/entrypoints/admin-preview.scss', 'css/admin-preview.css')
     .webpackConfig({
         resolve: {
             fallback: {


### PR DESCRIPTION
- Rename menu item in H5P menu from "Update libraries" to "Manage libraries"
- New menu item "Content info" for finding content by various ids
- Before deleting library also check if library is used by other libraries
- On Content details:
  - Add buttons for Preview and Export
  - List libraries
- Fix use of different date and time formats

ToDo: Add tests