### PR TITLE
remove use of profile "helper"

### DIFF
--- a/sourcecode/apis/contentauthor/app/Http/Controllers/API/LockStatusController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/API/LockStatusController.php
@@ -9,7 +9,7 @@ use Carbon\Carbon;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Session;
 
-use function Cerpus\Helper\Helpers\profile as config;
+use function config;
 
 class LockStatusController extends Controller
 {

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/ArticleController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/ArticleController.php
@@ -28,7 +28,7 @@ use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
 
-use function Cerpus\Helper\Helpers\profile as config;
+use function config;
 
 class ArticleController extends Controller
 {

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/H5PController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/H5PController.php
@@ -53,7 +53,7 @@ use stdClass;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 use function app;
-use function Cerpus\Helper\Helpers\profile as config;
+use function config;
 use function request;
 
 class H5PController extends Controller

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/QuestionSetController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/QuestionSetController.php
@@ -23,7 +23,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Session;
 use Illuminate\View\View;
 
-use function Cerpus\Helper\Helpers\profile as config;
+use function config;
 
 class QuestionSetController extends Controller
 {

--- a/sourcecode/apis/contentauthor/app/Libraries/Games/Millionaire/Millionaire.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/Games/Millionaire/Millionaire.php
@@ -20,7 +20,7 @@ use Illuminate\Support\Facades\Session;
 use Illuminate\View\View;
 use Ramsey\Uuid\Uuid;
 
-use function Cerpus\Helper\Helpers\profile as config;
+use function config;
 
 class Millionaire extends GameBase
 {

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Adapters/NDLAH5PAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Adapters/NDLAH5PAdapter.php
@@ -12,7 +12,7 @@ use App\Libraries\H5P\Traits\H5PCommonAdapterTrait;
 use Carbon\Carbon;
 
 use function array_unique;
-use function Cerpus\Helper\Helpers\profile as config;
+use function config;
 
 use const JSON_THROW_ON_ERROR;
 
@@ -244,7 +244,6 @@ class NDLAH5PAdapter implements H5PAdapterInterface
      */
     public function overrideAdapterSettings()
     {
-        config(['app.deploymentEnvironment' => 'ndlaprod']);
         config(collect([
             'app.enable_licensing',
             'feature.licensing',

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PConfigAbstract.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PConfigAbstract.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Session;
 use Iso639p3;
 use Ramsey\Uuid\Uuid;
 
-use function Cerpus\Helper\Helpers\profile as config;
+use function config;
 
 abstract class H5PConfigAbstract implements ConfigInterface
 {

--- a/sourcecode/apis/contentauthor/config/app.php
+++ b/sourcecode/apis/contentauthor/config/app.php
@@ -211,6 +211,5 @@ return [
     'consumer-secret' => env('LTI_CONSUMER_SECRET', env('H5P_CONSUMER_SECRET')),
 
     'displayPropertiesBox' => env('DISPLAY_PROPERTIES_BOX', true),
-    'deploymentEnvironment' => env('DEPLOYMENT_ENVIRONMENT'),
     'cdnPrefix' => env('CDN_WITH_PREFIX', ''),
 ];

--- a/sourcecode/apis/contentauthor/config/ndla-mode.php
+++ b/sourcecode/apis/contentauthor/config/ndla-mode.php
@@ -26,6 +26,7 @@ return [
         'singleContentUpgrade' => env('NDLA_H5P_SINGLE_CONTENT_UPGRADE', true),
         'isHubEnabled' => env('NDLA_H5P_IS_HUB_ENABLED', false),
         'defaultExportOption' => env('NDLA_H5P_DEFAULT_EXPORT_OPTION', H5PDisplayOptionBehaviour::CONTROLLED_BY_AUTHOR_DEFAULT_OFF),
+        'defaultShareSetting' => 'share',
         'include-mathjax' => env("NDLA_H5P_INCLUDE_MATHJAX", true),
         'crossOrigin' => env('NDLA_H5P_CROSSORIGIN'),
         'crossOriginRegexp' => env('NDLA_H5P_CROSSORIGIN_REGEXP', '/.*/'),

--- a/sourcecode/apis/contentauthor/config/ndlaprod/h5p.php
+++ b/sourcecode/apis/contentauthor/config/ndlaprod/h5p.php
@@ -1,5 +1,0 @@
-<?php
-
-return [
-    'defaultShareSetting' => 'share',
-];


### PR DESCRIPTION
This is used to override a single environment variable that could just be set correctly to begin with.

Even Edlib 2 [marked this as to be removed](https://github.com/cerpus/Edlib/blame/edlib2/chart/templates/common.yaml#L49-L50).