### PR TITLE
remove lti_tools.proxy_launch

### DIFF
--- a/docs/docs/hosting/ca-setup.mdx
+++ b/docs/docs/hosting/ca-setup.mdx
@@ -45,7 +45,6 @@ tool**. Fill in the following and save:
 - **Key**: The value of `LTI_CONSUMER_KEY`
 - **Secret**: The value of `LTI_CONSUMER_SECRET`
 - Tick the following:
-    - **Return proxied content URLs**
     - **Deep Linking request to content URL**
     - **Send full name of user to tool**
     - **Send email address of user to tool**

--- a/sourcecode/hub/app/Console/Commands/AddLtiTool.php
+++ b/sourcecode/hub/app/Console/Commands/AddLtiTool.php
@@ -34,7 +34,6 @@ class AddLtiTool extends Command
         $tool->consumer_secret = $this->secret('Secret');
         $tool->send_name = $this->option('send-name');
         $tool->send_email = $this->option('send-email');
-        $tool->proxy_launch = true;
 
         if ($this->option('slug')) {
             $tool->slug = $this->option('slug');

--- a/sourcecode/hub/app/Http/Requests/StoreLtiToolRequest.php
+++ b/sourcecode/hub/app/Http/Requests/StoreLtiToolRequest.php
@@ -32,7 +32,6 @@ class StoreLtiToolRequest extends FormRequest
             'edit_mode' => ['required', Rule::enum(LtiToolEditMode::class)],
             'send_name' => ['boolean'],
             'send_email' => ['boolean'],
-            'proxy_launch' => ['boolean'],
             'slug' => ['sometimes', 'string', 'max:50', 'regex:/^[a-z0-9-_]+$/'],
         ];
     }

--- a/sourcecode/hub/app/Http/Requests/UpdateLtiToolRequest.php
+++ b/sourcecode/hub/app/Http/Requests/UpdateLtiToolRequest.php
@@ -24,7 +24,6 @@ final class UpdateLtiToolRequest extends FormRequest
 
         $parameters->set('send_name', $parameters->getBoolean('send_name', false));
         $parameters->set('send_email', $parameters->getBoolean('send_email', false));
