### PR TITLE
GH #3051: Fix fail to upgrade content to newer H5P content type version in Editor

### DIFF
--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PConfigAbstract.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/H5PConfigAbstract.php
@@ -320,6 +320,8 @@ abstract class H5PConfigAbstract implements ConfigInterface
         return array_merge(
             [
                 (string) mix("js/h5pmetadata.js"),
+                // Used by 'Update content' functionality, upgrading to a newer version of the content type, in Editor
+                '/js/editor-setup.js',
             ],
             $this->adapter->getCustomEditorScripts(),
         );

--- a/sourcecode/apis/contentauthor/public/js/editor-setup.js
+++ b/sourcecode/apis/contentauthor/public/js/editor-setup.js
@@ -4,31 +4,15 @@
         if (Integration === undefined) {
             return;
         }
-        if (typeof CKEDITOR !== 'undefined') {
-            if (typeof Integration.editor.wirisPath !== 'undefined') {
-                // Add wiris plugin
-                CKEDITOR.plugins.addExternal('ckeditor_wiris', Integration.editor.wirisPath);
-            }
-
-            if (Integration.hasOwnProperty('editor') && Integration.editor.hasOwnProperty('extraAllowedContent')) {
-                if( CKEDITOR.hasOwnProperty('extraAllowedContent') !== true){
-                    CKEDITOR.config.extraAllowedContent = "";
-                }
-                CKEDITOR.config.extraAllowedContent += Integration.editor.extraAllowedContent;
-            }
-
-            if( Integration.hasOwnProperty('editor') && Integration.editor.hasOwnProperty('editorBodyClass') ){
-                CKEDITOR.config.bodyClass = Integration.editor.editorBodyClass;
-            }
-        }
-
-        if (window.parent !== null && typeof H5PEditor !== "undefined") {
-            window.parent.IframeH5PEditor = H5PEditor;
-        }
 
         if (Integration.hasOwnProperty('crossorigin') && Integration.crossorigin === true &&
             Integration.hasOwnProperty('crossoriginRegex') && Integration.crossoriginRegex !== null) {
             Integration.crossoriginRegex = new RegExp(Integration.crossoriginRegex);
+        }
+
+        // Used by 'Update content' functionality, upgrading to a newer version of the content type, in Editor
+        if (window.parent !== null && typeof H5PEditor !== "undefined") {
+            window.parent.IframeH5PEditor = H5PEditor;
         }
     });
 })(typeof H5P !== "undefined" ? H5P.jQuery : $);


### PR DESCRIPTION
In CA Editor it is possible to update content to a newer version of the H5P content type used.
A script required for the update to function was not loaded after PR #3008. The script also modified CKEditor settings, this is removed from the script and the script will now be loaded again.