### PR TITLE
add www redirect for ndla

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,7 +168,6 @@ services:
           # legacy domains, needed for browser tests
           - core.cerpus-course.com
           - api.edlib.com
-          - www.edlib.com
 
 
   # ==================

--- a/sourcecode/hub/routes/edlib-legacy.php
+++ b/sourcecode/hub/routes/edlib-legacy.php
@@ -11,6 +11,11 @@ Route::domain('www.edlib.com')
     ->uses([EdlibLegacyController::class, 'redirectFromEdlib2Id'])
     ->whereUuid('edlib2Content');
 
+Route::domain('www.h5p.ndla.no')
+    ->get('/s/resources/{edlib2Content}')
+    ->uses([EdlibLegacyController::class, 'redirectFromEdlib2Id'])
+    ->whereUuid('edlib2Content');
+
 Route::middleware([LtiValidatedRequest::class . ':platform'])->group(function () {
     Route::domain('core.cerpus-course.com')
         ->post('/lti/launch/{edlib2UsageContent}')

--- a/sourcecode/hub/tests/Feature/EdlibLegacyTest.php
+++ b/sourcecode/hub/tests/Feature/EdlibLegacyTest.php
@@ -6,20 +6,23 @@ namespace Tests\Feature;
 
 use App\Models\Content;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\TestWith;
 use Tests\TestCase;
 
 final class EdlibLegacyTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function testRedirectsFromLegacyResourceUrls(): void
+    #[TestWith(['https://www.edlib.com/s/resources/a3dcbd28-bf37-4123-ac5e-ba2f72a8f420'], 'www.edlib.com')]
+    #[TestWith(['https://www.h5p.ndla.no/s/resources/a3dcbd28-bf37-4123-ac5e-ba2f72a8f420'], 'www.h5p.ndla.no')]
+    public function testRedirectsFromLegacyResourceUrls(string $url): void
     {
         $content = Content::factory()
             ->withPublishedVersion()
             ->tag('edlib2_id:a3dcbd28-bf37-4123-ac5e-ba2f72a8f420')
             ->create();
 
-        $this->get('https://www.edlib.com/s/resources/a3dcbd28-bf37-4123-ac5e-ba2f72a8f420')
+        $this->get($url)
             ->assertRedirect('https://hub-test.edlib.test/content/' . $content->id . '/embed');
     }
 }


### PR DESCRIPTION
Additionally, `www.edlib.com` is removed from docker-compose.yml since it's not actually used by a browser test.