### PR TITLE
hub: add url slugs for tools

### DIFF
--- a/sourcecode/hub/app/Console/Commands/AddLtiTool.php
+++ b/sourcecode/hub/app/Console/Commands/AddLtiTool.php
@@ -16,6 +16,7 @@ class AddLtiTool extends Command
     edlib:add-lti-tool
     {name : The name of the tool}
     {url : The URL to which LTI Deep Linking requests will be sent}
+    {--slug=} The URL slug of the tool
     {--send-name} Send the name of the user to the tool upon launch
     {--send-email} Send the email address of the user to the tool upon launch
     {--edlib-editable} The tool accepts edit requests via an Edlib-specific mechanism
@@ -34,6 +35,10 @@ class AddLtiTool extends Command
         $tool->send_name = $this->option('send-name');
         $tool->send_email = $this->option('send-email');
         $tool->proxy_launch = true;
+
+        if ($this->option('slug')) {
+            $tool->slug = $this->option('slug');
+        }
 
         if ($this->option('edlib-editable')) {
             $tool->edit_mode = LtiToolEditMode::DeepLinkingRequestToContentUrl;

--- a/sourcecode/hub/app/Http/Requests/StoreLtiToolExtraRequest.php
+++ b/sourcecode/hub/app/Http/Requests/StoreLtiToolExtraRequest.php
@@ -8,6 +8,15 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class StoreLtiToolExtraRequest extends FormRequest
 {
+    public function prepareForValidation(): void
+    {
+        $parameters = $this->getInputSource();
+
+        if (!$parameters->get('slug')) {
+            $parameters->remove('slug');
+        }
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -17,6 +26,7 @@ class StoreLtiToolExtraRequest extends FormRequest
             'name' => ['required', 'string', 'max:100'],
             'lti_launch_url' => ['required', 'url'],
             'admin' => ['sometimes', 'boolean'],
+            'slug' => ['sometimes', 'string', 'max:50', 'regex:/^[a-z0-9-_]+$/'],
         ];
     }
 }

--- a/sourcecode/hub/app/Http/Requests/StoreLtiToolRequest.php
+++ b/sourcecode/hub/app/Http/Requests/StoreLtiToolRequest.php
@@ -10,6 +10,15 @@ use Illuminate\Validation\Rule;
 
 class StoreLtiToolRequest extends FormRequest
 {
+    public function prepareForValidation(): void
+    {
+        $parameters = $this->getInputSource();
+
+        if (!$parameters->get('slug')) {
+            $parameters->remove('slug');
+        }
+    }
+
     /**
      * @return mixed[]
      */

--- a/sourcecode/hub/app/Http/Requests/StoreLtiToolRequest.php
+++ b/sourcecode/hub/app/Http/Requests/StoreLtiToolRequest.php
@@ -24,6 +24,7 @@ class StoreLtiToolRequest extends FormRequest
             'send_name' => ['boolean'],
             'send_email' => ['boolean'],
             'proxy_launch' => ['boolean'],
+            'slug' => ['sometimes', 'string', 'max:50', 'regex:/^[a-z0-9-_]+$/'],
         ];
     }
 }

--- a/sourcecode/hub/app/Models/LtiTool.php
+++ b/sourcecode/hub/app/Models/LtiTool.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use LogicException;
 
 use function assert;
 
@@ -56,7 +57,15 @@ class LtiTool extends Model
         'send_email',
         'proxy_launch',
         'edit_mode',
+        'slug',
     ];
