### PR TITLE
restore iframe dimensions

### DIFF
--- a/sourcecode/hub/resources/views/components/launch.blade.php
+++ b/sourcecode/hub/resources/views/components/launch.blade.php
@@ -3,6 +3,8 @@
     'name' => 'launch-frame-' . $uniqueId,
     'data-log-to' => $logTo,
     'frameborder' => '0',
+    'width' => $width,
+    'height' => $height,
 ])->class([
     'lti-launch',
     'd-block',


### PR DESCRIPTION
`$attributes` apparently doesn't contain attributes defined by a class-backed component.