### PR TITLE
GH #2855: Fix race condition in LockStatusTest

### DIFF
--- a/sourcecode/apis/contentauthor/app/Http/Controllers/API/LockStatusController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/API/LockStatusController.php
@@ -5,7 +5,6 @@ namespace App\Http\Controllers\API;
 use App\Content;
 use App\ContentLock;
 use App\Libraries\DataObjects\ContentLockDataObject;
-use Carbon\Carbon;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Session;
 
@@ -56,9 +55,8 @@ class LockStatusController extends Controller
 
         /** @var ContentLock $lock */
         $lock = ContentLock::notExpiredById($id);
-        if ($lock && $lock->auth_id === $userId && Carbon::now()->subHours(config('feature.lock-max-hours'))->lessThan($lock->created_at)) {
-            $lock->updated_at = Carbon::now();
-            $lock->save();
+        if ($lock && $lock->auth_id === $userId && $lock->created_at->addHours(config('feature.lock-max-hours'))->isFuture()) {
+            $lock->touch();
         }
     }
 }

--- a/sourcecode/apis/contentauthor/tests/Integration/Models/ContentLockTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Models/ContentLockTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tests\Integration\Models;
+
+use App\ContentLock;
+use App\H5PContent;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use PHPUnit\Framework\Attributes\TestWith;
+use Tests\TestCase;
+
+class ContentLockTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithFaker;
+
+    public function testLock(): void
+    {
+        $user = User::factory()->make();
+        $this->session([
+            'authId' => $user->auth_id,
+            'name' => $user->name,
+            'email' => $user->email,
+        ]);
+
+        $content = H5PContent::factory()->create([
+            'user_id' => $user->auth_id,
+        ]);
+
+        $this->assertDatabaseEmpty('content_locks');
+        (new ContentLock())->lock($content->id);
+
+        $this->assertDatabaseHas('content_locks', [
+            'content_id' => $content->id,
+            'auth_id' => $user->auth_id,
+            'email' => $user->email,
+            'name' => $user->name,
+        ]);
+    }
+
+    public function testUnlock(): void
+    {
+        $user = User::factory()->make();
+        $content = H5PContent::factory()->create([
+            'user_id' => $user->auth_id,
+        ]);
+        ContentLock::factory()->create([
+            'content_id' => $content->id,
+            'auth_id' => $user->auth_id,
+            'email' => $user->email,
+            'name' => $user->name,
+        ]);
+        $this->assertDatabaseHas('content_locks', [
+            'content_id' => $content->id,
+            'auth_id' => $user->auth_id,
+            'email' => $user->email,
+            'name' => $user->name,
+        ]);
+
+        (new ContentLock())->unlock($content->id);
+
+        $this->assertDatabaseEmpty('content_locks');
+    }
+
+    #[TestWith([true], 'Current user has active lock')]
+    #[TestWith([false], 'Other user has active lock')]
+    public function testHasLock(bool $asLockOwner): void
+    {
+        $lockOwner = User::factory()->make();
+        $user = $asLockOwner ? $lockOwner : User::factory()->make();
+
+        $this->session([
+            'authId' => $user->auth_id,
+            'name' => $user->name,
+            'email' => $user->email,
+        ]);
+        $content = H5PContent::factory()->create();
+
+        $this->assertNull((new ContentLock())->hasLock($content->id));
+
+        ContentLock::factory()->create([
+            'content_id' => $content->id,
+            'auth_id' => $lockOwner->auth_id,
+            'email' => $lockOwner->email,
+            'name' => $lockOwner->name,
+        ]);
+
+        $activeLock = (new ContentLock())->hasLock($content->id);
+
+        if ($asLockOwner) {
+            $this->assertFalse($activeLock);
+        } else {
+            $this->assertInstanceOf(ContentLock::class, $activeLock);
+            $this->assertSame($lockOwner->auth_id, $activeLock->auth_id);
+        }
+    }
+}


### PR DESCRIPTION
The race condition:
The `updated_at` was updated by doing a POST to the `lock.status` endpoint. Then the `ContentLock` model was used to update the `created_at` value, `updated_at` would be set by the framework and could get a new value. The  test assumed that `updated_at` would be unchanged by the model update.

- Move testing of lock update from `testLockStatusWithActivePulseButExpired()` to new test `testLockUpdate()`
- Add tests for `ContentLock` model functions
- Minor adjustment in `LockStatusController::pulse()` to make it more readable