### PR TITLE
hub: send default published/shared flags

### DIFF
--- a/docs/docs/developers/content-types.mdx
+++ b/docs/docs/developers/content-types.mdx
@@ -51,11 +51,13 @@ support this, content selected via the default endpoint just replaces the previo
 
 * `ext_edlib3_published`
 
-  Sent by the hub when editing content. Will be `1` if published, or `0` otherwise.
+  Sent by the hub when creating or editing content. When editing, will be `1` if published, or `0` otherwise. When
+  creating, will be the desired default value of the published flag.
 
 * `ext_edlib3_shared`
 
-  Sent by the hub when editing content. Will be `1` if the content is shared, or `0` otherwise.
+  Sent by the hub when creating or editing content. When editing, will be `1` if the content is shared, or `0`
+  otherwise. When creating, will be the desired default value of the shared flag.
 
 ## Resizing
 

--- a/sourcecode/hub/app/Events/LaunchItemSelection.php
+++ b/sourcecode/hub/app/Events/LaunchItemSelection.php
@@ -6,12 +6,14 @@ namespace App\Events;
 
 use App\Lti\LtiLaunchBuilder;
 use App\Models\ContentVersion;
+use App\Models\LtiTool;
 
 class LaunchItemSelection
 {
     public function __construct(
         private LtiLaunchBuilder $launch,
         private readonly ContentVersion|null $contentVersion,
+        private readonly LtiTool $tool,
     ) {}
 
     public function getLaunch(): LtiLaunchBuilder
@@ -27,5 +29,10 @@ class LaunchItemSelection
     public function getContentVersion(): ContentVersion|null
     {
         return $this->contentVersion;
+    }
+
+    public function getTool(): LtiTool
+    {
+        return $this->tool;
     }
 }

--- a/sourcecode/hub/app/Http/Requests/StoreLtiToolRequest.php
+++ b/sourcecode/hub/app/Http/Requests/StoreLtiToolRequest.php
@@ -17,6 +17,9 @@ class StoreLtiToolRequest extends FormRequest
         if (!$parameters->get('slug')) {
             $parameters->remove('slug');
         }
