### PR TITLE
CA Admin: Use tabs on manage content type page, add descriptions and help text. Rename 'Update libraries' to 'Manage content types'

### DIFF
--- a/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/LibraryUpgradeController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/LibraryUpgradeController.php
@@ -15,6 +15,7 @@ use H5PCore;
 use H5PFrameworkInterface;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Http\UploadedFile;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -99,24 +100,26 @@ class LibraryUpgradeController extends Controller
         }
 
         $available = collect();
-        $hubCacheLibraries
-            ->each(function ($hubCache) use ($contentTypes, $available) {
-                $hasLast = $contentTypes->where('machineName', $hubCache->name)->firstWhere('isLast', true);
-                if (empty($hasLast)) {
-                    $available->push([
-                        'machineName' => $hubCache->name,
-                        'majorVersion' => $hubCache->major_version,
-                        'minorVersion' => $hubCache->minor_version,
-                        'title' => sprintf('%s (%d.%d.%d)', $hubCache->title, $hubCache->major_version, $hubCache->minor_version, $hubCache->patch_version),
-                        'summary' => $hubCache->summary,
-                        'external_link' => $hubCache->example,
-                        'numContent' => 0,
-                        'numLibraryDependencies' => 0,
-                        'hubUpgrade' => sprintf('%s.%s.%s', $hubCache->major_version, $hubCache->minor_version, $hubCache->patch_version),
-                        'isLast' => true,
-                    ]);
-                }
-            });
+        if (config('h5p.isHubEnabled')) {
+            $hubCacheLibraries
+                ->each(function ($hubCache) use ($contentTypes, $available) {
+                    $hasLast = $contentTypes->where('machineName', $hubCache->name)->firstWhere('isLast', true);
+                    if (empty($hasLast)) {
+                        $available->push([
+                            'machineName' => $hubCache->name,
+                            'majorVersion' => $hubCache->major_version,
+                            'minorVersion' => $hubCache->minor_version,
+                            'title' => sprintf('%s (%d.%d.%d)', $hubCache->title, $hubCache->major_version, $hubCache->minor_version, $hubCache->patch_version),
+                            'summary' => $hubCache->summary,
+                            'external_link' => $hubCache->example,
+                            'numContent' => 0,
+                            'numLibraryDependencies' => 0,
+                            'hubUpgrade' => sprintf('%s.%s.%s', $hubCache->major_version, $hubCache->minor_version, $hubCache->patch_version),
+                            'isLast' => true,
+                        ]);
+                    }
+                });
+        }
 
         return view('admin.library-upgrade.index', [
             'installedLibraries' => $libraries->sortBy('machineName', SORT_STRING | SORT_FLAG_CASE)->toArray(),
@@ -149,15 +152,15 @@ class LibraryUpgradeController extends Controller
         }
 
         return response()
-            ->redirectToRoute('admin.update-libraries')
+            ->redirectToRoute('admin.update-libraries', ['activetab' => $request->input('activetab')])
             ->withErrors($errors);
     }
 
-    public function checkForUpdates(): RedirectResponse
+    public function checkForUpdates(Request $request): RedirectResponse
     {
         $this->core->updateContentTypeCache();
 
-        return response()->redirectToRoute('admin.update-libraries');
+        return response()->redirectToRoute('admin.update-libraries', ['activetab' => $request->input('activetab')]);
     }
 
     public function deleteLibrary(H5PLibrary $library): Response

