### PR TITLE
CA Admin: Fix listing of content versions

### DIFF
--- a/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/content-details.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/content-details.blade.php
@@ -35,8 +35,16 @@
                                 <td>{{ $content->updated_at->format('Y-m-d H:i:s e') }}</td>
                             </tr>
                             <tr>
-                                <th>Latest version</th>
-                                <td>{{ $latestVersion ? 'Yes' : 'No' }}</td>
+                                <th>Latest version id</th>
+                                <td>
+                                    @if($requestedVersion && $requestedVersion->id !== $content->version_id)
+                                        <a href="{{ route('admin.content-details', [$content->id]) }}">
+                                            {{ $content->version_id }}
+                                        </a>
+                                    @else
+                                        {{ $content->version_id }}
+                                    @endif
+                                </td>
                             </tr>
                             <tr>
                                 <th>Language</th>
@@ -91,8 +99,9 @@
                             <table class="table table-striped">
                                 <thead>
                                     <tr>
-                                        <th>Id</th>
-                                        <th>Date (Version)</th>
+                                        <th>Version id</th>
+                                        <th>Content id</th>
+                                        <th>Version created</th>
                                         <th>Title</th>
                                         <th>License</th>
                                         <th>Language</th>
@@ -101,43 +110,40 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    @while(true)
-                                        @php
-                                            if (!isset($itemId)) {
-                                                $itemId = $content->id;
-                                            } else {
-                                                $itemId = !empty($history[$itemId]['parent']) && !empty($history[$history[$itemId]['parent']]) ? $history[$itemId]['parent'] : null;
-                                            }
-                                            if ($itemId === null) {
-                                                break;
-                                            }
-                                        @endphp
+                                    @foreach($history as $historyItem)
+                                        @php($versionId = $requestedVersion ? $requestedVersion->id : $content->version_id)
                                         <tr>
-                                            <td>
-                                                @if ($itemId !== $content->id && isset($history[$itemId]['content']))
-                                                    <a href="{{ route('admin.content-details', [$history[$itemId]['content_id']]) }}">
-                                                        {{ $history[$itemId]['content_id'] }}
+                                            @if ($historyItem['id'] !== $versionId)
+                                                <td>
+                                                    <a href="{{ route('admin.content-details', [$historyItem['content_id'], $historyItem['id']]) }}">
+                                                        {{ $historyItem['id'] }}
                                                     </a>
-                                                @else
-                                                    {{ $history[$itemId]['content_id'] }}
-                                                @endif
+                                                </td>
+                                            @else
+                                                <td>{{ $historyItem['id'] }}</td>
+                                            @endif
+                                            <td>
+                                                <a href="{{ route('admin.content-details', [$historyItem['content_id']]) }}">
+                                                    {{ $historyItem['content_id'] }}
+                                                </a>
                                             </td>
-                                            <td>{{ $history[$itemId]['versionDate']->format('Y-m-d H:i:s.u e') }}</td>
-                                            <td>{{ $history[$itemId]['content']['title'] ?? '' }}</td>
-                                            <td>{{ $history[$itemId]['content']['license'] ?? '' }}</td>
-                                            <td>{{ $history[$itemId]['content']['language'] ?? '' }}</td>
-                                            <td>{{ $history[$itemId]['version_purpose'] }}</td>
+                                            <td>{{ $historyItem['versionDate']->format('Y-m-d H:i:s.u e') }}</td>
+                                            <td>{{ $historyItem['content']['title'] ?? '' }}</td>
+                                            <td>{{ $historyItem['content']['license'] ?? '' }}</td>
+                                            <td>{{ $historyItem['content']['language'] ?? '' }}</td>
+                                            <td>{{ $historyItem['version_purpose'] }}</td>
                                             <td>