+
+        $parameters->set('default_published', $parameters->getBoolean('default_published', false));
+        $parameters->set('default_shared', $parameters->getBoolean('default_shared', false));
     }
 
     /**
@@ -33,6 +36,8 @@ class StoreLtiToolRequest extends FormRequest
             'send_name' => ['boolean'],
             'send_email' => ['boolean'],
             'slug' => ['sometimes', 'string', 'max:50', 'regex:/^[a-z0-9-_]+$/'],
+            'default_published' => ['boolean'],
+            'default_shared' => ['boolean'],
         ];
     }
 }

--- a/sourcecode/hub/app/Http/Requests/UpdateLtiToolRequest.php
+++ b/sourcecode/hub/app/Http/Requests/UpdateLtiToolRequest.php
@@ -24,6 +24,8 @@ final class UpdateLtiToolRequest extends FormRequest
 
         $parameters->set('send_name', $parameters->getBoolean('send_name', false));
         $parameters->set('send_email', $parameters->getBoolean('send_email', false));
+        $parameters->set('default_published', $parameters->getBoolean('default_published', false));
+        $parameters->set('default_shared', $parameters->getBoolean('default_shared', false));
     }
 
     /**
@@ -40,6 +42,8 @@ final class UpdateLtiToolRequest extends FormRequest
             'send_name' => ['boolean'],
             'send_email' => ['boolean'],
             'slug' => ['sometimes', 'string', 'max:50', 'regex:/^[a-z0-9-_]+$/'],
+            'default_published' => ['boolean'],
+            'default_shared' => ['boolean'],
         ];
     }
 }

--- a/sourcecode/hub/app/Listeners/AddContentStatusFlagsToLtiLaunch.php
+++ b/sourcecode/hub/app/Listeners/AddContentStatusFlagsToLtiLaunch.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Listeners;
 
 use App\Events\LaunchItemSelection;
+use function assert;
 
 class AddContentStatusFlagsToLtiLaunch
 {
@@ -12,17 +13,21 @@ class AddContentStatusFlagsToLtiLaunch
     {
         $version = $event->getContentVersion();
 
-        if ($version === null) {
-            return;
-        }
+        if ($version !== null) {
+            $content = $version->content;
+            assert($content !== null);
 
-        $content = $version->content;
-        assert($content !== null);
+            $published = $version->published;
+            $shared = $content->shared;
+        } else {
+            $published = $event->getTool()->default_published;
+            $shared = $event->getTool()->default_shared;
+        }
 
         $event->setLaunch(
             $event->getLaunch()
-                ->withClaim('ext_edlib3_published', $version->published ? '1' : '0')
-                ->withClaim('ext_edlib3_shared', $content->shared ? '1' : '0'),
+                ->withClaim('ext_edlib3_published', $published ? '1' : '0')
+                ->withClaim('ext_edlib3_shared', $shared ? '1' : '0'),
         );
     }
 }

--- a/sourcecode/hub/app/Listeners/AddContentStatusFlagsToLtiLaunch.php
+++ b/sourcecode/hub/app/Listeners/AddContentStatusFlagsToLtiLaunch.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Listeners;
 
 use App\Events\LaunchItemSelection;
+
 use function assert;
 
 class AddContentStatusFlagsToLtiLaunch

--- a/sourcecode/hub/app/Lti/LtiLaunchBuilder.php
+++ b/sourcecode/hub/app/Lti/LtiLaunchBuilder.php
@@ -126,7 +126,7 @@ class LtiLaunchBuilder
         $event = new LaunchLti($url, $launch, $tool);
         $this->dispatcher->dispatch($event);
 
-        $event = new LaunchItemSelection($event->getLaunch(), $version);
+        $event = new LaunchItemSelection($event->getLaunch(), $version, $tool);
         $this->dispatcher->dispatch($event);
 
         $request = new Oauth1Request('POST', $url, $event->getLaunch()->claims);

--- a/sourcecode/hub/app/Models/LtiTool.php
+++ b/sourcecode/hub/app/Models/LtiTool.php
@@ -32,6 +32,8 @@ class LtiTool extends Model
         'send_name' => false,
         'send_email' => false,
         'edit_mode' => LtiToolEditMode::Replace,
+        'default_published' => false,
+        'default_shared' => false,
     ];
 
     protected $casts = [
@@ -39,6 +41,8 @@ class LtiTool extends Model
         'edit_mode' => LtiToolEditMode::class,
         'send_name' => 'boolean',
         'send_email' => 'boolean',
+        'default_published' => 'boolean',
+        'default_shared' => 'boolean',
     ];
 
     protected $hidden = [
@@ -54,6 +58,8 @@ class LtiTool extends Model
         'send_email',
         'edit_mode',
         'slug',
+        'default_published',
+        'default_shared',
     ];
 
     public static function booted(): void

--- a/sourcecode/hub/app/Transformers/LtiToolTransformer.php
+++ b/sourcecode/hub/app/Transformers/LtiToolTransformer.php
@@ -21,6 +21,8 @@ final class LtiToolTransformer extends TransformerAbstract
             'edit_mode' => $tool->edit_mode->value,
             'send_email' => $tool->send_email,
             'send_name' => $tool->send_name,
+            'default_published' => $tool->default_published,
+            'default_shared' => $tool->default_shared,
             'proxies_lti_launches' => true, // deprecated
             'links' => [
                 'self' => route('api.lti-tools.show', [$tool]),

--- a/sourcecode/hub/database/factories/LtiToolFactory.php
+++ b/sourcecode/hub/database/factories/LtiToolFactory.php
@@ -25,6 +25,8 @@ final class LtiToolFactory extends Factory
             'send_name' => $this->faker->boolean,
             'send_email' => $this->faker->boolean,
             'slug' => $this->faker->unique()->slug(nbWords: 2),
+            'default_published' => $this->faker->boolean,
+            'default_shared' => $this->faker->boolean,
         ];
     }
 
@@ -69,5 +71,15 @@ final class LtiToolFactory extends Factory
     public function editMode(LtiToolEditMode $editMode): self
     {
         return $this->state(['edit_mode' => $editMode]);
+    }
+
+    public function defaultPublished(bool $defaultPublished = true): self
+    {
+        return $this->state(['default_published' => $defaultPublished]);
+    }
+
+    public function defaultShared(bool $defaultShared = true): self
+    {
+        return $this->state(['default_shared' => $defaultShared]);
     }
 }

--- a/sourcecode/hub/database/migrations/2025_03_19_add_default_tool_flags.php
+++ b/sourcecode/hub/database/migrations/2025_03_19_add_default_tool_flags.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration {
+return new class extends Migration {
     public function up(): void
     {
         Schema::table('lti_tools', function (Blueprint $table) {

--- a/sourcecode/hub/database/migrations/2025_03_19_add_default_tool_flags.php
+++ b/sourcecode/hub/database/migrations/2025_03_19_add_default_tool_flags.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('lti_tools', function (Blueprint $table) {
+            $table->boolean('default_published')->default(false);
+            $table->boolean('default_shared')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('lti_tools', function (Blueprint $table) {
+            $table->dropColumn('default_published');
+            $table->dropColumn('default_shared');
+        });
+    }
+};

--- a/sourcecode/hub/lang/en/messages.php
+++ b/sourcecode/hub/lang/en/messages.php
@@ -247,4 +247,7 @@ return [
     'admins' => 'Admins',
     'publish' => 'Publish',
     'content-published-notice' => 'The content has been published.',
+    'tool-settings' => 'Tool settings',
+    'default-published-flag' => 'Published by default',
+    'default-shared-flag' => 'Shared by default',
 ];

--- a/sourcecode/hub/resources/views/admin/lti-tools/index.blade.php
+++ b/sourcecode/hub/resources/views/admin/lti-tools/index.blade.php
@@ -47,6 +47,14 @@
                                 <th scope="row">{{ trans('messages.send-email-to-lti-tool', ['site' => config('app.name')]) }}</th>
                                 <td class="lti-tool-card-send-email">{{ $tool->send_email ? trans('messages.yes') : trans('messages.no') }}</td>
                             </tr>
+                            <tr>
+                                <th scope="row">{{ trans('messages.default-published-flag') }}</th>
+                                <td class="lti-tool-default-published-flag">{{ $tool->default_published ? trans('messages.yes') : trans('messages.no') }}</td>
+                            </tr>
+                            <tr>
+                                <th scope="row">{{ trans('messages.default-shared-flag') }}</th>
+                                <td class="lti-tool-default-shared-flag">{{ $tool->default_shared ? trans('messages.yes') : trans('messages.no') }}</td>
+                            </tr>
                         </tbody>
                     </table>
 

--- a/sourcecode/hub/resources/views/components/admin/lti-tools/form.blade.php
+++ b/sourcecode/hub/resources/views/components/admin/lti-tools/form.blade.php
@@ -87,5 +87,23 @@
         />
     </fieldset>
 
+    <fieldset>
+        <legend>{{ trans('messages.tool-settings') }}</legend>
+
+        <x-form.field
+            name="default_published"
+            type="checkbox"
+            :checked="$tool?->default_published"
+            :label="trans('messages.default-published-flag')"
+        />
+
+        <x-form.field
+            name="default_shared"
+            type="checkbox"
+            :checked="$tool?->default_shared"
+            :label="trans('messages.default-shared-flag')"
+        />
+    </fieldset>
+
     {{ $button }}
 </x-form>

--- a/sourcecode/hub/tests/Feature/Api/LtiToolTest.php
+++ b/sourcecode/hub/tests/Feature/Api/LtiToolTest.php
@@ -41,6 +41,8 @@ final class LtiToolTest extends TestCase
                             ->where('proxies_lti_launches', true)
                             ->where('send_name', $tool->send_name)
                             ->where('send_email', $tool->send_email)
+                            ->where('default_published', $tool->default_published)
+                            ->where('default_shared', $tool->default_shared)
                             ->where('links.self', 'https://hub-test.edlib.test/api/lti-tools/' . $tool->id),
                     ),
             );

--- a/sourcecode/hub/tests/Feature/LtiPlatformTest.php
+++ b/sourcecode/hub/tests/Feature/LtiPlatformTest.php
@@ -200,17 +200,41 @@ final class LtiPlatformTest extends TestCase
         $this->assertSame($flagValue, $request->get('ext_edlib3_shared'));
     }
 
-    public function testClaimsDoNotContainContentStatusFlagsWhenNotEditing(): void
-    {
+    #[TestWith(['1', true])]
+    #[TestWith(['0', false])]
+    public function testClaimsContainDefaultPublishedFlagWhenCreating(
+        string $flagValue,
+        bool $defaultPublished,
+    ): void {
+        $tool = LtiTool::factory()->defaultPublished($defaultPublished)->create();
+
         $request = $this->app->make(LtiLaunchBuilder::class)
             ->toItemSelectionLaunch(
-                tool: LtiTool::factory()->create(),
+                tool: $tool,
                 url: $this->faker->url,
                 itemReturnUrl: $this->faker->url,
             )
             ->getRequest();
 
-        $this->assertFalse($request->has('ext_edlib3_published'));
-        $this->assertFalse($request->has('ext_edlib3_shared'));
+        $this->assertSame($flagValue, $request->get('ext_edlib3_published'));
+    }
+
+    #[TestWith(['1', true])]
+    #[TestWith(['0', false])]
+    public function testClaimsContainDefaultSharedFlagWhenCreating(
+        string $flagValue,
+        bool $defaultShared,
+    ): void {
+        $tool = LtiTool::factory()->defaultShared($defaultShared)->create();
+
+        $request = $this->app->make(LtiLaunchBuilder::class)
+            ->toItemSelectionLaunch(
+                tool: $tool,
+                url: $this->faker->url,
+                itemReturnUrl: $this->faker->url,
+            )
+            ->getRequest();
+
+        $this->assertSame($flagValue, $request->get('ext_edlib3_shared'));
     }
 }


### PR DESCRIPTION
Add new tool settings for deciding the default values of the published/shared flags when creating content.