+
+    public static function booted(): void
+    {
+        static::creating(function (self $tool) {
+            $tool->slug ??= $tool->id ?? throw new LogicException('expected an ID');
+        });
+    }
 
     /**
      * @return HasMany<ContentVersion, $this>

--- a/sourcecode/hub/app/Models/LtiToolExtra.php
+++ b/sourcecode/hub/app/Models/LtiToolExtra.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use LogicException;
 
 class LtiToolExtra extends Model
 {
@@ -35,7 +36,15 @@ class LtiToolExtra extends Model
         'name',
         'lti_launch_url',
         'admin',
+        'slug',
     ];
+
+    public static function booted(): void
+    {
+        static::creating(function (self $tool) {
+            $tool->slug ??= $tool->id ?? throw new LogicException('expected an ID');
+        });
+    }
 
     /**
      * @return BelongsTo<LtiTool, $this>

--- a/sourcecode/hub/database/factories/LtiToolExtraFactory.php
+++ b/sourcecode/hub/database/factories/LtiToolExtraFactory.php
@@ -20,11 +20,17 @@ final class LtiToolExtraFactory extends Factory
             'lti_tool_id' => LtiTool::factory(),
             'lti_launch_url' => $this->faker->url,
             'admin' => $this->faker->boolean,
+            'slug' => $this->faker->unique()->slug(nbWords: 2),
         ];
     }
 
     public function admin(bool $admin = true): self
     {
         return $this->state(['admin' => $admin]);
+    }
+
+    public function slug(string $slug): self
+    {
+        return $this->state(['slug' => $slug]);
     }
 }

--- a/sourcecode/hub/database/factories/LtiToolFactory.php
+++ b/sourcecode/hub/database/factories/LtiToolFactory.php
@@ -24,7 +24,13 @@ final class LtiToolFactory extends Factory
             'send_name' => $this->faker->boolean,
             'send_email' => $this->faker->boolean,
             'proxy_launch' => $this->faker->boolean,
+            'slug' => $this->faker->unique()->slug(nbWords: 2),
         ];
+    }
+
+    public function slug(string $slug): self
+    {
+        return $this->state(['slug' => $slug]);
     }
 
     public function launchUrl(string $launchUrl): self

--- a/sourcecode/hub/database/migrations/2024_12_11_080000_add_lti_tool_slug.php
+++ b/sourcecode/hub/database/migrations/2024_12_11_080000_add_lti_tool_slug.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class () extends Migration {
     public function up(): void
     {
         Schema::table('lti_tools', function (Blueprint $table) {

--- a/sourcecode/hub/database/migrations/2024_12_11_080000_add_lti_tool_slug.php
+++ b/sourcecode/hub/database/migrations/2024_12_11_080000_add_lti_tool_slug.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('lti_tools', function (Blueprint $table) {
+            $table->string('slug')->nullable();
+
+            $table->unique(['slug']);
+        });
+
+        Schema::table('lti_tool_extras', function (Blueprint $table) {
+            $table->string('slug')->nullable();
+
+            $table->unique(['lti_tool_id', 'slug']);
+        });
+
+        DB::update('UPDATE lti_tools SET slug = id');
+        DB::update('UPDATE lti_tool_extras SET slug = id');
+
+        Schema::table('lti_tools', function (Blueprint $table) {
+            $table->string('slug')->nullable(false)->change();
+        });
+
+        Schema::table('lti_tool_extras', function (Blueprint $table) {
+            $table->string('slug')->nullable(false)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('lti_tools', function (Blueprint $table) {
+            $table->dropColumn('slug');
+        });
+
+        Schema::table('lti_tool_extras', function (Blueprint $table) {
+            $table->dropColumn('slug');
+        });
+    }
+};

--- a/sourcecode/hub/lang/en/messages.php
+++ b/sourcecode/hub/lang/en/messages.php
@@ -215,4 +215,5 @@ return [
     'lti-platform-authorizes-edit' => 'The platform authorizes edit access',
     'lti-platform-authorizes-edit-help' => 'Transfers responsibility for access control of editing from :site to the platform, i.e. :site will accept all valid edit requests from the platform',
     'dangerous-lti-platform-settings' => 'These settings are dangerous, and should only be enabled for trusted platforms with email verification.',
+    'url-slug' => 'URL slug',
 ];

--- a/sourcecode/hub/resources/views/admin/lti-tools/add-extra.blade.php
+++ b/sourcecode/hub/resources/views/admin/lti-tools/add-extra.blade.php
@@ -4,6 +4,8 @@
     <x-form :action="route('admin.lti-tools.store-extra', [$tool])" method="POST">
         <x-form.field name="name" :label="trans('messages.name')" />
 
+        <x-form.field name="slug" :label="trans('messages.url-slug')" />
+
         <x-form.field name="lti_launch_url" :label="trans('messages.lti-launch-url')" />
 
         <div class="form-check mb-3">

--- a/sourcecode/hub/resources/views/admin/lti-tools/add.blade.php
+++ b/sourcecode/hub/resources/views/admin/lti-tools/add.blade.php
@@ -19,6 +19,11 @@ use App\Enums\LtiToolEditMode;
         />
 
         <x-form.field
+            name="slug"
+            :label="trans('messages.url-slug')"
+        />
+
+        <x-form.field
             name="creator_launch_url"
             inputmode="url"
             required

--- a/sourcecode/hub/resources/views/admin/lti-tools/index.blade.php
+++ b/sourcecode/hub/resources/views/admin/lti-tools/index.blade.php
@@ -32,6 +32,10 @@
                                 </td>
                             </tr>
                             <tr>
+                                <th scope="row">{{ trans('messages.url-slug') }}</th>
+                                <td>{{ $tool->slug }}</td>
+                            </tr>
+                            <tr>
                                 <th scope="row">Associated resources</th>
                                 <td>{{ $tool->content_versions_count }}</td>
                             </tr>
@@ -55,6 +59,7 @@
                     <table class="table table-striped">
                         <thead>
                             <th>{{ trans('messages.name') }}</th>
+                            <th>{{ trans('messages.url-slug') }}</th>
                             <th>{{ trans('messages.lti-launch-url') }}</th>
                             <th>{{ trans('messages.admin-tool') }}
                             <th></th>
@@ -64,6 +69,7 @@
                             @foreach ($tool->extras as $extra)
                                 <tr>
                                     <td>{{ $extra->name }}</td>
+                                    <td>{{ $extra->slug }}</td>
                                     <td>{{ $extra->lti_launch_url }}</td>
                                     <td>{{ $extra->admin ? trans('messages.yes') : trans('messages.no') }}</td>
                                     <td>

--- a/sourcecode/hub/routes/web.php
+++ b/sourcecode/hub/routes/web.php
@@ -152,11 +152,11 @@ Route::controller(ContentController::class)->group(function () {
         ->can('delete', 'content')
         ->whereUlid('content');
 
-    Route::get('/content/create/{tool}/{extra?}', 'launchCreator')
+    Route::get('/content/create/{tool:slug}/{extra:slug?}', 'launchCreator')
+        ->uses([ContentController::class, 'launchCreator'])
         ->name('content.launch-creator')
         ->can('create', \App\Models\Content::class)
         ->can('launchCreator', ['tool', 'extra'])
-        ->whereUlid('tool')
         ->scopeBindings();
 });
 

--- a/sourcecode/hub/tests/Browser/AdminTest.php
+++ b/sourcecode/hub/tests/Browser/AdminTest.php
@@ -105,7 +105,8 @@ final class AdminTest extends DuskTestCase
         $platform = LtiPlatform::factory()->create();
         $user = User::factory()->admin()->create();
 
-        $this->browse(fn (Browser $browser) =>
+        $this->browse(
+            fn (Browser $browser) =>
             $browser
                 ->loginAs($user->email)
                 ->assertAuthenticated()

--- a/sourcecode/hub/tests/Browser/AdminTest.php
+++ b/sourcecode/hub/tests/Browser/AdminTest.php
@@ -89,6 +89,7 @@ final class AdminTest extends DuskTestCase
                 ->type('lti_launch_url', 'https://hub-test.edlib.test/lti/samples/resize')
                 ->check('admin')
                 ->press('Add')
+                ->assertSee('The extra endpoint was added')
                 ->visit('/admin')
                 ->clickLink('LTI extra test')
                 ->withinFrame(
@@ -96,6 +97,34 @@ final class AdminTest extends DuskTestCase
                     fn (Browser $frame) => $frame
                         ->press('Resize to 640')
                 )
+        );
+    }
+
+    public function testCreatesToolsWithSlug(): void
+    {
+        $platform = LtiPlatform::factory()->create();
+        $user = User::factory()->admin()->create();
+
+        $this->browse(fn (Browser $browser) =>
+            $browser
+                ->loginAs($user->email)
+                ->assertAuthenticated()
+                ->visit('/')
+                ->press($user->name)
+                ->clickLink('Admin home')
+                ->clickLink('Manage LTI tools')
+                ->clickLink('Add LTI tool')
+                ->type('name', 'The tool')
+                ->type('slug', 'the-tool')
+                ->type('creator_launch_url', 'https://hub-test.edlib.test/lti/samples/resize')
+                ->type('consumer_key', $platform->key)
+                ->type('consumer_secret', $platform->secret)
+                ->press('Add')
+                ->assertSee('LTI tool added')
+                ->clickLink('Create')
+                ->clickLink('The tool')
+                ->assertUrlIs('https://hub-test.edlib.test/content/create/the-tool')
+                ->assertPresent('.lti-launch')
         );
     }
 }

--- a/sourcecode/hub/tests/Browser/ContentTest.php
+++ b/sourcecode/hub/tests/Browser/ContentTest.php
@@ -183,7 +183,7 @@ final class ContentTest extends DuskTestCase
 
         $platform = LtiPlatform::factory()->create();
 
-        $tool = LtiTool::factory()->create([
+        LtiTool::factory()->slug('the-tool')->create([
             'name' => 'Edlib 3',
             'consumer_key' => $platform->key,
             'consumer_secret' => $platform->secret,
@@ -191,7 +191,7 @@ final class ContentTest extends DuskTestCase
             'send_email' => true,
         ]);
 
-        $this->browse(function (Browser $browser) use ($content, $tool, $user) {
+        $this->browse(function (Browser $browser) use ($content, $user) {
             $browser
                 ->visit('/login')
                 // FIXME: it seems buttons in iframes cannot be clicked, even if
@@ -202,7 +202,7 @@ final class ContentTest extends DuskTestCase
                 ->type('password', 'password')
                 ->press('Log in')
                 ->assertAuthenticated()
-                ->visit('/content/create/' . $tool->id)
+                ->visit('/content/create/the-tool')
                 ->assertPresent('.lti-launch')
                 ->withinFrame('.lti-launch', function (Browser $iframe) use ($content) {
                     $iframe
@@ -309,7 +309,8 @@ final class ContentTest extends DuskTestCase
     public function testUsesContentViaButtonInPreviewModal(): void
     {
         $ltiPlatform = LtiPlatform::factory()->create();
-        $ltiTool = LtiTool::factory()
+        LtiTool::factory()
+            ->slug('the-tool')
             ->state(['creator_launch_url' => 'https://hub-test.edlib.test/lti/dl'])
             ->withCredentials($ltiPlatform->getOauth1Credentials())
             ->create();
@@ -323,7 +324,7 @@ final class ContentTest extends DuskTestCase
         $this->browse(
             fn (Browser $browser) => $browser
                 ->loginAs($user->email)
-                ->visit('/content/create/' . $ltiTool->id)
+                ->visit('/content/create/the-tool')
                 ->waitFor('iframe.lti-launch')
                 ->withinFrame(
                     '.lti-launch',
@@ -403,7 +404,8 @@ final class ContentTest extends DuskTestCase
     public function testContentCardsHaveUseButtonAfterSearchingInLtiContext(): void
     {
         $platform = LtiPlatform::factory()->create();
-        $tool = LtiTool::factory()
+        LtiTool::factory()
+            ->slug('the-tool')
             ->state(['creator_launch_url' => route('lti.select')])
             ->withCredentials($platform->getOauth1Credentials())
             ->create();
@@ -423,7 +425,7 @@ final class ContentTest extends DuskTestCase
         $this->browse(fn (Browser $browser) => $browser
             ->loginAs(User::factory()->create()->email)
             ->assertAuthenticated()
-            ->visit('/content/create/' . $tool->id)
+            ->visit('/content/create/the-tool')
             ->withinFrame('.lti-launch', fn (Browser $frame) => $frame
                 ->assertSee('found content')
                 ->assertSee('excluded content')
@@ -482,7 +484,8 @@ final class ContentTest extends DuskTestCase
     public function testCreatesDraftVersions(): void
     {
         $platform = LtiPlatform::factory()->create();
-        $tool = LtiTool::factory()
+        LtiTool::factory()
+            ->slug('the-tool')
             ->withCredentials($platform->getOauth1Credentials())
             ->create();
 
@@ -490,7 +493,7 @@ final class ContentTest extends DuskTestCase
             fn (Browser $browser) => $browser
                 ->loginAs(User::factory()->create()->email)
                 ->assertAuthenticated()
-                ->visit('/content/create/' . $tool->id)
+                ->visit('/content/create/the-tool')
                 ->withinFrame(
                     '.lti-launch',
                     fn (Browser $browser) => $browser
@@ -526,7 +529,8 @@ final class ContentTest extends DuskTestCase
     public function testCreatesContentWithContentTypeTag(): void
     {
         $platform = LtiPlatform::factory()->create();
-        $tool = LtiTool::factory()
+        LtiTool::factory()
+            ->slug('the-tool')
             ->withCredentials($platform->getOauth1Credentials())
             ->create();
 
@@ -534,7 +538,7 @@ final class ContentTest extends DuskTestCase
             fn (Browser $browser) => $browser
                 ->loginAs(User::factory()->create()->email)
                 ->assertAuthenticated()
-                ->visit('/content/create/' . $tool->id)
+                ->visit('/content/create/the-tool')
                 ->withinFrame(
                     '.lti-launch',
                     fn (Browser $browser) => $browser
@@ -576,13 +580,15 @@ final class ContentTest extends DuskTestCase
     public function testEnsuresContentReturnedToLtiPlatformIsPublished(): void
     {
         $platform = LtiPlatform::factory()->create();
-        $edlib3 = LtiTool::factory()
+        LtiTool::factory()
+            ->slug('edlib-3')
             ->withName('Edlib 3')
             ->withCredentials($platform->getOauth1Credentials())
             ->launchUrl('https://hub-test.edlib.test/lti/dl')
             ->state(['send_name' => true, 'send_email' => true])
             ->create();
         LtiTool::factory()
+            ->slug('sample-tool')
             ->withName('Sample tool')
             ->withCredentials($platform->getOauth1Credentials())
             ->launchUrl('https://hub-test.edlib.test/lti/samples/deep-link')
@@ -593,7 +599,7 @@ final class ContentTest extends DuskTestCase
             fn (Browser $browser) => $browser
                 ->loginAs(User::factory()->create()->email)
                 ->assertAuthenticated()
-                ->visit('/content/create/' . $edlib3->id)
+                ->visit('/content/create/edlib-3')
                 ->waitFor('iframe.lti-launch')
                 ->withinFrame(
                     '.lti-launch',

--- a/sourcecode/hub/tests/DuskTestCase.php
+++ b/sourcecode/hub/tests/DuskTestCase.php
@@ -19,7 +19,6 @@ use function is_string;
 
 abstract class DuskTestCase extends BaseTestCase
 {
-    use CreatesApplication;
     use DatabaseTruncation;
 
     /**

--- a/sourcecode/hub/tests/DuskTestCase.php
+++ b/sourcecode/hub/tests/DuskTestCase.php
@@ -19,6 +19,7 @@ use function is_string;
 
 abstract class DuskTestCase extends BaseTestCase
 {
+    use CreatesApplication;
     use DatabaseTruncation;
 
     /**

--- a/sourcecode/hub/tests/Feature/Admin/AdminTest.php
+++ b/sourcecode/hub/tests/Feature/Admin/AdminTest.php
@@ -40,10 +40,13 @@ final class AdminTest extends TestCase
 
     public function testNonAdminsCannotUseAdminEndpoints(): void
     {
-        $tool = LtiTool::factory()->extra(LtiToolExtra::factory()->admin())->create();
+        LtiTool::factory()
+            ->slug('the-tool')
+            ->extra(LtiToolExtra::factory()->slug('the-extra')->admin())
+            ->create();
 
         $this->actingAs(User::factory()->create())
-            ->get('/content/create/' . $tool->id . '/' . $tool->extras->firstOrFail()->id)
+            ->get('/content/create/the-tool/the-extra')
             ->assertForbidden();
     }
 }

--- a/sourcecode/hub/tests/Feature/Commands/AddLtiToolTest.php
+++ b/sourcecode/hub/tests/Feature/Commands/AddLtiToolTest.php
@@ -19,6 +19,7 @@ class AddLtiToolTest extends TestCase
         $this->command('edlib:add-lti-tool', [
             'name' => 'Content Author',
             'url' => 'https://ca.edlib.test/lti-content/create',
+            '--slug' => 'sluggish-tool',
             '--send-name' => true,
             '--send-email' => true,
             '--edlib-editable' => true,
@@ -37,5 +38,6 @@ class AddLtiToolTest extends TestCase
         $this->assertSame('secret2', $tool->consumer_secret);
         $this->assertSame(LtiToolEditMode::DeepLinkingRequestToContentUrl, $tool->edit_mode);
         $this->assertSame(LtiVersion::Lti1_1, $tool->lti_version);
+        $this->assertSame('sluggish-tool', $tool->slug);
     }
 }


### PR DESCRIPTION
Adds human-friendly URL slugs for LTI tools and the non-admin extras.

Before (awful):
- https://hub.edlib.test/content/create/01j713jgj0yfp0zac2ffb0myjg
- https://hub.edlib.test/content/create/01j713jgj0yfp0zac2ffb0myjg/01jeb378mhgabn5fpwajpt95sn

After:
- https://hub.edlib.test/content/create/contentauthor
- https://hub.edlib.test/content/create/contentauthor/article

The ID is used as the slug for existing tools.