### PR TITLE
fix h5pstorage symlink properly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,7 +135,7 @@ services:
       - ./sourcecode/apis/contentauthor/docker/contentAuthor.conf.template:/etc/nginx/templates/contentAuthor.conf.template:ro
       - ./sourcecode/apis/contentauthor/docker/no-security-theatre.conf:/etc/nginx/conf.d/no-security-theatre.conf:ro
       - ./sourcecode/apis/contentauthor/public:/app/public
-      - ./sourcecode/apis/contentauthor/storage/app:/app/public/h5pstorage
+      - ./sourcecode/apis/contentauthor/storage:/app/storage
       - ./sourcecode/apis/contentauthor/vendor/h5p/h5p-editor:/app/public/h5p-editor-php-library:ro
       - ./sourcecode/apis/contentauthor/vendor/h5p/h5p-core:/app/public/h5p-php-library:ro
     environment:

--- a/sourcecode/apis/contentauthor/Dockerfile
+++ b/sourcecode/apis/contentauthor/Dockerfile
@@ -94,7 +94,7 @@ RUN set -eux; \
         storage/framework/sessions \
         storage/framework/views \
         storage/logs; \
-    ln -s /app/public/storage/app/public /app/public/storage; \
+    ln -s ../storage/app public/h5pstorage; \
     chmod -R o+w \
         bootstrap/cache \
         storage; \

--- a/sourcecode/apis/contentauthor/config/filesystems.php
+++ b/sourcecode/apis/contentauthor/config/filesystems.php
@@ -71,4 +71,20 @@ return [
         ],
     ],
 
+
+    /*
+    |--------------------------------------------------------------------------
+    | Symbolic Links
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the symbolic links that will be created when the
+    | `storage:link` Artisan command is executed. The array keys should be
+    | the locations of the links and the values should be their targets.
+    |
+    */
+
+    'links' => [
+        public_path('h5pstorage') => '../storage/app',
+    ],
+
 ];

--- a/sourcecode/apis/contentauthor/docker/php/docker-entrypoint-dev.sh
+++ b/sourcecode/apis/contentauthor/docker/php/docker-entrypoint-dev.sh
@@ -6,4 +6,6 @@ if [ "$1" = "php-fpm" ]; then
     chmod -R o+w bootstrap/cache storage
 fi
 
+php artisan storage:link
+
 exec "$@"


### PR DESCRIPTION
Creates a symlink at `/app/public/h5pstorage` that points to `/app/storage/app`.

The symlink is relative, so should be visible and working in the IDE outside the container, too.

This should have no effect on live environments, since these use S3.