--- a/sourcecode/apis/contentauthor/resources/assets/js/admin.js
+++ b/sourcecode/apis/contentauthor/resources/assets/js/admin.js
@@ -60,6 +60,7 @@ function installLibrary(event) {
     const url = element.data('ajax-url')
     const action = element.data('ajax-action');
     const library = element.data('name');
+    const activetab = element.data('ajax-activetab');
 
     element.prop('disabled', true);
     sendRequest(element, url, {
@@ -68,7 +69,13 @@ function installLibrary(event) {
     }, function (response) {
         if (response.success === true) {
             alert('Library installed');
-            window.location.reload();
+            if (typeof activetab === 'string') {
+                const params = new URLSearchParams(location.search);
+                params.set('activetab', activetab);
+                window.location.search = params.toString();
+            } else {
+                window.location.reload();
+            }
         } else {
             console.log(response);
         }
@@ -80,6 +87,7 @@ function rebuildLibrary(event) {
     const url = element.data('ajax-url')
     const action = element.data('ajax-action');
     const libraryId = element.data('libraryid');
+    const activetab = element.data('ajax-activetab');
 
     element.prop('disabled', true);
     sendRequest(element, url, {
@@ -88,7 +96,13 @@ function rebuildLibrary(event) {
     }, function (response) {
         if (response.success === true) {
             alert(response.message);
-            window.location.reload();
+            if (typeof activetab === 'string') {
+                const params = new URLSearchParams(location.search);
+                params.set('activetab', activetab);
+                window.location.search = params.toString();
+            } else {
+                window.location.reload();
+            }
         } else {
             console.log(response);
         }
@@ -100,10 +114,17 @@ function deleteLibrary(event) {
 
     const element = $(event.currentTarget);
     const url = element.data('ajax-url')
+    const activetab = element.data('ajax-activetab');
 
     element.prop('disabled', true);
     sendRequest(element, { method: 'DELETE', url }, null, function () {
         alert('Library deleted');
-        window.location.reload();
+        if (typeof activetab === 'string') {
+            const params = new URLSearchParams(location.search);
+            params.set('activetab', activetab);
+            window.location.search = params.toString();
+        } else {
+            window.location.reload();
+        }
     });
 }

--- a/sourcecode/apis/contentauthor/resources/assets/sass/admin.scss
+++ b/sourcecode/apis/contentauthor/resources/assets/sass/admin.scss
@@ -6,6 +6,8 @@
 
 $questionset-primary-color: #465c6c;
 
+@import "navtabs";
+
 .versioncontent {
   margin-top: 20px;
 }

--- a/sourcecode/apis/contentauthor/resources/assets/sass/navtabs.scss
+++ b/sourcecode/apis/contentauthor/resources/assets/sass/navtabs.scss
@@ -1,0 +1,49 @@
+.panel.with-nav-tabs .panel-heading{
+    padding: 5px 5px 0 5px;
+}
+.panel.with-nav-tabs .nav-tabs{
+    border-bottom: none;
+}
+.panel.with-nav-tabs .nav-justified{
+    margin-bottom: -1px;
+}
+
+.with-nav-tabs.panel-default .nav-tabs > li > a,
+.with-nav-tabs.panel-default .nav-tabs > li > a:hover,
+.with-nav-tabs.panel-default .nav-tabs > li > a:focus {
+    color: #777;
+}
+.with-nav-tabs.panel-default .nav-tabs > .open > a,
+.with-nav-tabs.panel-default .nav-tabs > .open > a:hover,
+.with-nav-tabs.panel-default .nav-tabs > .open > a:focus,
+.with-nav-tabs.panel-default .nav-tabs > li > a:hover,
+.with-nav-tabs.panel-default .nav-tabs > li > a:focus {
+    color: #777;
+    background-color: #ddd;
+    border-color: transparent;
+}
+.with-nav-tabs.panel-default .nav-tabs > li.active > a,
+.with-nav-tabs.panel-default .nav-tabs > li.active > a:hover,
+.with-nav-tabs.panel-default .nav-tabs > li.active > a:focus {
+    color: #555;
+    background-color: #fff;
+    border-color: #ddd;
+    border-bottom-color: transparent;
+}
+.with-nav-tabs.panel-default .nav-tabs > li.dropdown .dropdown-menu {
+    background-color: #f5f5f5;
+    border-color: #ddd;
+}
+.with-nav-tabs.panel-default .nav-tabs > li.dropdown .dropdown-menu > li > a {
+    color: #777;
+}
+.with-nav-tabs.panel-default .nav-tabs > li.dropdown .dropdown-menu > li > a:hover,
+.with-nav-tabs.panel-default .nav-tabs > li.dropdown .dropdown-menu > li > a:focus {
+    background-color: #ddd;
+}
+.with-nav-tabs.panel-default .nav-tabs > li.dropdown .dropdown-menu > .active > a,
+.with-nav-tabs.panel-default .nav-tabs > li.dropdown .dropdown-menu > .active > a:hover,
+.with-nav-tabs.panel-default .nav-tabs > li.dropdown .dropdown-menu > .active > a:focus {
+    color: #fff;
+    background-color: #555;
+}

--- a/sourcecode/apis/contentauthor/resources/views/admin/fragments/library-table.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/fragments/library-table.blade.php
@@ -41,21 +41,24 @@
                 @if (!empty($library['upgradeUrl']))
                     <a title="Content bulk upgrade" href="{{ $library['upgradeUrl'] }}">
                         <button
-                                type="button"
-                                class="btn btn-info btn-xs h5p-action-button"
-                                title="Content bulk upgrade"
+                            type="button"
+                            class="btn btn-info btn-xs h5p-action-button"
+                            title="Content bulk upgrade"
                         >
                             <span class="fa fa-refresh"></span>
                         </button>
                     </a>
                 @elseif ($library['hubUpgrade'] !== null)
                     <button
-                            type="button"
-                            class="btn btn-success btn-xs install-btn h5p-action-button"
-                            data-name="{{$library['machineName']}}"
-                            data-ajax-url="{{route('admin.ajax')}}"
-                            data-ajax-action="{{H5PEditorEndpoints::LIBRARY_INSTALL}}"
-                            title="Install version {{ $library['hubUpgrade'] }}"
+                        type="button"
+                        class="btn btn-success btn-xs install-btn h5p-action-button"
+                        data-name="{{$library['machineName']}}"
+                        data-ajax-url="{{route('admin.ajax')}}"
+                        data-ajax-action="{{H5PEditorEndpoints::LIBRARY_INSTALL}}"
+                        @isset($activetab)
+                            data-ajax-activetab="{{$activetab}}"
+                        @endisset
+                        title="Download and install version {{ $library['hubUpgrade'] }}"
                     >
                         <span class="fa fa-cloud-download"></span>
                     </button>
@@ -64,22 +67,28 @@
                 @endif
                 @if(!empty($library['libraryId']))
                     <button
-                            type="button"
-                            class="btn btn-warning btn-xs rebuild-btn h5p-action-button"
-                            data-libraryId="{{$library['libraryId']}}"
-                            data-ajax-url="{{route('admin.ajax')}}"
-                            data-ajax-action="{{\App\Libraries\H5P\AjaxRequest::LIBRARY_REBUILD}}"
-                            title="Rebuild"
+                        type="button"
+                        class="btn btn-warning btn-xs rebuild-btn h5p-action-button"
+                        data-libraryId="{{$library['libraryId']}}"
+                        data-ajax-url="{{route('admin.ajax')}}"
+                        data-ajax-action="{{\App\Libraries\H5P\AjaxRequest::LIBRARY_REBUILD}}"
+                        @isset($activetab)
+                            data-ajax-activetab="{{$activetab}}"
+                        @endisset
+                        title="Rebuild"
                     >
                         <span class="fa fa-history"></span>
                     </button>
                 @endif
                 @if(empty($library['numLibraryDependencies']) && !empty($library['libraryId']))
                     <button
-                            type="button"
-                            class="btn btn-danger btn-xs h5p-action-button delete-btn"
-                            data-ajax-url="{{ route('admin.delete-library', [$library['libraryId']]) }}"
-                            title="Delete"
+                        type="button"
+                        class="btn btn-danger btn-xs h5p-action-button delete-btn"
+                        data-ajax-url="{{ route('admin.delete-library', [$library['libraryId']]) }}"
+                        @isset($activetab)
+                            data-ajax-activetab="{{$activetab}}"
+                        @endisset
+                        title="Delete"
                     >
                         <span class="fa fa-trash"></span>
                     </button>

--- a/sourcecode/apis/contentauthor/resources/views/admin/fragments/update-explanation.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/fragments/update-explanation.blade.php
@@ -1,0 +1,8 @@
+Installing or updating content types may also install or update other content types and libraries.
+<br>
+For <dfn title="The first part of the version number, e.g. the 3 in 3.6.42">major</dfn> and
+<dfn title="The middle part of the verison number, e.g. the 6 in 3.6.42">minor</dfn>
+version updates, the new version will be installed in addition to existing versions.
+For <dfn title="The last part of the version number, e.g. the 42 in 3.6.42">patch</dfn>
+version updates, the new version will replace installed version with same major and minor version and lower patch version.
+E.g. new version <code>3.6.42</code> will replace <code>3.6.23</code>, but not <code>3.6.47</code>, <code>3.5.21</code>, <code>2.6.29</code> or <code>3.7.18</code>.

--- a/sourcecode/apis/contentauthor/resources/views/admin/index.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/index.blade.php
@@ -12,7 +12,7 @@
                             <i class="glyphicon glyphicon-edit"></i> Capabilities
                         </a>
                         <a class="col-md-4 well well-lg" href="{{ route('admin.update-libraries') }}">
-                            <i class="glyphicon glyphicon-upload"></i> Update H5P Libraries
+                            <i class="glyphicon glyphicon-upload"></i> Manage H5P content types
                         </a>
                         <a class="col-md-4 well well-lg" href="{{ route('admin.games') }}">
                             <i class="glyphicon glyphicon-upload"></i> Update games

--- a/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/index.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/index.blade.php
@@ -1,85 +1,132 @@
 @extends('layouts.admin')
-
+@php
+    $activeTab = request()->query('activetab', 'tabContentTypes');
+@endphp
 @section('content')
     <div class="container">
+        <div class="page-header">
+            <h1>Manage H5P content types</h1>
+        </div>
         <div class="row">
             <div class="col-md-12">
-                <div id="minor-publishing" class="panel panel-default">
+                <div class="panel with-nav-tabs panel-default">
                     <div class="panel-heading">
-                        <h3>Install or update H5P content types and libraries</h3>
+                        <div class="panel-heading">
+                            <ul class="nav nav-tabs">
+                                <li @class(['active' => $activeTab === 'tabContentTypes'])>
+                                    <a href="#tabContentTypes" data-toggle="tab">
+                                        Installed content types
+                                    </a>
+                                </li>
+                                <li @class(['active' => $activeTab === 'tabLibraries'])>
+                                    <a href="#tabLibraries" data-toggle="tab">
+                                        Installed libraries
+                                    </a>
+                                </li>
+                                <li @class(['active' => $activeTab === 'tabUpload'])>
+                                    <a href="#tabUpload" data-toggle="tab">
+                                        Upload content type
+                                    </a>
+                                </li>
+                                <li @class(['active' => $activeTab === 'tabInstall'])>
+                                    <a href="#tabInstall" data-toggle="tab">
+                                        Install from h5p.org
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
                     </div>
-
-                    <div class="panel-body row">
-                        <form method="post" enctype="multipart/form-data" id="h5p-library-form" class="col-md-6">
-                            <h4>By file upload</h4>
-                            <p>File must be .h5p format.</p>
-                            <input type="file" name="h5p_file" id="h5p-file"/>
-                            <br>
-                            <div class="h5p-disable-file-check">
-                                <label><input type="checkbox" name="h5p_upgrade_only" id="h5p-upgrade-only"/> Only update existing libraries</label>
-                                <br>
-                                <label><input type="checkbox" name="h5p_disable_file_check" id="h5p-disable-file-check"/> Disable file extension check</label>
+                    <div class="panel-body">
+                        <div class="tab-content">
+                            <div
+                                id="tabContentTypes"
+                                @class([
+                                    "tab-pane fade",
+                                    'in active' => $activeTab === 'tabContentTypes',
+                                ])
+                            >
+                                <div class="panel panel-default">
+                                    <div class="panel-heading">
+                                        <h4>Local cache of content types available from h5.org</h4>
+                                    </div>
+                                    @include('admin.library-upgrade.update-content-type-cache', ['activeTab' => 'tabContentTypes'])
+                                </div>
+                                <p>
+                                    The list contains content types that are currently installed in Edlib.
+                                    If available new versions can be downloaded and installed.
+                                </p>
+                                <p>
+                                    @include('admin.fragments.update-explanation')
+                                </p>
+                                <div class="panel-body row">
+                                    @include('admin.fragments.library-table', [
+                                        'libraries' => $installedContentTypes,
+                                        'showCount' => true,
+                                        'activetab' => 'tabContentTypes'
+                                    ])
+                                </div>
                             </div>
-                            <br>
-                            <input type="hidden" id="lets_upgrade_that" name="lets_upgrade_that" value="228e7591a1">
-                            <input type="hidden" name="_wp_http_referer" value="/wordpress/wp-admin/admin.php?page=h5p_libraries">
-                            {!! csrf_field() !!}
-                            <div id="major-publishing-actions" class="submitbox">
-                                <input type="submit" name="submit" value="Upload" class="button button-primary button-large btn btn-primary"/>
+                            <div
+                                @class([
+                                    "tab-pane fade",
+                                    'in active' => $activeTab === 'tabLibraries',
+                                ])
+                                id="tabLibraries"
+                            >
+                                <p>Libraries are used by content types, and are installed/updated when content types are installed/updated.</p>
+                                <div class="panel-body row">
+                                    @include('admin.fragments.library-table', [
+                                        'libraries' => $installedLibraries,
+                                        'showCount' => true,
+                                        'activetab' => 'tabLibraries'
+                                    ])
+                                </div>
                             </div>
-                        </form>
-
-                        <form action="{{ route('admin.check-for-updates') }}" method="post">
-                            @csrf
-                            <h4>Content types from h5p.org</h4>
-                            <div style="margin: 1em 0;">Last updated:
-                                @isset($contentTypeCacheUpdateAt)
-                                    {{ \Carbon\Carbon::createFromTimestamp($contentTypeCacheUpdateAt)->format('Y-m-d H:i:s e') }}
-                                @endempty
+                            <div
+                                id="tabUpload"
+                                @class([
+                                    "tab-pane fade",
+                                    'in active' => $activeTab === 'tabUpload',
+                                ])
+                            >
+                                <h4>Install or update H5P content types and libraries by uploading a file in <code>.h5p</code> format.</h4>
+                                <p>Any content in the file will not be imported, only content types and libraries.</p>
+                                <p>
+                                    @include('admin.fragments.update-explanation')
+                                </p>
+                                @include('admin.library-upgrade.upload-content-type', [
+                                    'activetab' => 'tabUpload',
+                                ])
                             </div>
-                            <button type="submit" class="btn btn-success">Check for updates</button>
-                        </form>
-                    </div>
-
-                    @include('fragments.invalidFlashMessage')
-                </div>
-
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h3>Content types installed</h3>
-                    </div>
-
-                    <div class="panel-body row">
-                        @include('admin.fragments.library-table', [
-                            'libraries' => $installedContentTypes,
-                            'showCount' => true,
-                        ])
-                    </div>
-                </div>
-
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h3>Libraries installed</h3>
-                    </div>
-
-                    <div class="panel-body row">
-                        @include('admin.fragments.library-table', [
-                            'libraries' => $installedLibraries,
-                            'showCount' => true,
-                        ])
-                    </div>
-                </div>
-
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <h3>Install from H5P.org</h3>
-                    </div>
-
-                    <div class="panel-body row">
-                        @include('admin.fragments.library-table', [
-                            'libraries' => $available,
-                            'showSummary' => true,
-                        ])
+                            <div
+                                id="tabInstall"
+                                @class([
+                                    "tab-pane fade",
+                                    'in active' => $activeTab === 'tabInstall',
+                                ])
+                            >
+                                <div class="panel panel-default">
+                                    <div class="panel-heading">
+                                        <h4>Local cache of content types available from h5.org</h4>
+                                    </div>
+                                    @include('admin.library-upgrade.update-content-type-cache', ['activeTab' => 'tabInstall'])
+                                </div>
+                                <h4>Content types available from <a href="https://h5p.org" target="_blank">h5p.org</a></h4>
+                                <p>
+                                    The list contains content types that was available when the local cache was updated. Available content types are maintained by H5P Group.
+                                </p>
+                                <p>
+                                    @include('admin.fragments.update-explanation')
+                                </p>
+                                <div class="panel-body row">
+                                    @include('admin.fragments.library-table', [
+                                        'libraries' => $available,
+                                        'showSummary' => true,
+                                        'activetab' => 'tabInstall'
+                                    ])
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/update-content-type-cache.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/update-content-type-cache.blade.php
@@ -1,0 +1,21 @@
+@if (config('h5p.isHubEnabled') === true)
+    <form action="{{ route('admin.check-for-updates', isset($activeTab) ? ['activetab' => $activeTab] : []) }}" method="post">
+        <div class="panel-body">
+            @isset($contentTypeCacheUpdateAt)
+                Last updated
+                <strong>
+                    {{ \Carbon\Carbon::createFromTimestamp($contentTypeCacheUpdateAt)->format('Y-m-d H:i:s e') }}
+                </strong>
+            @else
+                Could not find last update time, click the 'Update' button to refresh the cache.
+                This will also register the installation with the h5p.org hub if not registered.
+            @endisset
+        </div>
+        <div class="panel-body">
+            @csrf
+            <button type="submit" class="btn btn-success">Update</button>
+        </div>
+    </form>
+@else
+    Use of h5p.org hub is not enabled. To enable set <code>H5P_IS_HUB_ENABLED=true</code>
+@endif

--- a/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/upload-content-type.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/upload-content-type.blade.php
@@ -1,0 +1,23 @@
+<div class="panel-body row">
+    @include('fragments.invalidFlashMessage')
+    <form method="post" enctype="multipart/form-data" id="h5p-library-form" class="col-md-6">
+        <div class="form-group">
+            <input type="file" name="h5p_file" id="h5p-file"/>
+        </div>
+        <div class="form-group h5p-disable-file-check">
+            <div class="checkbox">
+                <label><input type="checkbox" name="h5p_upgrade_only" id="h5p-upgrade-only"/> Only update existing libraries</label>
+            </div>
+            <div class="checkbox">
+                <label><input type="checkbox" name="h5p_disable_file_check" id="h5p-disable-file-check"/> Disable file extension check</label>
+            </div>
+        </div>
+        @isset($activetab)
+            <input type="hidden" name="activetab" value="{{$activetab}}">
+        @endisset
+        @csrf
+        <div id="form-group major-publishing-actions" class="submitbox">
+            <input type="submit" name="submit" value="Upload" class="button button-primary button-large btn btn-primary"/>
+        </div>
+    </form>
+</div>

--- a/sourcecode/apis/contentauthor/resources/views/layouts/admin.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/layouts/admin.blade.php
@@ -90,7 +90,7 @@
                                 <a href="{{ route('admin.capability') }}">Capabilities</a>
                             </li>
                             <li>
-                                <a href="{{ route('admin.update-libraries') }}">Update libraries</a>
+                                <a href="{{ route('admin.update-libraries') }}">Manage content types</a>
                             </li>
                             @if( resolve(\App\Libraries\H5P\Interfaces\H5PAdapterInterface::class)->useMaxscore() )
                                 <li>


### PR DESCRIPTION
The "Update libraries" page can be quite long, containing both upload and listing of content types and libraries. This splits the long page into four parts using tabs; 'Installed content types', 'Installed libraries', 'Upload content type' and 'Install from h5p.org'. Info/help text was also added on each tab.
Menu item 'Update libraries' is rename to 'Manage content types'.