### PR TITLE
Update `php.ini` to set `memory_limit` to 256M

### DIFF
--- a/sourcecode/apis/contentauthor/docker/php/php.ini
+++ b/sourcecode/apis/contentauthor/docker/php/php.ini
@@ -2,3 +2,4 @@ post_max_size = 2G
 upload_max_filesize = 2G
 max_execution_time = 120
 expose_php = off
+memory_limit = 256M


### PR DESCRIPTION
Could help with H5P import issues