### PR TITLE
use `npm ci` for CA

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -203,7 +203,7 @@ services:
 
   contentauthor-watch:
     image: node:16-alpine
-    command: [sh, -c, 'npm install --legacy-peer-deps && npm run watch']
+    command: [sh, -c, 'npm ci && npm run watch']
     volumes:
       - npm_cache:/root/.npm
       - ./sourcecode/apis/contentauthor:/app

--- a/sourcecode/apis/contentauthor/Dockerfile
+++ b/sourcecode/apis/contentauthor/Dockerfile
@@ -52,7 +52,7 @@ WORKDIR /app
 RUN npm i -g node-gyp
 
 COPY package.json package-lock.json ./
-RUN npm i
+RUN npm ci
 
 COPY --from=composer_deps /app/vendor/ckeditor/ckeditor vendor/ckeditor/ckeditor
 COPY --from=composer_deps /app/vendor/h5p vendor/h5p


### PR DESCRIPTION
`npm install` alters package.json, which is undesirable.

https://docs.npmjs.com/cli/v10/commands/npm-ci

`--legacy-peer-deps` isn't necessary since 1a8424e0b293701ea8105f5b9fbc2b741a7c9a30, but that commit did not remove it from docker-compose.yml.