### PR TITLE
hub: fix unsetting flags on tools

### DIFF
--- a/sourcecode/hub/app/Http/Requests/UpdateLtiToolRequest.php
+++ b/sourcecode/hub/app/Http/Requests/UpdateLtiToolRequest.php
@@ -21,6 +21,10 @@ final class UpdateLtiToolRequest extends FormRequest
         if (!$parameters->get('slug')) {
             $parameters->remove('slug');
         }
+
+        $parameters->set('send_name', $parameters->getBoolean('send_name', false));
+        $parameters->set('send_email', $parameters->getBoolean('send_email', false));
+        $parameters->set('proxy_launch', $parameters->getBoolean('proxy_launch', false));
     }
 
     /**

--- a/sourcecode/hub/database/factories/LtiToolFactory.php
+++ b/sourcecode/hub/database/factories/LtiToolFactory.php
@@ -38,7 +38,17 @@ final class LtiToolFactory extends Factory
         return $this->state(['creator_launch_url' => $launchUrl]);
     }
 
-    public function proxyLaunch(bool $proxyLaunch): self
+    public function sendName(bool $sendName = true): self
+    {
+        return $this->state(['send_name' => $sendName]);
+    }
+
+    public function sendEmail(bool $sendEmail = true): self
+    {
+        return $this->state(['send_email' => $sendEmail]);
+    }
+
+    public function proxyLaunch(bool $proxyLaunch = true): self
     {
         return $this->state(['proxy_launch' => $proxyLaunch]);
     }

--- a/sourcecode/hub/resources/views/admin/lti-tools/index.blade.php
+++ b/sourcecode/hub/resources/views/admin/lti-tools/index.blade.php
@@ -5,7 +5,7 @@
 
     <div class="d-flex flex-column gap-3">
         @foreach ($tools as $tool)
-            <article class="card">
+            <article class="card lti-tool-card">
                 <div class="card-header">
                     <strong class="card-title">{{ $tool->name }}</strong>
                 </div>
@@ -41,15 +41,15 @@
                             </tr>
                             <tr>
                                 <th scope="row">{{ trans('messages.send-full-name-to-lti-tool', ['site' => config('app.name')]) }}</th>
-                                <td>{{ $tool->send_name ? trans('messages.yes') : trans('messages.no') }}</td>
+                                <td class="lti-tool-card-send-name">{{ $tool->send_name ? trans('messages.yes') : trans('messages.no') }}</td>
                             </tr>
                             <tr>
                                 <th scope="row">{{ trans('messages.send-email-to-lti-tool', ['site' => config('app.name')]) }}</th>
-                                <td>{{ $tool->send_email ? trans('messages.yes') : trans('messages.no') }}</td>
+                                <td class="lti-tool-card-send-email">{{ $tool->send_email ? trans('messages.yes') : trans('messages.no') }}</td>
                             </tr>
                             <tr>
                                 <th scope="row">{{ trans('messages.proxy-launch-to-lti-tool', ['site' => config('app.name')]) }}</th>
-                                <td>{{ $tool->proxy_launch ? trans('messages.yes') : trans('messages.no') }}</td>
+                                <td class="lti-tool-card-proxy-launch">{{ $tool->proxy_launch ? trans('messages.yes') : trans('messages.no') }}</td>
                             </tr>
                         </tbody>
                     </table>

--- a/sourcecode/hub/tests/Browser/AdminTest.php
+++ b/sourcecode/hub/tests/Browser/AdminTest.php
@@ -163,7 +163,8 @@ final class AdminTest extends DuskTestCase
             ->proxyLaunch()
             ->create();
 
-        $this->browse(fn (Browser $browser) =>
+        $this->browse(
+            fn (Browser $browser) =>
             $browser
                 ->loginAs($user->email)
                 ->assertAuthenticated()
@@ -171,7 +172,9 @@ final class AdminTest extends DuskTestCase
                 ->press('Flagg Stang')
                 ->clickLink('Admin home')
                 ->clickLink('Manage LTI tools')
-                ->with(new LtiToolCard(), fn (Browser $card) =>
+                ->with(
+                    new LtiToolCard(),
+                    fn (Browser $card) =>
                     $card
                         ->assertSeeIn('@proxy-launch', 'Yes')
                         ->assertSeeIn('@send-email', 'Yes')
@@ -189,7 +192,9 @@ final class AdminTest extends DuskTestCase
                 ->press('Flagg Stang')
                 ->clickLink('Admin home')
                 ->clickLink('Manage LTI tools')
-                ->with(new LtiToolCard(), fn (Browser $card) =>
+                ->with(
+                    new LtiToolCard(),
+                    fn (Browser $card) =>
                     $card
                         ->assertSeeIn('@proxy-launch', 'No')
                         ->assertSeeIn('@send-email', 'No')

--- a/sourcecode/hub/tests/Browser/Components/LtiToolCard.php
+++ b/sourcecode/hub/tests/Browser/Components/LtiToolCard.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Browser\Components;
+
+use Laravel\Dusk\Browser;
+use Laravel\Dusk\Component;
+
+final class LtiToolCard extends Component
+{
+    public function selector(): string
+    {
+        return '.lti-tool-card';
+    }
+
+    public function assert(Browser $browser): void
+    {
+        $browser->assertVisible($this->selector());
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function elements(): array
+    {
+        return [
+            '@proxy-launch' => '.lti-tool-card-proxy-launch',
+            '@send-email' => '.lti-tool-card-send-email',
+            '@send-name' => '.lti-tool-card-send-name',
+        ];
+    }
+}


### PR DESCRIPTION
`$tool->fill($request->validated())` didn't work correctly, as unchecked checkboxes don't "exist" in the form data.