### PR TITLE
remove unused index routes

### DIFF
--- a/sourcecode/apis/contentauthor/app/Http/Controllers/ArticleController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/ArticleController.php
@@ -47,16 +47,6 @@ class ArticleController extends Controller
     }
 
     /**
-     * Display a listing of the resource.
-     *
-     * @return \Illuminate\Http\Response
-     */
-    public function index()
-    {
-        abort(404);
-    }
-
-    /**
      * Show the form for creating a new resource.
      */
     public function create(Request $request): View

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/H5PController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/H5PController.php
@@ -79,12 +79,6 @@ class H5PController extends Controller
         $this->middleware('core.locale', ['only' => ['create', 'edit', 'store']]);
     }
 
-    public function index(): View
-    {
-        $title = "Viewing H5P content";
-        return view('h5p.index', ['title' => $title, 'message' => trans('h5p-editor.need-id')]);
-    }
-
     public function doShow($id, $context, $preview = false): View
     {
         $ltiRequest = $this->lti->getRequest(request());

--- a/sourcecode/apis/contentauthor/resources/lang/en/h5p-editor.php
+++ b/sourcecode/apis/contentauthor/resources/lang/en/h5p-editor.php
@@ -4,5 +4,4 @@ return [
     'anonymous' => "Anonymous",
     'could-not-find-content' => 'Could not find or create the content you want. Sorry! :(',
     'download-not-available' => 'Download not available',
-    'need-id' => "You need an ID to view content",
 ];

--- a/sourcecode/apis/contentauthor/resources/lang/ko/h5p-editor.php
+++ b/sourcecode/apis/contentauthor/resources/lang/ko/h5p-editor.php
@@ -4,5 +4,4 @@ return [
     'anonymous' => "익명의",
     'could-not-find-content' => '원하는 콘텐츠를 찾거나 만들 수 없습니다. 죄송합니다! :(',
     'download-not-available' => '다운로드 이용불가',
-    'need-id' => "콘텐츠를 보기 위해서는 ID가 필요합니다.",
 ];

--- a/sourcecode/apis/contentauthor/resources/lang/nb/h5p-editor.php
+++ b/sourcecode/apis/contentauthor/resources/lang/nb/h5p-editor.php
@@ -4,5 +4,4 @@ return [
     'anonymous' => "Anonym",
     'could-not-find-content' => 'Kunne ikke finne eller opprette innholdet du ønsker! Beklager. :(',
     'download-not-available' => 'Fil ikke tilgjengelig',
-    'need-id' => "Du trenger en ID for å se innhold",
 ];

--- a/sourcecode/apis/contentauthor/resources/lang/nn/h5p-editor.php
+++ b/sourcecode/apis/contentauthor/resources/lang/nn/h5p-editor.php
@@ -4,5 +4,4 @@ return [
     'anonymous' => "Anonym",
     'could-not-find-content' => 'Kunne ikkje finne eller opprette innhaldet du ynskjer. Me beklager! :(',
     'download-not-available' => 'Nedlasting er ikkje tilgjengeleg',
-    'need-id' => "Du treng ein ID for å sjå innhaldet",
 ];

--- a/sourcecode/apis/contentauthor/resources/lang/sv/h5p-editor.php
+++ b/sourcecode/apis/contentauthor/resources/lang/sv/h5p-editor.php
@@ -1,5 +1,4 @@
 <?php
 
 return [
-    'need-id' => "Du behöver ett ID för att se innehåll",
 ];

--- a/sourcecode/apis/contentauthor/resources/views/h5p/index.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/h5p/index.blade.php
@@ -1,8 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-</head>
-<body>
-    <h2>{{ $message }}</h2>
-</body>
-</html>

--- a/sourcecode/apis/contentauthor/routes/web.php
+++ b/sourcecode/apis/contentauthor/routes/web.php
@@ -37,7 +37,7 @@ Route::post('h5p/adapter', function () {
 })->name('h5p.adapter')->middleware('adaptermode');
 Route::get('h5p/{h5p}/copyright', [H5PController::class, 'getCopyright']);
 Route::get('h5p/{h5p}/info', [H5PController::class, 'getInfo']);
-Route::resource('/h5p', H5PController::class, ['except' => ['destroy']]);
+Route::resource('/h5p', H5PController::class, ['except' => ['index', 'destroy']]);
 
 Route::get('images/browse', [H5PController::class, 'browseImages']);
 Route::get('images/browse/{imageId}', [H5PController::class, 'getImage']);
@@ -74,10 +74,10 @@ Route::middleware(['core.return', 'lti.add-to-session', 'lti.signed-launch', 'co
 
     Route::match(['GET', 'POST'], '/create/{contenttype?}', [ContentController::class, 'index'])->middleware(["lti.verify-auth", "lti.question-set", 'core.behavior-settings:editor'])->name('create');
 
-    Route::resource('questionset', QuestionSetController::class, ['except' => ['destroy']]);
+    Route::resource('questionset', QuestionSetController::class, ['except' => ['index', 'destroy']]);
     Route::post('questionset/{id}/edit', [QuestionSetController::class, 'ltiEdit']);
 
-    Route::resource('game', GameController::class, ['except' => ['destroy']]);
+    Route::resource('game', GameController::class, ['except' => ['index', 'destroy']]);
     Route::post('game/{id}/edit', [GameController::class, 'ltiEdit']);
 
     Route::group(['middleware' => ['core.ownership']], function () {
@@ -88,8 +88,8 @@ Route::middleware(['core.return', 'lti.add-to-session', 'lti.signed-launch', 'co
 
 Route::get('/slo', [SingleLogoutController::class, 'index'])->name('slo'); // Single logout route
 
-Route::resource('/article', ArticleController::class, ['except' => ['destroy']]);
-Route::resource('/link', LinkController::class, ['except' => ['destroy']]);
+Route::resource('/article', ArticleController::class, ['except' => ['index', 'destroy']]);
+Route::resource('/link', LinkController::class, ['except' => ['index', 'destroy']]);
 
 Route::post('/article/create/upload', [ArticleUploadController::class, 'uploadToNewArticle'])->name('article-upload.new');
 Route::post('/article/{id}/upload', [ArticleUploadController::class, 'uploadToExistingArticle'])->name('article-upload.existing');


### PR DESCRIPTION
Discovered while working on #2768 

Removes `GET /h5p` and similar routes created by `Route::resource()` that either do not have a corresponding controller method, or just 404.