### PR TITLE
GH #3031: Set iframe permissions

### DIFF
--- a/sourcecode/hub/resources/views/components/launch.blade.php
+++ b/sourcecode/hub/resources/views/components/launch.blade.php
@@ -5,6 +5,8 @@
     'frameborder' => '0',
     'width' => $width,
     'height' => $height,
+    'allowfullscreen' => 'allowfullscreen',
+    'allow' => 'fullscreen *; geolocation *; microphone *; camera *; midi *; encrypted-media *',
 ])->class([
     'lti-launch',
     'd-block',

--- a/sourcecode/hub/resources/views/ndla-legacy/oembed.blade.php
+++ b/sourcecode/hub/resources/views/ndla-legacy/oembed.blade.php
@@ -1,1 +1,8 @@
-<iframe src="{{ $src }}" title="{{ $title }}" width="800" height="600" allowfullscreen></iframe>
+<iframe
+    src="{{ $src }}"
+    title="{{ $title }}"
+    width="800"
+    height="600"
+    allowfullscreen="allowfullscreen"
+    allow="fullscreen *; geolocation *; microphone *; camera *; midi *; encrypted-media *"
+></iframe>


### PR DESCRIPTION
Set same permissions as used on h5p.org
Also setting `allowfullscreen` as the `allow.fullscreen` is not supported on all browsers e.g. Safari