### PR TITLE
Support for full image size for content type H5P.EscapeRoom

### DIFF
--- a/docs/docs/product/caseStudies/ndla.mdx
+++ b/docs/docs/product/caseStudies/ndla.mdx
@@ -60,7 +60,7 @@ When content using images from the Image API is exported, the image is included 
 
 If an image is deleted the alt-text set for the image will be displayed. Since exported content contains a copy of the image, they will not be affected.
 
-To provent loading of large images, an additional configuration setting `width=2500` is added when the content is viewed. The size is a configuration setting, the default value is `2500`. This functionality is not used for some content types, currently `H5P.ThreeImage` and `H5P.NDLAThreeImage`, that require the original quality.
+To provent loading of large images, an additional configuration setting `width=2500` is added when the content is viewed. The size is a configuration setting, the default value is `2500`. This functionality is not used for some content types, currently `H5P.ThreeImage`, `H5P.NDLAThreeImage` and `H5P.EscapeRoom`, that require the original quality.
  
 
 ### License and attribution

--- a/sourcecode/apis/contentauthor/app/H5PLibrary.php
+++ b/sourcecode/apis/contentauthor/app/H5PLibrary.php
@@ -353,7 +353,7 @@ class H5PLibrary extends Model
 
     public function includeImageWidth(): bool
     {
-        return !in_array($this->name, ['H5P.ThreeImage', 'H5P.NDLAThreeImage']);
+        return !in_array($this->name, ['H5P.ThreeImage', 'H5P.NDLAThreeImage', 'H5P.EscapeRoom']);
     }
 
     public function getIconUrl(): string


### PR DESCRIPTION
Both `H5P.ThreeImage` and `H5P.NDLAThreeImage` can get images in full size. As the latter has been renamed to `H5P.EscapeRoom`, it should also be added to the list of exemptions.