### PR TITLE
GH #2944: CA Admin: Fix slow check if content type/library can be deleted

### DIFF
--- a/sourcecode/apis/contentauthor/app/H5PLibrary.php
+++ b/sourcecode/apis/contentauthor/app/H5PLibrary.php
@@ -370,14 +370,14 @@ class H5PLibrary extends Model
         return $icon ?? url('/graphical/h5p_logo.svg');
     }
 
-    public static function canBeDeleted(int $libraryId, array|null $usage = null): bool
+    public static function canBeDeleted(int $libraryId, int|null $usageCount = null): bool
     {
-        if ($usage === null || array_key_exists('libraries', $usage) === false) {
+        if ($usageCount === null) {
             $h5pFramework = app(H5PFrameworkInterface::class);
             // Number of references by other content types/libraries. Only counts content using library as main content type, so we skip that
-            $usage = $h5pFramework->getLibraryUsage($libraryId, skipContent: true);
+            $usageCount = $h5pFramework->getLibraryUsage($libraryId, skipContent: true)['libraries'];
         }
 
-        return $usage['libraries'] === 0 && H5PContentLibrary::where('library_id', $libraryId)->doesntExist();
+        return $usageCount === 0 && H5PContentLibrary::where('library_id', $libraryId)->doesntExist();
     }
 }

--- a/sourcecode/apis/contentauthor/app/H5PLibrary.php
+++ b/sourcecode/apis/contentauthor/app/H5PLibrary.php
@@ -370,11 +370,13 @@ class H5PLibrary extends Model
         return $icon ?? url('/graphical/h5p_logo.svg');
     }
 
-    public static function canBeDeleted(int $libraryId): bool
+    public static function canBeDeleted(int $libraryId, array|null $usage = null): bool
     {
-        $h5pFramework = app(H5PFrameworkInterface::class);
-        // Number of references by other content types/libraries. Only counts content using library as main content type, so we skip that
-        $usage = $h5pFramework->getLibraryUsage($libraryId, skipContent: true);
+        if ($usage === null || array_key_exists('libraries', $usage) === false) {
+            $h5pFramework = app(H5PFrameworkInterface::class);
+            // Number of references by other content types/libraries. Only counts content using library as main content type, so we skip that
+            $usage = $h5pFramework->getLibraryUsage($libraryId, skipContent: true);
+        }
 
         return $usage['libraries'] === 0 && H5PContentLibrary::where('library_id', $libraryId)->doesntExist();
     }

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/LibraryUpgradeController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/LibraryUpgradeController.php
@@ -61,6 +61,7 @@ class LibraryUpgradeController extends Controller
             reset($versions);
             foreach ($versions as $library) {
                 $usage = $this->h5pFramework->getLibraryUsage($library->id);
+
                 $item = [
                     'machineName' => $library->name,
                     'majorVersion' => $library->major_version,
@@ -71,7 +72,7 @@ class LibraryUpgradeController extends Controller
                     'hubUpgrade' => null,
                     'isLast' => $library->id === $lastVersion->id,
                     'libraryId' => $library->id,
-                    'canDelete' => H5PLibrary::canBeDeleted($library->id),
+                    'canDelete' => H5PLibrary::canBeDeleted($library->id, $usage),
                 ];
 
                 if ($library->runnable) {

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/LibraryUpgradeController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/Admin/LibraryUpgradeController.php
@@ -72,7 +72,7 @@ class LibraryUpgradeController extends Controller
                     'hubUpgrade' => null,
                     'isLast' => $library->id === $lastVersion->id,
                     'libraryId' => $library->id,
-                    'canDelete' => H5PLibrary::canBeDeleted($library->id, $usage),
+                    'canDelete' => H5PLibrary::canBeDeleted($library->id, $usage['libraries']),
                 ];
 
                 if ($library->runnable) {

--- a/sourcecode/apis/contentauthor/database/migrations/2025_02_07_124500_create_h5p_contents_libraries_library_id_index.php
+++ b/sourcecode/apis/contentauthor/database/migrations/2025_02_07_124500_create_h5p_contents_libraries_library_id_index.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
      */

--- a/sourcecode/apis/contentauthor/database/migrations/2025_02_07_124500_create_h5p_contents_libraries_library_id_index.php
+++ b/sourcecode/apis/contentauthor/database/migrations/2025_02_07_124500_create_h5p_contents_libraries_library_id_index.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('h5p_contents_libraries', function (Blueprint $table) {
+            $table->index('library_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('h5p_contents_libraries', function (Blueprint $table) {
+            $table->dropIndex(['library_id']);
+        });
+    }
+};


### PR DESCRIPTION
Add missing database index on `h5p_contents_libraries.library_id`
Usage data for content type/library was already retrieved, so reuse that