### PR TITLE
GH #3038: Set searchparams for NDLA Audio and Image API

### DIFF
--- a/sourcecode/apis/contentauthor/app/Http/Controllers/NdlaContentController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/NdlaContentController.php
@@ -47,22 +47,6 @@ final readonly class NdlaContentController
         return response($audio, 200, ['Content-Type' => 'application/json']);
     }
 
-    public function browseImages(Request $request): Response
-    {
-        $request = $this->imageClient->request('GET', '/image-api/v3/images', [
-            'query' => [
-                'page' => $request->input('page', 1),
-                'query' => $request->input('searchstring'),
-                'language' => $request->input('language'),
-                'fallback' => $request->input('fallback'),
-            ],
-        ]);
-
-        $images = $request->getBody()->getContents();
-
-        return response($images, 200, ['Content-Type' => 'application/json']);
-    }
-
     public function getImage($imageId, Request $request): Response
     {
         $language = $request->input('language');

--- a/sourcecode/apis/contentauthor/app/Http/Controllers/NdlaContentController.php
+++ b/sourcecode/apis/contentauthor/app/Http/Controllers/NdlaContentController.php
@@ -18,23 +18,6 @@ final readonly class NdlaContentController
         private NdlaImageClient $imageClient,
     ) {}
 
-    public function browseAudio(Request $request): Response
-    {
-        $query = [
-            'query' => $request->input('query.query'),
-            'fallback' => $request->input('query.fallback', 'true'),
-            'page-size' => $request->input('query.pageSize'),
-            'language' => $request->input('query.language'),
-        ];
-
-        $request = $this->audioClient->get('/audio-api/v1/audio', [
-            'query' => $query,
-        ]);
-        $audios = $request->getBody()->getContents();
-
-        return response($audios, 200, ['Content-Type' => 'application/json']);
-    }
-
     public function getAudio($audioId, Request $request): Response
     {
         $request = $this->audioClient->get('/audio-api/v1/audio/' . $audioId, [

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Audio/NdlaAudioAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Audio/NdlaAudioAdapter.php
@@ -91,4 +91,17 @@ final readonly class NdlaAudioAdapter implements H5PAudioInterface, H5PExternalP
     {
         return [];
     }
+
+    public function getBrowserConfig(): array
+    {
+        return [
+            'searchUrl' => rtrim($this->url, '/') . '/audio-api/v1/audio',
+            'detailsUrl' => rtrim($this->url, '/') . '/audio-api/v1/audio',
+            'searchParams' => [
+                'fallback' => config('ndla.audio.searchparams.fallback'),
+                'license' => config('ndla.audio.searchparams.license'),
+                'page-size' => config('ndla.audio.searchparams.pagesize'),
+            ],
+        ];
+    }
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PCreateConfig.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PCreateConfig.php
@@ -66,7 +66,7 @@ class H5PCreateConfig extends H5PConfigAbstract
         }
         $audioBrowser = app(H5PAudioInterface::class);
         if ($audioBrowser instanceof NdlaAudioAdapter) {
-            $this->config['audioBrowserDetailsUrl'] = $audioBrowser->getClientDetailsUrl();
+            $this->config['audioBrowserConfig'] = $audioBrowser->getBrowserConfig();
         }
     }
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PCreateConfig.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PCreateConfig.php
@@ -62,7 +62,7 @@ class H5PCreateConfig extends H5PConfigAbstract
 
         $imageBrowser = app(H5PImageInterface::class);
         if ($imageBrowser instanceof NdlaImageAdapter) {
-            $this->config['imageBrowserDetailsUrl'] = $imageBrowser->getClientDetailsUrl();
+            $this->config['imageBrowserConfig'] = $imageBrowser->getBrowserConfig();
         }
         $audioBrowser = app(H5PAudioInterface::class);
         if ($audioBrowser instanceof NdlaAudioAdapter) {

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PEditConfig.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PEditConfig.php
@@ -76,7 +76,7 @@ class H5PEditConfig extends H5PConfigAbstract
         }
         $audioBrowser = app(H5PAudioInterface::class);
         if ($audioBrowser instanceof NdlaAudioAdapter) {
-            $this->config['audioBrowserDetailsUrl'] = $audioBrowser->getClientDetailsUrl();
+            $this->config['audioBrowserConfig'] = $audioBrowser->getBrowserConfig();
         }
     }
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PEditConfig.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PEditConfig.php
@@ -72,7 +72,7 @@ class H5PEditConfig extends H5PConfigAbstract
 
         $imageBrowser = app(H5PImageInterface::class);
         if ($imageBrowser instanceof NdlaImageAdapter) {
-            $this->config['imageBrowserDetailsUrl'] = $imageBrowser->getClientDetailsUrl();
+            $this->config['imageBrowserConfig'] = $imageBrowser->getBrowserConfig();
         }
         $audioBrowser = app(H5PAudioInterface::class);
         if ($audioBrowser instanceof NdlaAudioAdapter) {

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Image/NdlaImageAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Image/NdlaImageAdapter.php
@@ -131,11 +131,6 @@ final class NdlaImageAdapter implements H5PImageInterface, H5PExternalProviderIn
         return $imageProperties;
     }
 
