### PR TITLE
only forward resize messages in embed view

### DIFF
--- a/sourcecode/hub/app/View/Components/LtiLaunch.php
+++ b/sourcecode/hub/app/View/Components/LtiLaunch.php
@@ -7,6 +7,7 @@ namespace App\View\Components;
 use Illuminate\Contracts\Encryption\Encrypter;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Str;
 use Illuminate\View\Component;
 
 use function view;
@@ -15,19 +16,31 @@ class LtiLaunch extends Component
 {
     public readonly string $url;
 
+    public readonly string $uniqueId;
+
     /**
      * @param string $logTo
      *     A selector for an element in which to log messages sent by the
      *     iframe.
+     * @param array<string, string> $parameters
      */
     public function __construct(
         private Encrypter $encrypter,
         public \App\Lti\LtiLaunch $launch,
+        public string $method = 'GET',
+        public array $parameters = [],
+        public string $target = '_self',
+        public int $width = 640,
+        public int $height = 480,
         public string $logTo = '',
+        public bool $forwardsResizeMessages = false,
+        public bool $direct = false,
     ) {
         $this->url = URL::signedRoute('lti.launch', [
             'launch' => $this->encrypter->encrypt($launch),
         ]);
+
+        $this->uniqueId = Str::uuid()->toString();
     }
 
     public function render(): View

--- a/sourcecode/hub/resources/js/resize.js
+++ b/sourcecode/hub/resources/js/resize.js
@@ -37,8 +37,9 @@ addEventListener('message', (event) => {
     const border = iframe.getBoundingClientRect().height - iframe.scrollHeight;
     iframe.height = String(event.data.scrollHeight + border);
 
-    if (window.parent) {
-        // forward to parent iframe
+    if (window.parent && iframe.closest('.forwards-resize-messages')) {
+        console.debug('Forwarding the resize request');
+
         parent.postMessage({
             action: 'resize',
             scrollHeight: event.data.scrollHeight,

--- a/sourcecode/hub/resources/views/components/launch.blade.php
+++ b/sourcecode/hub/resources/views/components/launch.blade.php
@@ -1,25 +1,12 @@
-@php use Illuminate\Support\Str; @endphp
-
-@props([
-    'url' => 'about:blank',
-    'method' => 'GET',
-    'parameters' => [],
-    'target' => '_self',
-    'direct' => false,
-    'width' => 640,
-    'height' => 480,
-    'logTo' => '',
-    'uniqueId' => (string) Str::uuid(),
-])
-
-<iframe {{ $attributes->except('direct')->merge([
+<iframe {{ $attributes->except(['direct', 'forwards-resize-messages'])->merge([
     'src' => $direct ? 'about:blank' : $url,
     'name' => 'launch-frame-' . $uniqueId,
-    'width' => $width,
-    'height' => $height,
-    'class' => 'lti-launch d-block',
     'data-log-to' => $logTo,
     'frameborder' => '0',
+])->class([
+    'lti-launch',
+    'd-block',
+    'forwards-resize-messages' => $forwardsResizeMessages,
 ]) }}></iframe>
 
 @if ($direct)

--- a/sourcecode/hub/resources/views/content/embed.blade.php
+++ b/sourcecode/hub/resources/views/content/embed.blade.php
@@ -2,5 +2,5 @@
 <x-layout no-nav no-header no-footer expand>
     <x-slot:title>{{ $version->title }}</x-slot:title>
 
-    <x-lti-launch :launch="$launch" class="w-100 h-100" />
+    <x-lti-launch :launch="$launch" class="w-100 h-100" forwards-resize-messages />
 </x-layout>


### PR DESCRIPTION
This fixes a bug where e.g. previewing content that emits resize messages would signal to Edlib's parent frame that Edlib must be resized, even as Edlib is currently displaying more than just the content.

The `@props` rubbish is removed, as it interferes with `$attributes`.

Fixes #2804