### PR TITLE
hub: do not expose server versions

### DIFF
--- a/sourcecode/hub/Dockerfile
+++ b/sourcecode/hub/Dockerfile
@@ -141,4 +141,5 @@ FROM nginx:1-alpine AS web
 ENV PHP_FPM_HOST "localhost:9000"
 
 COPY --from=prod /app/public /app/public
+COPY docker/nginx/server_tokens.conf /etc/nginx/conf.d/
 COPY docker/nginx/default.conf.template /etc/nginx/templates/

--- a/sourcecode/hub/docker/nginx/server_tokens.conf
+++ b/sourcecode/hub/docker/nginx/server_tokens.conf
@@ -1,0 +1,1 @@
+server_tokens off;

--- a/sourcecode/hub/docker/php/php-dev.ini
+++ b/sourcecode/hub/docker/php/php-dev.ini
@@ -1,3 +1,5 @@
+expose_php = on
+
 xdebug.client_host = host.docker.internal
 xdebug.discover_client_host = on
 xdebug.idekey = PHPSTORM

--- a/sourcecode/hub/docker/php/php.ini
+++ b/sourcecode/hub/docker/php/php.ini
@@ -1,1 +1,1 @@
-; left blank so far
+expose_php = off


### PR DESCRIPTION
As was done with CA, secures against low-effort "security" reports.