-                                                @if(isset($history[$itemId]['content']) && isset($history[$itemId]['content']['library_id']))
-                                                    <a href="{{ route('admin.check-library', [$history[$itemId]['content']['library_id']]) }}">
-                                                        {{ $history[$itemId]['content']['library'] }}
+                                                @if(isset($historyItem['content']) && isset($historyItem['content']['library_id']))
+                                                    <a href="{{ route('admin.check-library', [$historyItem['content']['library_id']]) }}">
+                                                        {{ $historyItem['content']['library'] }}
                                                     </a>
                                                 @else
-                                                    {{ $history[$itemId]['content']['library'] ?? '' }}
+                                                    {{ $historyItem['content']['library'] ?? '' }}
                                                 @endif
                                             </td>
                                         </tr>
-                                    @endwhile
+                                        @break($historyItem['id'] === $versionId)
+                                    @endforeach
                                 </tbody>
                             </table>
                         </div>
@@ -150,8 +156,9 @@
                             <table class="table table-striped">
                                 <thead>
                                     <tr>
-                                        <th>Id</th>
-                                        <th>Date (Version)</th>
+                                        <th>Version id</th>
+                                        <th>Content id</th>
+                                        <th>Version created</th>
                                         <th>Title</th>
                                         <th>License</th>
                                         <th>Language</th>
@@ -160,39 +167,41 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    @empty($history[$content->id]['children'])
-                                        <tr>
-                                            <td colspan="6">
-                                                {{ $latestVersion ? 'This is the latest version' : 'No content found' }}
-                                            </td>
-                                        </tr>
-                                    @else
-                                        @foreach($history[$content->id]['children'] as $itemId)
+                                    @php($versionId = $requestedVersion ? $requestedVersion->id : $content->version_id)
+                                    @if(!empty($history[$versionId]) && !empty($history[$versionId]['children']))
+                                        @foreach($history[$versionId]['children'] as $child)
                                             <tr>
                                                 <td>
-                                                    @isset($history[$itemId]['content'])
-                                                        <a href="{{ route('admin.content-details', [$history[$itemId]['content_id']]) }}">{{ $history[$itemId]['content_id'] }}</a>
-                                                    @else
-                                                        {{ $history[$itemId]['external_reference'] }}
-                                                    @endisset
+                                                    <a href="{{ route('admin.content-details', [$child['content_id'], $child['id']]) }}">
+                                                        {{ $child['id'] }}
+                                                    </a>
                                                 </td>
-                                                <td>{{ $history[$itemId]['versionDate']->format('Y-m-d H:i:s.u e') }}</td>
-                                                <td>{{ $history[$itemId]['content']['title'] ?? '' }}</td>
-                                                <td>{{ $history[$itemId]['content']['license'] ?? '' }}</td>
-                                                <td>{{ $history[$itemId]['content']['language'] ?? '' }}</td>
-                                                <td>{{ $history[$itemId]['version_purpose'] }}</td>
                                                 <td>
-                                                    @if(isset($history[$itemId]['content']) && isset($history[$itemId]['content']['library_id']))
-                                                        <a href="{{ route('admin.check-library', [$history[$itemId]['content']['library_id']]) }}">
-                                                            {{ $history[$itemId]['content']['library'] }}
-                                                        </a>
-                                                    @else
-                                                        {{ $history[$itemId]['content']['library'] ?? '' }}
-                                                    @endif
+                                                    <a href="{{ route('admin.content-details', [$child['content_id']]) }}">
+                                                        {{ $child['content_id'] }}
+                                                    </a>
                                                 </td>
+                                                @isset($child['content'])
+                                                    <td>{{ $child['versionDate']->format('Y-m-d H:i:s.u e') }}</td>
+                                                    <td>{{ $child['content']['title'] ?? '' }}</td>
+                                                    <td>{{ $child['content']['license'] ?? '' }}</td>
+                                                    <td>{{ $child['content']['language'] ?? '' }}</td>
+                                                    <td>{{ $child['version_purpose'] }}</td>
+                                                    <td>
+                                                        @isset($child['content']['library_id'])
+                                                            <a href="{{ route('admin.check-library', [$child['content']['library_id']]) }}">
+                                                                {{ $child['content']['library'] }}
+                                                            </a>
+                                                        @else
+                                                            {{ $child['content']['library'] ?? '' }}
+                                                        @endif
+                                                    </td>
+                                                @else
+                                                    <td colspan="6"></td>
+                                                @endisset
                                             </tr>
                                         @endforeach
