### PR TITLE
Fix double slash in H5P cached asset font/image URLs

### DIFF
--- a/sourcecode/apis/contentauthor/app/Libraries/H5P/Storage/H5PCerpusStorage.php
+++ b/sourcecode/apis/contentauthor/app/Libraries/H5P/Storage/H5PCerpusStorage.php
@@ -328,7 +328,8 @@ class H5PCerpusStorage implements H5PFileStorage, H5PDownloadInterface, CerpusSt
                     $filePath = ContentStorageSettings::CACHEDASSETS_JS_PATH;
                 } else {
                     // Rewrite relative URLs used inside stylesheets
-                    $cssRelPath = preg_replace('/[^\/]+$/', '', $asset->path);
+                    // Strip any leading slash so it doesn't combine with the "../" prefix below into "..//"
+                    $cssRelPath = ltrim(preg_replace('/[^\/]+$/', '', $asset->path), '/');
                     $content .= preg_replace_callback(
                         '/url\([\'"]?([^"\')]+)[\'"]?\)/i',
                         function ($matches) use ($cssRelPath) {


### PR DESCRIPTION
H5PCore builds content dependency asset paths with a leading slash. When cacheAssets() combines library stylesheets for a content item, it rewrites relative url() references by prepending "../" to that leading-slash path, producing a "..//" double slash. This mainly surfaced on webfonts referenced via @font-face src: url(...), since those are almost always relative CSS urls, while the stylesheet's own URL (built via Storage::url()) was already slash-safe.