### PR TITLE
CA Admin: Remove Edlib 2 info

### DIFF
--- a/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/content-details.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/content-details.blade.php
@@ -19,19 +19,15 @@
                                 <td>{{ $content->id }}</td>
                             </tr>
                             <tr>
-                                <th>Folium id</th>
-                                <td>{{ $resource?->id ?? '' }}</td>
-                            </tr>
-                            <tr>
                                 <th>Title</th>
                                 <td>{{ $content->title }}</td>
                             </tr>
                             <tr>
-                                <th>Created (Content author)</th>
+                                <th>Created</th>
                                 <td>{{ $content->created_at->format('Y-m-d H:i:s e') }}</td>
                             </tr>
                             <tr>
-                                <th>Updated (Content author)</th>
+                                <th>Updated</th>
                                 <td>{{ $content->updated_at->format('Y-m-d H:i:s e') }}</td>
                             </tr>
                             <tr>
@@ -53,10 +49,6 @@
                             <tr>
                                 <th>Published</th>
                                 <td>{{ $content->isPublished() ? 'Yes' : 'No' }}</td>
-                            </tr>
-                            <tr>
-                                <th>Listed</th>
-                                <td>{{ $content->isListed() ? 'Yes' : 'No' }}</td>
                             </tr>
                             <tr>
                                 <th>Has lock</th>

--- a/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/library-content.blade.php
+++ b/sourcecode/apis/contentauthor/resources/views/admin/library-upgrade/library-content.blade.php
@@ -37,7 +37,6 @@
                                     <th>Language</th>
                                     <th>License</th>
                                     <th>Published</th>
-                                    <th>Listed</th>
                                     <th>Has lock</th>
                                     <th>Latest</th>
                                 </tr>
@@ -51,7 +50,6 @@
                                             <td>{{ $content['item']->language_iso_639_3 }}</td>
                                             <td>{{ $content['item']->license }}</td>
                                             <td>{{ $content['item']->isPublished() ? 1 : 0 }}</td>
-                                            <td>{{ $content['item']->isListed() ? 1 : 0 }}</td>
                                             <td>{{ $content['item']->hasLock() ? 1 : 0 }}</td>
                                             <td>{{ $content['isLatest'] !== null ? ($content['isLatest'] ? 'Yes' : 'No') : '' }}</td>
                                         </tr>


### PR DESCRIPTION
Remove Edlib 2 info, Folium Id and listed, remove unnecessary specification on created and updated dates, it's all CA now.