-                                    @endempty
+                                    @endif
                                 </tbody>
                             </table>
                         </div>

--- a/sourcecode/apis/contentauthor/routes/admin.php
+++ b/sourcecode/apis/contentauthor/routes/admin.php
@@ -47,7 +47,7 @@ Route::middleware(['auth:sso', 'can:superadmin'])->prefix('admin')->group(
             ->name('admin.check-library');
         Route::get('libraries/{library}/content', [AdminH5PDetailsController::class, 'contentForLibrary'])
             ->name('admin.content-library');
-        Route::get('content/{content}/details', [AdminH5PDetailsController::class, 'contentHistory'])
+        Route::get('content/{content}/details/{version?}', [AdminH5PDetailsController::class, 'contentHistory'])
             ->name('admin.content-details');
         Route::get('libraries/{library}/translation/{locale}', [AdminH5PDetailsController::class, 'libraryTranslation'])
             ->name('admin.library-translation');

--- a/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/Admin/AdminH5PDetailsControllerTest.php
+++ b/sourcecode/apis/contentauthor/tests/Integration/Http/Controllers/Admin/AdminH5PDetailsControllerTest.php
@@ -281,24 +281,25 @@ class AdminH5PDetailsControllerTest extends TestCase
         $data = $response->getData();
 
         $this->assertArrayHasKey('content', $data);
-        $this->assertArrayHasKey('latestVersion', $data);
+        $this->assertArrayHasKey('requestedVersion', $data);
         $this->assertArrayHasKey('history', $data);
 
-        $this->assertFalse($data['latestVersion']);
+        $this->assertNull($data['requestedVersion']);
         $this->assertSame($content->id, $data['content']->id);
 
         $this->assertInstanceOf(Collection::class, $data['history']);
         $this->assertCount(3, $data['history']);
-        $this->assertArrayHasKey($parent->id, $data['history']);
-        $this->assertArrayHasKey($content->id, $data['history']);
-        $this->assertArrayHasKey($child->id, $data['history']);
+        $this->assertArrayHasKey($parentVersion->id, $data['history']);
+        $this->assertArrayHasKey($version->id, $data['history']);
+        $this->assertArrayHasKey($childVersion->id, $data['history']);
 
-        $history = $data['history']->get($content->id);
-        $this->assertNotNull($history);
-        $this->assertSame($content->version_id, $history['content']['version_id']);
-        $this->assertEquals($parent->id, $history['parent']);
+        $history = $data['history']->get($version->id);
+        $this->assertIsArray($history);
+        $this->assertEquals($content->id, $history['content_id']);
+        $this->assertEquals($parent->version_id, $history['parent']);
         $this->assertCount(1, $history['children']);
-        $this->assertEquals($child->id, $history['children'][0]);
+        $this->assertEquals($child->version_id, $history['children'][0]['id']);
+        $this->assertEquals($child->id, $history['children'][0]['content_id']);
     }
 
     public function test_contentHistory_noResource(): void
@@ -322,7 +323,7 @@ class AdminH5PDetailsControllerTest extends TestCase
         $data = $response->getData();
 
         $this->assertSame($content->id, $data['content']['id']);
-        $this->assertTrue($data['latestVersion']);
+        $this->assertNull($data['requestedVersion']);
         $this->assertCount(0, $data['history']);
     }
 


### PR DESCRIPTION
Listing of content versions did not list all versions. Not all changes in CA causes a new content id, but a new version is always created, so one content id can have multiple versions. Since the data was collected using content id as key, not all versions was included, this also caused some child content to not be included causing an exception when displaying the page.
Data is now collected using the version id as key.