### PR TITLE
add redirect for legacy e2 urls

### DIFF
--- a/sourcecode/hub/.env.example
+++ b/sourcecode/hub/.env.example
@@ -64,6 +64,9 @@ AUTH0_CLIENT_SECRET=
 # e.g. https://dev--abcdef.eu.auth0.com - must not end in a slash
 AUTH0_BASE_URL=
 
+# Should only be used for legacy environments
+EDLIB_LEGACY_DOMAIN=www.edlib.test
+
 # These should not be used, except in development and some legacy environments
 NDLA_LEGACY_DOMAIN=hub-ndla-legacy.edlib.test
 NDLA_LEGACY_CONTENTAUTHOR_HOST=ca.edlib.test

--- a/sourcecode/hub/app/Http/Controllers/ContentController.php
+++ b/sourcecode/hub/app/Http/Controllers/ContentController.php
@@ -463,4 +463,9 @@ class ContentController extends Controller
             ],
         ]);
     }
+
+    public function redirectFromEdlib2Id(Content $edlib2Content): RedirectResponse
+    {
+        return redirect()->route('content.embed', [$edlib2Content]);
+    }
 }

--- a/sourcecode/hub/app/Providers/RouteServiceProvider.php
+++ b/sourcecode/hub/app/Providers/RouteServiceProvider.php
@@ -51,6 +51,11 @@ class RouteServiceProvider extends ServiceProvider
             ])->limit(1)->firstOrFail();
         });
 
+        Route::bind('edlib2Content', fn(string $value) => Content::ofTag([
+            'prefix' => 'edlib2_id',
+            'name' => $value,
+        ])->limit(1)->firstOrFail());
+
         $this->configureRateLimiting();
 
         $this->routes(function (NdlaLegacyConfig $ndlaLegacy) {
@@ -62,6 +67,10 @@ class RouteServiceProvider extends ServiceProvider
             // must exist on all domains
             Route::middleware('stateless')
                 ->get('/up', HealthController::class);
+
+            Route::middleware('stateless')
+                ->domain(config('app.edlib-legacy-domain', 'invalid.'))
+                ->group(base_path('routes/edlib-legacy.php'));
 
             Route::middleware('ndla-legacy')
                 ->domain($ndlaLegacy->isEnabled() ? $ndlaLegacy->getDomain() : 'invalid.')

--- a/sourcecode/hub/config/app.php
+++ b/sourcecode/hub/config/app.php
@@ -21,6 +21,8 @@ return [
 
     'contact-url' => env('APP_CONTACT_URL', ''),
 
+    'edlib-legacy-domain' => env('EDLIB_LEGACY_DOMAIN'),
+
     /*
     |--------------------------------------------------------------------------
     | Application Environment

--- a/sourcecode/hub/phpunit.xml
+++ b/sourcecode/hub/phpunit.xml
@@ -26,6 +26,7 @@
         <env name="APP_ENV" value="testing"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="DUSK_DRIVER_URL" value="http://chromedriver:9515"/>
+        <env name="EDLIB_LEGACY_DOMAIN" value="www.edlib.test"/>
         <env name="SESSION_DRIVER" value="array"/>
     </php>
 </phpunit>

--- a/sourcecode/hub/routes/edlib-legacy.php
+++ b/sourcecode/hub/routes/edlib-legacy.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\ContentController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/s/resources/{edlib2Content}')
+    ->uses([ContentController::class, 'redirectFromEdlib2Id'])
+    ->whereUuid('edlib2Content');

--- a/sourcecode/hub/tests/Feature/ContentTest.php
+++ b/sourcecode/hub/tests/Feature/ContentTest.php
@@ -84,6 +84,17 @@ final class ContentTest extends TestCase
             ->assertRedirect('https://hub-test.edlib.test/content/' . $content->id . '/embed');
     }
 
+    public function testRedirectsFromLegacyResourceUrls(): void
+    {
+        $content = Content::factory()
+            ->withPublishedVersion()
+            ->tag('edlib2_id:a3dcbd28-bf37-4123-ac5e-ba2f72a8f420')
+            ->create();
+
+        $this->get('http://www.edlib.test/s/resources/a3dcbd28-bf37-4123-ac5e-ba2f72a8f420')
+            ->assertRedirect('http://hub-test.edlib.test/content/' . $content->id . '/embed');
+    }
+
     public function testCannotPreviewUnpublishedContent(): void
     {
         $content = Content::factory()


### PR DESCRIPTION
Redirects `/s/resources/<uuid>` on a configurable domain to the hub's embed equivalent for that content.