-        $parameters->set('proxy_launch', $parameters->getBoolean('proxy_launch', false));
     }
 
     /**
@@ -40,7 +39,6 @@ final class UpdateLtiToolRequest extends FormRequest
             'edit_mode' => ['required', Rule::enum(LtiToolEditMode::class)],
             'send_name' => ['boolean'],
             'send_email' => ['boolean'],
-            'proxy_launch' => ['boolean'],
             'slug' => ['sometimes', 'string', 'max:50', 'regex:/^[a-z0-9-_]+$/'],
         ];
     }

--- a/sourcecode/hub/app/Models/ContentVersion.php
+++ b/sourcecode/hub/app/Models/ContentVersion.php
@@ -163,11 +163,6 @@ class ContentVersion extends Model
     public function getExternalLaunchUrl(): string
     {
         $content = $this->content ?? throw new DomainException('No content for version');
-        $tool = $this->tool ?? throw new DomainException('No tool for LTI resource');
-
-        if (!$tool->proxy_launch) {
-            return $this->lti_launch_url;
-        }
 
         if (session('lti.ext_edlib3_return_exact_version')) {
             return route('lti.content-version', [

--- a/sourcecode/hub/app/Models/LtiTool.php
+++ b/sourcecode/hub/app/Models/LtiTool.php
@@ -31,7 +31,6 @@ class LtiTool extends Model
         'lti_version' => LtiVersion::Lti1_1,
         'send_name' => false,
         'send_email' => false,
-        'proxy_launch' => false,
         'edit_mode' => LtiToolEditMode::Replace,
     ];
 
@@ -40,7 +39,6 @@ class LtiTool extends Model
         'edit_mode' => LtiToolEditMode::class,
         'send_name' => 'boolean',
         'send_email' => 'boolean',
-        'proxy_launch' => 'boolean',
     ];
 
     protected $hidden = [
@@ -54,7 +52,6 @@ class LtiTool extends Model
         'consumer_secret',
         'send_name',
         'send_email',
-        'proxy_launch',
         'edit_mode',
         'slug',
     ];

--- a/sourcecode/hub/app/Transformers/LtiToolTransformer.php
+++ b/sourcecode/hub/app/Transformers/LtiToolTransformer.php
@@ -19,9 +19,9 @@ final class LtiToolTransformer extends TransformerAbstract
             'consumer_key' => $tool->consumer_key,
             'deep_linking_url' => $tool->creator_launch_url,
             'edit_mode' => $tool->edit_mode->value,
-            'proxies_lti_launches' => $tool->proxy_launch,
             'send_email' => $tool->send_email,
             'send_name' => $tool->send_name,
+            'proxies_lti_launches' => true, // deprecated
             'links' => [
                 'self' => route('api.lti-tools.show', [$tool]),
             ],

--- a/sourcecode/hub/database/factories/LtiToolFactory.php
+++ b/sourcecode/hub/database/factories/LtiToolFactory.php
@@ -24,7 +24,6 @@ final class LtiToolFactory extends Factory
             'consumer_secret' => $this->faker->password(32),
             'send_name' => $this->faker->boolean,
             'send_email' => $this->faker->boolean,
-            'proxy_launch' => $this->faker->boolean,
             'slug' => $this->faker->unique()->slug(nbWords: 2),
         ];
     }
@@ -47,11 +46,6 @@ final class LtiToolFactory extends Factory
     public function sendEmail(bool $sendEmail = true): self
     {
         return $this->state(['send_email' => $sendEmail]);
-    }
-
-    public function proxyLaunch(bool $proxyLaunch = true): self
-    {
-        return $this->state(['proxy_launch' => $proxyLaunch]);
     }
 
     public function withName(string $name): self

--- a/sourcecode/hub/database/migrations/2025_02_10_remove_lti_tools_proxy_launch.php
+++ b/sourcecode/hub/database/migrations/2025_02_10_remove_lti_tools_proxy_launch.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('lti_tools', function (Blueprint $table) {
+            $table->dropColumn('proxy_launch');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('lti_tools', function (Blueprint $table) {
+            $table->boolean('proxy_launch')->default(true);
+        });
+    }
+};

--- a/sourcecode/hub/database/migrations/2025_02_10_remove_lti_tools_proxy_launch.php
+++ b/sourcecode/hub/database/migrations/2025_02_10_remove_lti_tools_proxy_launch.php
@@ -6,8 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class extends Migration {
     public function up(): void
     {
         Schema::table('lti_tools', function (Blueprint $table) {

--- a/sourcecode/hub/lang/en/messages.php
+++ b/sourcecode/hub/lang/en/messages.php
@@ -140,8 +140,6 @@ return [
     'send-email-to-lti-tool' => 'Send email address of :site user to tool',
     'content-selection' => 'Content selection',
     'launch-settings' => 'Launch settings',
-    'proxy-launch-to-lti-tool' => 'Return proxied content URLs',
-    'proxy-launch-to-lti-tool-help' => 'If enabled, the selected content will be shown through :site. Otherwise, the platform is required to have exchanged keys with the tool beforehand.',
     'yes' => 'Yes',
     'no' => 'No',
     'continue' => 'Continue',

--- a/sourcecode/hub/lang/nb/messages.php
+++ b/sourcecode/hub/lang/nb/messages.php
@@ -110,8 +110,6 @@ return [
     'send-email-to-lti-tool' => 'Send epostadresse på :site-bruker til verktøy',
     'content-selection' => 'Valg av innhold',
     'launch-settings' => 'Oppstartsinnstillinger',
-    'proxy-launch-to-lti-tool' => 'Returner :site-URLer til verktøy',
-    'proxy-launch-to-lti-tool-help' => 'Om aktivert, vil innholdet bli vist gjennom :site. Ellers er plattformen påkrevd å ha utvekslet nøkler med verktøyet på forhånd.',
     'yes' => 'Ja',
     'no' => 'Nei',
     'continue' => 'Fortsett',

--- a/sourcecode/hub/resources/views/admin/lti-tools/index.blade.php
+++ b/sourcecode/hub/resources/views/admin/lti-tools/index.blade.php
@@ -47,10 +47,6 @@
                                 <th scope="row">{{ trans('messages.send-email-to-lti-tool', ['site' => config('app.name')]) }}</th>
                                 <td class="lti-tool-card-send-email">{{ $tool->send_email ? trans('messages.yes') : trans('messages.no') }}</td>
                             </tr>
-                            <tr>
-                                <th scope="row">{{ trans('messages.proxy-launch-to-lti-tool', ['site' => config('app.name')]) }}</th>
-                                <td class="lti-tool-card-proxy-launch">{{ $tool->proxy_launch ? trans('messages.yes') : trans('messages.no') }}</td>
-                            </tr>
                         </tbody>
                     </table>
 

--- a/sourcecode/hub/resources/views/components/admin/lti-tools/form.blade.php
+++ b/sourcecode/hub/resources/views/components/admin/lti-tools/form.blade.php
@@ -48,18 +48,6 @@
     />
 
     <fieldset>
-        <legend>{{ trans('messages.launch-settings') }}</legend>
-
-        <x-form.field
-            name="proxy_launch"
-            type="checkbox"
-            :label="trans('messages.proxy-launch-to-lti-tool', ['site' => config('app.name')])"
-            :text="trans('messages.proxy-launch-to-lti-tool-help', ['site' => config('app.name')])"
-            :checked="$tool?->proxy_launch"
-        />
-    </fieldset>
-
-    <fieldset>
         <legend>{{ trans('messages.edit-mode') }}</legend>
 
         <x-form.field

--- a/sourcecode/hub/tests/Browser/AdminTest.php
+++ b/sourcecode/hub/tests/Browser/AdminTest.php
@@ -232,7 +232,6 @@ final class AdminTest extends DuskTestCase
             ->withName('The Tool')
             ->sendName()
             ->sendEmail()
-            ->proxyLaunch()
             ->create();
 
         $this->browse(
@@ -248,13 +247,10 @@ final class AdminTest extends DuskTestCase
                     new LtiToolCard(),
                     fn(Browser $card) =>
                     $card
-                        ->assertSeeIn('@proxy-launch', 'Yes')
                         ->assertSeeIn('@send-email', 'Yes')
                         ->assertSeeIn('@send-name', 'Yes'),
                 )
                 ->clickLink('Edit')
-                ->assertChecked('proxy_launch')
-                ->uncheck('proxy_launch')
                 ->assertChecked('send_name')
                 ->uncheck('send_name')
                 ->assertChecked('send_email')
@@ -268,7 +264,6 @@ final class AdminTest extends DuskTestCase
                     new LtiToolCard(),
                     fn(Browser $card) =>
                     $card
-                        ->assertSeeIn('@proxy-launch', 'No')
                         ->assertSeeIn('@send-email', 'No')
                         ->assertSeeIn('@send-name', 'No'),
                 ),

--- a/sourcecode/hub/tests/Browser/Components/LtiToolCard.php
+++ b/sourcecode/hub/tests/Browser/Components/LtiToolCard.php
@@ -25,7 +25,6 @@ final class LtiToolCard extends Component
     public function elements(): array
     {
         return [
-            '@proxy-launch' => '.lti-tool-card-proxy-launch',
             '@send-email' => '.lti-tool-card-send-email',
             '@send-name' => '.lti-tool-card-send-name',
         ];

--- a/sourcecode/hub/tests/Feature/Api/LtiToolTest.php
+++ b/sourcecode/hub/tests/Feature/Api/LtiToolTest.php
@@ -38,7 +38,7 @@ final class LtiToolTest extends TestCase
                             ->missing('consumer_secret')
                             ->where('deep_linking_url', $tool->creator_launch_url)
                             ->where('edit_mode', $tool->edit_mode->value)
-                            ->where('proxies_lti_launches', $tool->proxy_launch)
+                            ->where('proxies_lti_launches', true)
                             ->where('send_name', $tool->send_name)
                             ->where('send_email', $tool->send_email)
                             ->where('links.self', 'https://hub-test.edlib.test/api/lti-tools/' . $tool->id),

--- a/sourcecode/hub/tests/Feature/Commands/AddLtiToolTest.php
+++ b/sourcecode/hub/tests/Feature/Commands/AddLtiToolTest.php
@@ -33,7 +33,6 @@ class AddLtiToolTest extends TestCase
         $this->assertSame('https://ca.edlib.test/lti-content/create', $tool->creator_launch_url);
         $this->assertTrue($tool->send_name);
         $this->assertTrue($tool->send_email);
-        $this->assertTrue($tool->proxy_launch);
         $this->assertSame('h5p', $tool->consumer_key);
         $this->assertSame('secret2', $tool->consumer_secret);
         $this->assertSame(LtiToolEditMode::DeepLinkingRequestToContentUrl, $tool->edit_mode);

--- a/sourcecode/hub/tests/Feature/ContentVersionTest.php
+++ b/sourcecode/hub/tests/Feature/ContentVersionTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use App\Models\ContentVersion;
-use App\Models\LtiTool;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use PHPUnit\Framework\Attributes\TestWith;
 use Tests\TestCase;
@@ -30,28 +29,9 @@ final class ContentVersionTest extends TestCase
         $this->assertSame($expected, $v->givesScore());
     }
 
-    /** @param array<mixed> $session */
-    #[TestWith([[]])]
-    #[TestWith([['lti' => ['ext_edlib3_return_exact_version' => '1']]])]
-    public function testLaunchUrlIsUnproxiedWhenProxyingIsDisabled(array $session): void
+    public function testLaunchUrlIsExactVersionWhenSettingExistsInSession(): void
     {
         $version = ContentVersion::factory()
-            ->tool(LtiTool::factory()->proxyLaunch(false))
-            ->withLaunchUrl('https://example.com/launch')
-            ->create();
-
-        $this->withSession($session);
-
-        $this->assertSame(
-            'https://example.com/launch',
-            $version->getExternalLaunchUrl(),
-        );
-    }
-
-    public function testLaunchUrlIsExactVersionWhenProxiedAndSettingExistsInSession(): void
-    {
-        $version = ContentVersion::factory()
-            ->tool(LtiTool::factory()->proxyLaunch(true))
             ->withLaunchUrl('https://example.com/launch')
             ->create();
 
@@ -69,10 +49,9 @@ final class ContentVersionTest extends TestCase
         );
     }
 
-    public function testLaunchUrlIsLatestVersionOfContentByDefaultWhenProxyingIsEnabled(): void
+    public function testLaunchUrlIsLatestVersionOfContentByDefault(): void
     {
         $version = ContentVersion::factory()
-            ->tool(LtiTool::factory()->proxyLaunch(true))
             ->withLaunchUrl('https://example.com/launch')
             ->create();
 


### PR DESCRIPTION
Removes the 'proxy launch' setting. With this disabled, Edlib would return a direct URL to the tool (e.g. Content Author) upon insertion, instead of a URL to the Hub, which would only work if the platform and the tool had exchanged keys in advance.

Adding this setting on the tool level was a mistake, but returning direct URLs might be useful in some circumstances. It could be brought back as an instance or LTI platform setting later, but right now there isn't much use for it.