-    public function getClientDetailsUrl(): ?string
-    {
-        return $this->url . '/image-api/v3/images';
-    }
-
     public function getViewCss(): array
     {
         return [];
@@ -161,5 +156,18 @@ final class NdlaImageAdapter implements H5PImageInterface, H5PExternalProviderIn
     public function getConfigJs(): array
     {
         return [];
+    }
+
+    public function getBrowserConfig(): array
+    {
+        return [
+            'searchUrl' => $this->url . '/image-api/v3/images',
+            'detailsUrl' => $this->url . '/image-api/v3/images',
+            'searchParams' => [
+                'fallback' => config('ndla.image.searchparams.fallback'),
+                'license' => config('ndla.image.searchparams.license'),
+                'page-size' => config('ndla.image.searchparams.pagesize'),
+            ],
+        ];
     }
 }

--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Image/NdlaImageAdapter.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Image/NdlaImageAdapter.php
@@ -161,8 +161,8 @@ final class NdlaImageAdapter implements H5PImageInterface, H5PExternalProviderIn
     public function getBrowserConfig(): array
     {
         return [
-            'searchUrl' => $this->url . '/image-api/v3/images',
-            'detailsUrl' => $this->url . '/image-api/v3/images',
+            'searchUrl' => rtrim($this->url, '/') . '/image-api/v3/images',
+            'detailsUrl' => rtrim($this->url, '/') . '/image-api/v3/images',
             'searchParams' => [
                 'fallback' => config('ndla.image.searchparams.fallback'),
                 'license' => config('ndla.image.searchparams.license'),

--- a/sourcecode/apis/contentauthor/config/ndla.php
+++ b/sourcecode/apis/contentauthor/config/ndla.php
@@ -18,6 +18,11 @@ return [
         'properties' => [
             'width' => env('NDLA_H5P_IMAGE_PROPERTIES_WIDTH', 2500),
         ],
+        'searchparams' => [
+            'fallback' => env('NDLA_H5P_IMAGE_SEARCH_FALLBACK', true),
+            'license' => env('NDLA_H5P_IMAGE_SEARCH_LICENSE', 'all'),
+            'pagesize' => env('NDLA_H5P_IMAGE_SEARCH_PAGESIZE', 12),
+        ],
     ],
 
     'audio' => [

--- a/sourcecode/apis/contentauthor/config/ndla.php
+++ b/sourcecode/apis/contentauthor/config/ndla.php
@@ -21,12 +21,17 @@ return [
         'searchparams' => [
             'fallback' => env('NDLA_H5P_IMAGE_SEARCH_FALLBACK', true),
             'license' => env('NDLA_H5P_IMAGE_SEARCH_LICENSE', 'all'),
-            'pagesize' => env('NDLA_H5P_IMAGE_SEARCH_PAGESIZE', 12),
+            'pagesize' => env('NDLA_H5P_IMAGE_SEARCH_PAGESIZE', 15),
         ],
     ],
 
     'audio' => [
         'url' => env('NDLA_H5P_AUDIO_URL'),
+        'searchparams' => [
+            'fallback' => env('NDLA_H5P_AUDIO_SEARCH_FALLBACK', true),
+            'license' => env('NDLA_H5P_AUDIO_SEARCH_LICENSE', 'all'),
+            'pagesize' => env('NDLA_H5P_AUDIO_SEARCH_PAGESIZE', 10),
+        ],
     ],
 
 ];

--- a/sourcecode/apis/contentauthor/resources/assets/js/ndla.js
+++ b/sourcecode/apis/contentauthor/resources/assets/js/ndla.js
@@ -471,7 +471,9 @@ class ImageBrowser extends ContentBrowserBase {
             onToggleCallback: cb => this.toggleContentBrowser = cb,
             locale: H5PIntegration.locale,
             getCurrentLanguage: () => H5PEditor.defaultLanguage,
-            apiDetailsUrl: H5PIntegration?.imageBrowserDetailsUrl,
+            searchUrl: H5PIntegration.imageBrowserConfig.searchUrl,
+            detailsUrl: H5PIntegration.imageBrowserConfig.detailsUrl,
+            searchParams: H5PIntegration.imageBrowserConfig.searchParams,
         });
         this.copyrightHandler.handleDisplayCopyrightButton();
     }

--- a/sourcecode/apis/contentauthor/resources/assets/js/ndla.js
+++ b/sourcecode/apis/contentauthor/resources/assets/js/ndla.js
@@ -309,7 +309,9 @@ class AudioBrowser extends ContentBrowserBase {
             onToggleCallback: cb => this.toggleContentBrowser = cb,
             locale: H5PIntegration.locale,
             getCurrentLanguage: () => H5PEditor.defaultLanguage,
-            apiDetailsUrl: H5PIntegration?.audioBrowserDetailsUrl,
+            searchUrl: H5PIntegration.audioBrowserConfig.searchUrl,
+            detailsUrl: H5PIntegration.audioBrowserConfig.detailsUrl,
+            searchParams: H5PIntegration.audioBrowserConfig.searchParams,
         });
     }
 }

