### PR TITLE
make phpstan warn about misused functions/statements

### DIFF
--- a/sourcecode/hub/composer.json
+++ b/sourcecode/hub/composer.json
@@ -29,6 +29,7 @@
     "require-dev": {
         "barryvdh/laravel-ide-helper": "^3.2.2",
         "cache/array-adapter": "^1.2",
+        "ekino/phpstan-banned-code": "^3.0",
         "fakerphp/faker": "^1.24.1",
         "larastan/larastan": "^3",
         "laravel/dusk": "^8.2.12",

--- a/sourcecode/hub/composer.lock
+++ b/sourcecode/hub/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cac6593ef57a377adbb1c6da08a4594a",
+    "content-hash": "d6db6ce25bdfab092c2f59bcfd120fc6",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -8322,6 +8322,72 @@
                 "source": "https://github.com/doctrine/deprecations/tree/1.1.4"
             },
             "time": "2024-12-07T21:18:45+00:00"
+        },
+        {
+            "name": "ekino/phpstan-banned-code",
+            "version": "v3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ekino/phpstan-banned-code.git",
+                "reference": "27122aa1783d6521e500c0c397c53244cfbde26f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ekino/phpstan-banned-code/zipball/27122aa1783d6521e500c0c397c53244cfbde26f",
+                "reference": "27122aa1783d6521e500c0c397c53244cfbde26f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1",
+                "phpstan/phpstan": "^2.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.6",
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "nikic/php-parser": "^4.3",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/var-dumper": "^5.0"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ekino\\PHPStanBannedCode\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rémi Marseille",
+                    "email": "remi.marseille@ekino.com",
+                    "homepage": "https://www.ekino.com"
+                }
+            ],
+            "description": "Detected banned code using PHPStan",
+            "homepage": "https://github.com/ekino/phpstan-banned-code",
+            "keywords": [
+                "PHPStan",
+                "code quality",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/ekino/phpstan-banned-code/issues",
+                "source": "https://github.com/ekino/phpstan-banned-code/tree/v3.0.0"
+            },
+            "time": "2024-11-13T09:57:22+00:00"
         },
         {
             "name": "fakerphp/faker",

--- a/sourcecode/hub/phpstan.dist.neon
+++ b/sourcecode/hub/phpstan.dist.neon
@@ -1,4 +1,5 @@
 includes:
+    - vendor/ekino/phpstan-banned-code/extension.neon
     - vendor/larastan/larastan/extension.neon
     - phpstan-baseline.neon
 
@@ -17,3 +18,21 @@ parameters:
     checkModelProperties: true
 
     treatPhpDocTypesAsCertain: false
+
+    banned_code:
+        nodes:
+            -
+                type: Expr_FuncCall
+                functions:
+                    - dd
+                    - dump
+                    - phpinfo
+                    - print_r
+                    - printf
+                    - var_dump
+            -   { type: Expr_ShellExec, functions: null }
+            -   { type: Stmt_Echo, functions: null }
+            -   { type: Stmt_Exit, functions: null }
+            -   { type: Stmt_Print, functions: null }
+
+        use_from_tests: true


### PR DESCRIPTION
Similar to what CA has. Primarily to avoid committing `dd()` and such.