### PR TITLE
Add owner info to use/edit response

### DIFF
--- a/sourcecode/hub/app/Http/Controllers/ContentController.php
+++ b/sourcecode/hub/app/Http/Controllers/ContentController.php
@@ -242,14 +242,12 @@ class ContentController extends Controller
             ?? throw new BadMethodCallException('Not in LTI selection context');
         assert(is_string($returnUrl));
 
-        $credentials = LtiPlatform::where('key', $request->session()->get('lti.oauth_consumer_key'))
-            ->firstOrFail()
-            ->getOauth1Credentials();
+        $platform = LtiPlatform::where('key', $request->session()->get('lti.oauth_consumer_key'))->firstOrFail();
 
         $ltiRequest = $itemSelectionFactory->createItemSelection(
-            [$version->toLtiLinkItem()],
+            [$version->toLtiLinkItem($platform)],
             $returnUrl,
-            $credentials,
+            $platform->getOauth1Credentials(),
             $request->session()->get('lti.data'),
         );
 

--- a/sourcecode/hub/app/Models/ContentVersion.php
+++ b/sourcecode/hub/app/Models/ContentVersion.php
@@ -85,10 +85,10 @@ class ContentVersion extends Model
     public function toLtiLinkItem(LtiPlatform $platform): EdlibLtiLinkItem
     {
         $iconUrl = $this->icon?->getUrl();
-        $custom = [];
+        $ownerEmail = null;
 
         if (Session::get('lti.ext_edlib3_include_owner_info') === '1' && $platform->authorizes_edit) {
-            $custom['owner'] = $this->content?->users->first(
+            $ownerEmail = $this->content?->users->first(
                 fn(User $user) => $user->getRelationValue('pivot')->role === ContentRole::Owner,
             )?->email;
         }
@@ -100,12 +100,12 @@ class ContentVersion extends Model
             lineItem: $this->max_score > 0
                 ? new LineItem(new ScoreConstraints(normalMaximum: (float) $this->max_score))
                 : null,
-            custom: $custom,
         ))
             ->withEdlibVersionId($this->id)
             ->withLanguageIso639_3($this->language_iso_639_3)
             ->withLicense($this->license)
             ->withTags($this->getSerializedTags())
+            ->withOwnerEmail($ownerEmail)
         ;
     }
 

--- a/sourcecode/hub/composer.lock
+++ b/sourcecode/hub/composer.lock
@@ -293,12 +293,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/cerpus/php-edlib-resource-kit.git",
-                "reference": "af41490a0c70c69491616eab8382ae3dc01be55d"
+                "reference": "a3671acd6ffd26a421a750a4081a6b6f4ff1b1df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cerpus/php-edlib-resource-kit/zipball/af41490a0c70c69491616eab8382ae3dc01be55d",
-                "reference": "af41490a0c70c69491616eab8382ae3dc01be55d",
+                "url": "https://api.github.com/repos/cerpus/php-edlib-resource-kit/zipball/a3671acd6ffd26a421a750a4081a6b6f4ff1b1df",
+                "reference": "a3671acd6ffd26a421a750a4081a6b6f4ff1b1df",
                 "shasum": ""
             },
             "require": {
@@ -345,7 +345,7 @@
                 "issues": "https://github.com/cerpus/Edlib/issues",
                 "source": "https://github.com/cerpus/php-edlib-resource-kit/tree/master"
             },
-            "time": "2024-11-21T12:26:48+00:00"
+            "time": "2025-01-17T08:54:44+00:00"
         },
         {
             "name": "cerpus/edlib-resource-kit-laravel",


### PR DESCRIPTION
When user selects or edit content, the response can contain info about owner