### PR TITLE
GH #2722, #2623, #2203: Fields not displaying in script view

### DIFF
--- a/sourcecode/apis/contentauthor/resources/assets/react/components/H5pEditor/List/getTextFields.js
+++ b/sourcecode/apis/contentauthor/resources/assets/react/components/H5pEditor/List/getTextFields.js
@@ -11,7 +11,7 @@ const pathTypes = {
 const getItemFilterType = (semantic) => {
     const isHeader = semantic.name.toLowerCase().includes('header');
     const isTitle = semantic.name.toLowerCase().includes('title');
-    const isAlt = ['imageAltText', 'alt'].indexOf(semantic.name) !== -1;
+    const isAlt = ['imageAltText', 'alt', 'imageAlt', 'matchAlt'].indexOf(semantic.name) !== -1;
     const isHover = semantic.label && semantic.label.toLowerCase().includes('hover');
 
     return {
@@ -28,9 +28,13 @@ const getPathsFromSementics = (
     fieldTypes,
     results = [],
     path = [],
-    isParentList = false
+    isParentList = false,
+    addToPath = true
 ) => {
-    const currentPath = [...path, isParentList ? arrayKey : sementic.name];
+    const currentPath = [...path];
+    if (addToPath) {
+        currentPath.push(isParentList ? arrayKey : sementic.name);
+    }
 
     if (fieldNamesToIgnore.indexOf(sementic.name) !== -1) {
         return results;
@@ -65,8 +69,10 @@ const getPathsFromSementics = (
 
     if (sementic.type === 'group') {
         if (Object.keys(sementic.fields).length === 1) {
-            currentPath.pop();
-            return getPathsFromSementics(sementic.fields[0], fieldTypes, results, currentPath);
+            if (isParentList) {
+                currentPath.pop();
+            }
+            return getPathsFromSementics(sementic.fields[0], fieldTypes, results, currentPath, isParentList, isParentList);
         }
 
         return sementic.fields.reduce(
@@ -192,7 +198,7 @@ const getTranslationJobs = async (parameters, libraryName, loadedLibraries) => {
         .map(sementic => getPathsFromSementics(sementic, [
             {
                 type: 'text',
-                widgets: ['textarea', 'html', undefined, 'showWhen', 'NDLAShowWhen'],
+                widgets: ['textarea', 'html', undefined, 'showWhen', 'NDLAShowWhen', 'csv-to-text'],
             },
             {
                 type: h5pFieldTypes.LIBRARY,

--- a/sourcecode/apis/contentauthor/tests/Integration/Article/ArticleTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Article/ArticleTest.php
@@ -58,7 +58,7 @@ class ArticleTest extends TestCase
         // We don't really care that the output looks like this, but it's nice
         // to know if it suddenly changes after an update or such anyway.
         $this->assertSame(
-            "<div>Foo<b></b><p>bar</p></div>\n",
+            "<div>Foo<b></b></div><p>bar</p>\n",
             $article->render(),
         );
     }


### PR DESCRIPTION
CA Script View fixes:
- Issue where fields are not displayed
- Using `csv-to-text` widget on text-fields will not prevent it from displaying
- Update list of field names used as alt-text for images