--- a/sourcecode/apis/contentauthor/resources/assets/react/components/AudioBrowser/AudioBrowserContainer.js
+++ b/sourcecode/apis/contentauthor/resources/assets/react/components/AudioBrowser/AudioBrowserContainer.js
@@ -6,18 +6,19 @@ import AudioBrowserLayout from './AudioBrowserLayout';
 
 class AudioBrowserContainer extends Component {
     static propTypes = {
-        searchUrl: PropTypes.string,
+        searchUrl: PropTypes.string.isRequired,
         onSelect: PropTypes.func.isRequired,
         locale: PropTypes.string,
         onToggle: PropTypes.func,
         getCurrentLanguage: PropTypes.func,
-        apiDetailsUrl: PropTypes.string.isRequired,
+        detailsUrl: PropTypes.string.isRequired,
+        searchParams: PropTypes.object,
     };
 
     static defaultProps = {
-        searchUrl: '/audios/browse',
         locale: 'en',
         getCurrentLanguage: () => 'en',
+        searchParams: {},
     };
 
     constructor(props) {
@@ -29,11 +30,12 @@ class AudioBrowserContainer extends Component {
     }
 
     handleSearch(query) {
-        const paramQuery = query || {};
-        paramQuery.language = this.props.getCurrentLanguage();
         return Axios.get(this.props.searchUrl, {
             params: {
-                query: paramQuery,
+                ...this.props.searchParams,
+                page: query.page,
+                query: query.query,
+                language: this.props.getCurrentLanguage(),
             },
         }).then((response) => {
             return response.data;
@@ -46,7 +48,7 @@ class AudioBrowserContainer extends Component {
     }
 
     handleFetchAudioDetails(audioId) {
-        return Axios.get(this.props.apiDetailsUrl + '/' + audioId, {
+        return Axios.get(this.props.detailsUrl + '/' + audioId, {
             params: {
                 language: this.props.getCurrentLanguage(),
             }

--- a/sourcecode/apis/contentauthor/resources/assets/react/components/ImageBrowser/ImageBrowserContainer.js
+++ b/sourcecode/apis/contentauthor/resources/assets/react/components/ImageBrowser/ImageBrowserContainer.js
@@ -6,18 +6,19 @@ import { injectIntl } from 'react-intl';
 
 class ImageBrowserContainer extends Component {
     static propTypes = {
-        searchUrl: PropTypes.string,
+        searchUrl: PropTypes.string.isRequired,
         onSelect: PropTypes.func.isRequired,
         locale: PropTypes.string,
         onToggle: PropTypes.func,
         getCurrentLanguage: PropTypes.func,
-        apiDetailsUrl: PropTypes.string.isRequired,
+        detailsUrl: PropTypes.string.isRequired,
+        searchParams: PropTypes.object,
     };
 
     static defaultProps = {
-        searchUrl: '/images/browse',
         locale: 'en',
         getCurrentLanguage: () => 'en',
+        searchParams: {},
     };
 
     constructor(props) {
@@ -26,14 +27,14 @@ class ImageBrowserContainer extends Component {
         this.handleSearch = this.handleSearch.bind(this);
         this.handleOnSelect = this.handleOnSelect.bind(this);
         this.handleFetchImageDetails = this.handleFetchImageDetails.bind(this);
-
     }
 
     handleSearch(searchText, page) {
         return Axios.get(this.props.searchUrl, {
             params: {
+                ...this.props.searchParams,
                 page: page,
-                searchstring: typeof searchText !== 'undefined' ? searchText : null,
+                query: typeof searchText !== 'undefined' ? searchText : null,
                 language: this.props.getCurrentLanguage(),
             },
         })
@@ -43,7 +44,7 @@ class ImageBrowserContainer extends Component {
     }
 
     handleFetchImageDetails(imageId) {
-        return Axios.get( this.props.apiDetailsUrl + '/' + imageId, {
+        return Axios.get( this.props.detailsUrl + '/' + imageId, {
             params: {
                 language: this.props.getCurrentLanguage(),
             },

--- a/sourcecode/apis/contentauthor/resources/assets/react/contentBrowser.js
+++ b/sourcecode/apis/contentauthor/resources/assets/react/contentBrowser.js
@@ -66,7 +66,9 @@ function initAudioBrowser(element, settings) {
         locale,
         onToggleCallback,
         getCurrentLanguage,
-        apiDetailsUrl,
+        searchUrl,
+        detailsUrl,
+        searchParams,
     } = settings;
 
     (async () => {
@@ -79,7 +81,9 @@ function initAudioBrowser(element, settings) {
                     locale={locale}
                     onToggle={onToggleCallback}
                     getCurrentLanguage={getCurrentLanguage}
-                    apiDetailsUrl={apiDetailsUrl}
+                    detailsUrl={detailsUrl}
+                    searchUrl={searchUrl}
+                    searchParams={searchParams}
                 />
             </IntlProvider>,
             element

--- a/sourcecode/apis/contentauthor/resources/assets/react/contentBrowser.js
+++ b/sourcecode/apis/contentauthor/resources/assets/react/contentBrowser.js
@@ -12,7 +12,9 @@ function initImageBrowser(element, settings) {
         locale,
         onToggleCallback,
         getCurrentLanguage,
-        apiDetailsUrl,
+        searchUrl,
+        detailsUrl,
+        searchParams,
     } = settings;
 
     (async () => {
@@ -25,7 +27,9 @@ function initImageBrowser(element, settings) {
                     locale={locale}
                     onToggle={onToggleCallback}
                     getCurrentLanguage={getCurrentLanguage}
-                    apiDetailsUrl={apiDetailsUrl}
+                    detailsUrl={detailsUrl}
+                    searchUrl={searchUrl}
+                    searchParams={searchParams}
                 />
             </IntlProvider>,
             element

--- a/sourcecode/apis/contentauthor/routes/web.php
+++ b/sourcecode/apis/contentauthor/routes/web.php
@@ -30,7 +30,6 @@ Route::post('h5p/adapter', function () {
 Route::get('h5p/{h5p}/copyright', [H5PController::class, 'getCopyright']);
 Route::get('h5p/{h5p}/info', [H5PController::class, 'getInfo']);
 
-Route::get('images/browse', [NdlaContentController::class, 'browseImages']);
 Route::get('images/browse/{imageId}', [NdlaContentController::class, 'getImage']);
 
 Route::get('videos/browse', [H5PController::class, 'browseVideos']);

--- a/sourcecode/apis/contentauthor/routes/web.php
+++ b/sourcecode/apis/contentauthor/routes/web.php
@@ -35,7 +35,6 @@ Route::get('images/browse/{imageId}', [NdlaContentController::class, 'getImage']
 Route::get('videos/browse', [H5PController::class, 'browseVideos']);
 Route::get('videos/browse/{videoId}', [H5PController::class, 'getVideo']);
 
-Route::get('audios/browse', [NdlaContentController::class, 'browseAudio']);
 Route::get('audios/browse/{audioId}', [NdlaContentController::class, 'getAudio']);
 
 Route::get('h5p/{h5p}/download', [H5PController::class, 'downloadContent'])->name('content-download')->middleware(['adaptermode']);


### PR DESCRIPTION
- Set search parameters for NDLA Image API query:
  - fallback => NDLA_H5P_IMAGE_SEARCH_FALLBACK, default `true`
  - license => NDLA_H5P_IMAGE_SEARCH_LICENSE, default `'all'`
  - page-size => NDLA_H5P_IMAGE_SEARCH_PAGESIZE. default `15`

- Set search parameters for NDLA Audio API query:
  - fallback => NDLA_H5P_AUDIO_SEARCH_FALLBACK, default `true`
  - license => NDLA_H5P_AUDIO_SEARCH_LICENSE, default `'all'`
  - page-size => NDLA_H5P_AUDIO_SEARCH_PAGESIZE. default `10`

- Client uses API directly for search instead of through CA