### PR TITLE
Disable CKEditor version check

### DIFF
--- a/sourcecode/apis/contentauthor/resources/assets/ckeditor/config.js
+++ b/sourcecode/apis/contentauthor/resources/assets/ckeditor/config.js
@@ -53,4 +53,7 @@ CKEDITOR.editorConfig = function (config) {
     // config.extraAllowedContent = 'section aside header h1 h2 h3 h4 h5 h6 p ul ol li br b strong iframe embed *(*)[class,data-*];' +
     // 'math maction maligngroup malignmark menclose merror mfenced mfrac mglyph mi mlabeledtr mlongdiv mmultiscripts mn mo mover mpadded mphantom mroot mrow ms mscarries ' +
     // 'mscarry msgroup msline mspace msqrt msrow mstack mstyle msub msup msubsup mtable mtd mtext mtr munder munderover semantics annotation annotation-xml';
+
+    // Disable version check, https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-versionCheck
+    config.versionCheck = false;
 };

--- a/sourcecode/apis/contentauthor/resources/assets/ckeditor/inline-config.js
+++ b/sourcecode/apis/contentauthor/resources/assets/ckeditor/inline-config.js
@@ -12,4 +12,7 @@ CKEDITOR.editorConfig = function (config) {
     config.removeButtons = '';
 
     config.extraPlugins = 'edlibmatheditor';
+
+    // Disable version check, https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-versionCheck
+    config.versionCheck = false;
 };


### PR DESCRIPTION
Disable CKEditor version check that displays a popup in the editor saying the editor is unsafe and should be updated. The latest, and last, open source version, 4.22.1,  is already in use. Newer versions are available under commercial terms. The check was added in 4.22.0 and is default enabled.

This disables the check in Article and Question content types, and in H5P Script view. The editor used by H5P is included in the H5P Editor composer package and is currently at version 4.17.1.