### PR TITLE
CA Admin: Prevent deleting library if used by content or other libraries

### DIFF
--- a/sourcecode/apis/contentauthor/app/H5PLibrary.php
+++ b/sourcecode/apis/contentauthor/app/H5PLibrary.php
@@ -369,4 +369,13 @@ class H5PLibrary extends Model
 
         return $icon ?? url('/graphical/h5p_logo.svg');
     }
+
+    public static function canBeDeleted(int $libraryId): bool
+    {
+        $h5pFramework = app(H5PFrameworkInterface::class);
+        // Number of references by other content types/libraries. Only counts content using library as main content type, so we skip that
+        $usage = $h5pFramework->getLibraryUsage($libraryId, skipContent: true);
+
+        return $usage['libraries'] === 0 && H5PContentLibrary::where('library_id', $libraryId)->doesntExist();
+    }
 }

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/LibraryUpgradeController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/LibraryUpgradeController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Exceptions\InvalidH5pPackageException;
-use App\H5PContentLibrary;
 use App\H5PLibrariesHubCache;
 use App\H5PLibrary;
 use App\H5POption;

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/LibraryUpgradeController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/LibraryUpgradeController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Exceptions\InvalidH5pPackageException;
+use App\H5PContentLibrary;
 use App\H5PLibrariesHubCache;
 use App\H5PLibrary;
 use App\H5POption;
@@ -70,6 +71,7 @@ class LibraryUpgradeController extends Controller
                     'hubUpgrade' => null,
                     'isLast' => $library->id === $lastVersion->id,
                     'libraryId' => $library->id,
+                    'canDelete' => H5PLibrary::canBeDeleted($library->id),
                 ];
 
                 if ($library->runnable) {
@@ -162,8 +164,8 @@ class LibraryUpgradeController extends Controller
 
     public function deleteLibrary(H5PLibrary $library): Response
     {
-        if ($library->contents()->exists()) {
-            throw new BadRequestHttpException('Cannot delete libraries with existing content');
+        if (!H5PLibrary::canBeDeleted($library->id)) {
+            throw new BadRequestHttpException('Cannot delete library used by content or other libraries');
         }
 
         $this->core->deleteLibrary((object) [

--- a/sourcecode/apis/contentauthor/resources/assets/js/admin.js
+++ b/sourcecode/apis/contentauthor/resources/assets/js/admin.js
@@ -102,8 +102,19 @@ function deleteLibrary(event) {
     const url = element.data('ajax-url')
 
     element.prop('disabled', true);
-    sendRequest(element, { method: 'DELETE', url }, null, function () {
-        alert('Library deleted');
-        window.location.reload();
-    });
+    sendRequest(
+        element,
+        {
+            method: 'DELETE',
+            url,
+        },
+        null,
+        () => {
+            alert('Library deleted');
+            window.location.reload();
+        },
+        (err) => {
+            alert(err.responseJSON.message ?? 'Library delete failed');
+        }
+    );
 }

--- a/sourcecode/apis/contentauthor/resources/views/admin/fragments/library-table.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/fragments/library-table.blade.php
@@ -3,8 +3,8 @@
         <th>Machine name</th>
         <th>Title</th>
         @isset($showCount)
-            <th>#contents</th>
-            <th>#libdependencies</th>
+            <th><abbr title="Number of content using it as main content type">#contents</abbr></th>
+            <th><abbr title="Number of other content types or libraries that are referencing it">#libdependencies</abbr></th>
         @endif
         @isset($showSummary)
             <th>Summary</th>
@@ -74,7 +74,7 @@
                         <span class="fa fa-history"></span>
                     </button>
                 @endif
-                @if(empty($library['numLibraryDependencies']) && !empty($library['libraryId']))
+                @if(array_key_exists('canDelete', $library) && $library['canDelete'] === true)
                     <button
                             type="button"
                             class="btn btn-danger btn-xs h5p-action-button delete-btn"


### PR DESCRIPTION
Content type and libraries could be deleted if content did not use it as main content type, or if was not referenced by other content types or libraries.
Content types can use other content types dynamically, e.g. Course Presentation, this use is not stored in `h5p_libraries_libraries`. This adds a check if see if any content references the library by using `h5p_contents_libraries`.