### PR TITLE
fix audio/image url bugs

### DIFF
--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Audio/NdlaAudioAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Audio/NdlaAudioAdapter.php
@@ -24,8 +24,7 @@ final readonly class NdlaAudioAdapter implements H5PAudioInterface, H5PExternalP
 
     private function isSameDomain($pathToFile): bool
     {
-        $url = config('h5p.audio.url') ?: config('h5p.image.url');
-        return str_starts_with($pathToFile, $url);
+        return str_starts_with($pathToFile, $this->url);
     }
 
     private function isAudioMime($mime): bool

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Image/NdlaImageAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Image/NdlaImageAdapter.php
@@ -24,6 +24,7 @@ final class NdlaImageAdapter implements H5PImageInterface, H5PExternalProviderIn
     public function __construct(
         private readonly NdlaImageClient $client,
         private readonly CerpusStorageInterface $storage,
+        private readonly string $url,
     ) {}
 
     public function mapParams($params, $originalKeys = false)
@@ -54,7 +55,7 @@ final class NdlaImageAdapter implements H5PImageInterface, H5PExternalProviderIn
 
     private function getImageUrl($path, $requestParameters)
     {
-        return config('ndla.image.url') . $path . "?" . http_build_query($requestParameters);
+        return $this->url . $path . "?" . http_build_query($requestParameters);
     }
 
     public function isTargetType($mimeType, $pathToFile): bool
@@ -64,7 +65,7 @@ final class NdlaImageAdapter implements H5PImageInterface, H5PExternalProviderIn
 
     private function isSameDomain($pathToFile): bool
     {
-        return str_starts_with($pathToFile, config('h5p.image.url'));
+        return str_starts_with($pathToFile, $this->url);
     }
 
     private function isImageMime($mime): bool
@@ -130,14 +131,9 @@ final class NdlaImageAdapter implements H5PImageInterface, H5PExternalProviderIn
         return $imageProperties;
     }
 
-    public static function getClientDetailsUrl(): ?string
+    public function getClientDetailsUrl(): ?string
     {
-        $url = config('ndla.image.url');
-        if ($url !== null) {
-            return $url . '/image-api/v3/images';
-        }
-
-        return null;
+        return $this->url . '/image-api/v3/images';
     }
 
     public function getViewCss(): array

--- a/sourcecode/apis/contentauthor/app/Providers/H5PServiceProvider.php
+++ b/sourcecode/apis/contentauthor/app/Providers/H5PServiceProvider.php
@@ -106,6 +106,10 @@ class H5PServiceProvider extends ServiceProvider
             default => NullImageAdapter::class,
         });
 
+        $this->app->when(NdlaImageAdapter::class)
+            ->needs('$url')
+            ->giveConfig('ndla.image.url');
+
         $this->app->bind(NdlaImageClient::class, fn() => new NdlaImageClient([
             'base_uri' => config('ndla.image.url'),
         ]));
@@ -120,7 +124,7 @@ class H5PServiceProvider extends ServiceProvider
             ->giveConfig('ndla.audio.url');
 
         $this->app->bind(NdlaAudioClient::class, fn() => new NdlaAudioClient([
-            'base_uri' => config('ndla.image.url'),
+            'base_uri' => config('ndla.audio.url'),
         ]));
 
         $this->app->bind(H5PCerpusStorage::class);


### PR DESCRIPTION
* Reduce likelyhood of misconfiguration by making `NdlaImageAdapter` take a string URL upfront.
* Fix `NdlaAudioClient` being given the wrong base URL.

Closes #3032