### PR TITLE
CA: Adjust paths for php-cs-fixer

### DIFF
--- a/sourcecode/apis/contentauthor/.php-cs-fixer.dist.php
+++ b/sourcecode/apis/contentauthor/.php-cs-fixer.dist.php
@@ -1,13 +1,12 @@
 <?php
 
 $finder = PhpCsFixer\Finder::create()
-    ->in(__DIR__)
-    ->path('app')
-    ->path('bootstrap/app.php')
-    ->path('config')
-    ->path('database')
-    ->path('routes')
-    ->path('tests')
+    ->in(__DIR__ . '/app/')
+    ->in(__DIR__ . '/bootstrap/')->exclude('cache')->name('/app.php')
+    ->in(__DIR__ . '/config/')
+    ->in(__DIR__ . '/database/')
+    ->in(__DIR__ . '/routes/')
+    ->in(__DIR__ . '/tests/')
 ;
 
 return (new PhpCsFixer\Config())


### PR DESCRIPTION
When run from command line `php-cs-fixer` fails when trying to access a folder in `storage/app` that it doesn't have access to.
This adjusts the paths that `php-cs-fixer` checks.

The original config used `path()` to add folders, this function includes files/folders that contains the provided string in the path.
So `->path('app')` would include all files in the `app` folder but also any other file/folder containing the string `app`, e.g. `/storage/app/` and the file `public/js/h5p/ckeditor_wiris/integration/lib/com/wiris/system/CallWrapper.class.php` (the filename contains 'app')